### PR TITLE
Heap Limits

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -102,7 +102,8 @@ class ExecutionJob(object):
 
         # Set heap limit
         heap_limit_kb = self.config["HEAP_LIMIT"]
-        heap_t = (heap_limit_kb, heap_limit_kb)
+        heap_limit_b = heap_limit_kb * 1024  # resource module speaks in bytes
+        heap_t = (heap_limit_b, heap_limit_b)
         resource.setrlimit(resource.RLIMIT_DATA, heap_t)
         assert resource.getrlimit(resource.RLIMIT_DATA) == heap_t
 

--- a/krun.py
+++ b/krun.py
@@ -9,6 +9,7 @@ usage: runner.py <config_file.krun>
 import os, subprocess, sys, subprocess, json, time
 from collections import deque
 import datetime
+import resource
 
 import krun.util as util
 from krun import ANSI_RED, ANSI_GREEN, ANSI_MAGENTA, ANSI_CYAN, ANSI_RESET
@@ -98,6 +99,11 @@ class ExecutionJob(object):
 
         vm_env = self.vm_info.get("vm_env", {})
         vm_args = self.vm_info.get("vm_args", [])
+
+        # Set heap limit
+        heap_t = (self.config["HEAP_LIMIT"], self.config["HEAP_LIMIT"])
+        resource.setrlimit(resource.RLIMIT_DATA, heap_t)
+        assert resource.getrlimit(resource.RLIMIT_DATA) == heap_t
 
         # Rough ETA execution timer
         exec_start_rough = time.time()

--- a/krun.py
+++ b/krun.py
@@ -101,14 +101,16 @@ class ExecutionJob(object):
         vm_args = self.vm_info.get("vm_args", [])
 
         # Set heap limit
-        heap_t = (self.config["HEAP_LIMIT"], self.config["HEAP_LIMIT"])
+        heap_limit_kb = self.config["HEAP_LIMIT"]
+        heap_t = (heap_limit_kb, heap_limit_kb)
         resource.setrlimit(resource.RLIMIT_DATA, heap_t)
         assert resource.getrlimit(resource.RLIMIT_DATA) == heap_t
 
         # Rough ETA execution timer
         exec_start_rough = time.time()
         stdout = variant.run_exec(self.vm_info["path"], self.benchmark,
-                                  self.vm_info["n_iterations"], self.parameter, vm_env, vm_args)
+                                  self.vm_info["n_iterations"], self.parameter, vm_env,
+                                  vm_args, heap_limit_kb)
         exec_time_rough = time.time() - exec_start_rough
 
         try:

--- a/krun/variants.py
+++ b/krun/variants.py
@@ -7,6 +7,10 @@ DIR = os.path.abspath(os.path.dirname(__file__))
 ITERATIONS_RUNNER_DIR = os.path.abspath(os.path.join(DIR, "..", "iterations_runners"))
 BENCHMARKS_DIR = "benchmarks"
 
+# !!!
+# Don't mutate any lists passed down from the user's config file!
+# !!!
+
 class BaseVariant(object):
 
     def __init__(self, iterations_runner, entry_point=None, subdir=None, extra_env=None):
@@ -21,7 +25,7 @@ class BaseVariant(object):
         self.extra_env = extra_env
 
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        raise NotImplemented("abstract")
+        raise NotImplementedError("abstract")
 
     def _run_exec(self, args, env=None):
         """ Deals with actually shelling out """
@@ -70,6 +74,7 @@ class JavaVariant(BaseVariant):
                              extra_env=extra_env)
 
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+        vm_args = vm_args[:] + ["-Xmx%sK" % heap_limit_kb]
         args = [interpreter] + vm_args + [self.iterations_runner, self.entry_point, str(iterations), str(param)]
         bench_dir = os.path.abspath(os.path.join(os.getcwd(), BENCHMARKS_DIR, benchmark, self.subdir))
 
@@ -95,8 +100,9 @@ class PythonVariant(GenericScriptingVariant):
                                          extra_env=extra_env)
 
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        # XXX heap
-        return self._generic_scripting_run_exec(interpreter, benchmark, param, vm_env, vm_args)
+        # heap_limit_kb unused.
+        # Python reads the rlimit structure to decide its heap limit.
+        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
 class LuaVariant(GenericScriptingVariant):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
@@ -107,7 +113,11 @@ class LuaVariant(GenericScriptingVariant):
                                          extra_env=extra_env)
 
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        # XXX heap
+        # I was unable to find any special switches to limit lua's heap size.
+        # Looking at implementationsi:
+        #  * luajit uses anonymous mmap() to allocate memory, fiddling
+        #    with rlimits prior.
+        #  * Stock lua doesn't seem to do anything special. Just realloc().
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
 class PHPVariant(GenericScriptingVariant):
@@ -119,7 +129,7 @@ class PHPVariant(GenericScriptingVariant):
                                          extra_env=extra_env)
 
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        # XXX heap
+        vm_args = vm_args[:] + ["-d", "memory_limit=%sK" % heap_limit_kb]
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
 class RubyVariant(GenericScriptingVariant):
@@ -130,9 +140,10 @@ class RubyVariant(GenericScriptingVariant):
                                          subdir=subdir,
                                          extra_env=extra_env)
 
+class JRubyVariant(RubyVariant):
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        # XXX heap
-        return self._generic_scripting_run_exec(interpreter, benchmark, param, vm_env, vm_args)
+        vm_args = vm_args[:] + ["-J-Xmx%sK" % heap_limit_kb]
+        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
 class JavascriptVariant(GenericScriptingVariant):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
@@ -143,9 +154,13 @@ class JavascriptVariant(GenericScriptingVariant):
                                          extra_env=extra_env)
 
 
-    # pretty much the same as the generic implementation, but needs a '--' argument.
+class V8Variant(JavascriptVariant):
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        # XXX heap
+
+        # this is a best effort at limiting the heap space.
+        # V8 has a "new" and "old" heap. I can't see a way to limit the total of the two.
+        vm_args = vm_args[:] + ["--max_old_space_size", "%s" % int(heap_limit_kb / 1024)] # as MB
+
         script_path = os.path.join(BENCHMARKS_DIR, benchmark, self.subdir, self.entry_point)
         args = [interpreter] + vm_args + \
             [self.iterations_runner, '--', script_path, str(iterations), str(param)]

--- a/krun/variants.py
+++ b/krun/variants.py
@@ -20,10 +20,11 @@ class BaseVariant(object):
         self.subdir = subdir
         self.extra_env = extra_env
 
-    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args):
+    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
         raise NotImplemented("abstract")
 
     def _run_exec(self, args, env=None):
+        """ Deals with actually shelling out """
         if env is not None:
             use_env = env.copy()
         else:
@@ -51,7 +52,7 @@ class GenericScriptingVariant(BaseVariant):
                              subdir=subdir,
                              extra_env=extra_env)
 
-    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args):
+    def _generic_scripting_run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args):
         script_path = os.path.join(BENCHMARKS_DIR, benchmark, self.subdir, self.entry_point)
         args = [interpreter] + vm_args + [self.iterations_runner, script_path, str(iterations), str(param)]
 
@@ -68,7 +69,7 @@ class JavaVariant(BaseVariant):
                              subdir=subdir,
                              extra_env=extra_env)
 
-    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args):
+    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
         args = [interpreter] + vm_args + [self.iterations_runner, self.entry_point, str(iterations), str(param)]
         bench_dir = os.path.abspath(os.path.join(os.getcwd(), BENCHMARKS_DIR, benchmark, self.subdir))
 
@@ -93,6 +94,10 @@ class PythonVariant(GenericScriptingVariant):
                                          subdir=subdir,
                                          extra_env=extra_env)
 
+    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+        # XXX heap
+        return self._generic_scripting_run_exec(interpreter, benchmark, param, vm_env, vm_args)
+
 class LuaVariant(GenericScriptingVariant):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
         GenericScriptingVariant.__init__(self,
@@ -100,6 +105,10 @@ class LuaVariant(GenericScriptingVariant):
                                          entry_point=entry_point,
                                          subdir=subdir,
                                          extra_env=extra_env)
+
+    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+        # XXX heap
+        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
 class PHPVariant(GenericScriptingVariant):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
@@ -109,6 +118,10 @@ class PHPVariant(GenericScriptingVariant):
                                          subdir=subdir,
                                          extra_env=extra_env)
 
+    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+        # XXX heap
+        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
+
 class RubyVariant(GenericScriptingVariant):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
         GenericScriptingVariant.__init__(self,
@@ -116,6 +129,10 @@ class RubyVariant(GenericScriptingVariant):
                                          entry_point=entry_point,
                                          subdir=subdir,
                                          extra_env=extra_env)
+
+    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+        # XXX heap
+        return self._generic_scripting_run_exec(interpreter, benchmark, param, vm_env, vm_args)
 
 class JavascriptVariant(GenericScriptingVariant):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
@@ -125,8 +142,10 @@ class JavascriptVariant(GenericScriptingVariant):
                                          subdir=subdir,
                                          extra_env=extra_env)
 
+
     # pretty much the same as the generic implementation, but needs a '--' argument.
-    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args):
+    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+        # XXX heap
         script_path = os.path.join(BENCHMARKS_DIR, benchmark, self.subdir, self.entry_point)
         args = [interpreter] + vm_args + \
             [self.iterations_runner, '--', script_path, str(iterations), str(param)]


### PR DESCRIPTION
First attempt to implement heap limits. Harder than first imagined.

In doing this work I noticed a fixable flaw in krun's configuration model: #2. Will fix after this pull is merged.

Back to memory limits, in short:
 * Impose a rlimit-level heap resource limit using Python's `resource` module.
 * *If* a vm has a knob to change heap limits, also tweak this. This is essential for VMs that have an artificial low heap size, e.g. PHP.

Notes:
 * See V8 heap knob. Not ideal.