### PR TITLE
Variant refactor

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -72,13 +72,16 @@ class ExecutionJob(object):
     def run(self):
         """Runs this job (execution)"""
 
+        entry_point = self.config["VARIANTS"][self.variant]
+        vm_def = self.vm_info["vm_def"]
+        vm_env = self.vm_info.get("vm_env", {})
+        vm_args = self.vm_info.get("vm_args", [])
+
         print("%sRunning '%s(%d)' (%s variant) under '%s'%s" %
                     (ANSI_CYAN, self.benchmark, self.parameter, self.variant,
                      self.vm_name, ANSI_RESET))
 
         #benchmark_dir = os.path.abspath(self.benchmark)
-
-        variant = self.config["VARIANTS"][self.variant]
 
         # Print ETA for execution if available
         exec_start = datetime.datetime.now()
@@ -97,9 +100,6 @@ class ExecutionJob(object):
                                          tfmt.delta_str,
                                          ANSI_RESET))
 
-        vm_env = self.vm_info.get("vm_env", {})
-        vm_args = self.vm_info.get("vm_args", [])
-
         # Set heap limit
         heap_limit_kb = self.config["HEAP_LIMIT"]
         heap_limit_b = heap_limit_kb * 1024  # resource module speaks in bytes
@@ -109,9 +109,9 @@ class ExecutionJob(object):
 
         # Rough ETA execution timer
         exec_start_rough = time.time()
-        stdout = variant.run_exec(self.vm_info["path"], self.benchmark,
-                                  self.vm_info["n_iterations"], self.parameter, vm_env,
-                                  vm_args, heap_limit_kb)
+        #def run_exec(self, entry_point, benchmark, iterations, param, vm_env, vm_args):
+        stdout = vm_def.run_exec(entry_point, self.benchmark, self.vm_info["n_iterations"],
+                                 self.parameter, vm_env, vm_args, heap_limit_kb)
         exec_time_rough = time.time() - exec_start_rough
 
         try:

--- a/krun.py
+++ b/krun.py
@@ -74,8 +74,6 @@ class ExecutionJob(object):
 
         entry_point = self.config["VARIANTS"][self.variant]
         vm_def = self.vm_info["vm_def"]
-        vm_env = self.vm_info.get("vm_env", {})
-        vm_args = self.vm_info.get("vm_args", [])
 
         print("%sRunning '%s(%d)' (%s variant) under '%s'%s" %
                     (ANSI_CYAN, self.benchmark, self.parameter, self.variant,
@@ -109,9 +107,8 @@ class ExecutionJob(object):
 
         # Rough ETA execution timer
         exec_start_rough = time.time()
-        #def run_exec(self, entry_point, benchmark, iterations, param, vm_env, vm_args):
         stdout = vm_def.run_exec(entry_point, self.benchmark, self.vm_info["n_iterations"],
-                                 self.parameter, vm_env, vm_args, heap_limit_kb)
+                                 self.parameter, heap_limit_kb)
         exec_time_rough = time.time() - exec_start_rough
 
         try:

--- a/krun/__init__.py
+++ b/krun/__init__.py
@@ -4,3 +4,8 @@ ANSI_MAGENTA = '\033[95m'
 ANSI_CYAN = '\033[36m'
 ANSI_RESET = '\033[0m'
 
+
+class EntryPoint(object):
+    def __init__(self, target, subdir=None):
+        self.target = target
+        self.subdir = subdir

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -11,7 +11,7 @@ BENCHMARKS_DIR = "benchmarks"
 # Don't mutate any lists passed down from the user's config file!
 # !!!
 
-class BaseVariant(object):
+class BaseVMDef(object):
 
     def __init__(self, iterations_runner, entry_point=None, subdir=None, extra_env=None):
         assert entry_point is not None
@@ -47,10 +47,10 @@ class BaseVariant(object):
                 args, stdout=subprocess.PIPE, env=env).communicate()
         return stdout
 
-class GenericScriptingVariant(BaseVariant):
+class GenericScriptingVMDef(BaseVMDef):
     def __init__(self, iterations_runner, entry_point=None, subdir=None, extra_env=None):
         fp_iterations_runner = os.path.join(ITERATIONS_RUNNER_DIR, iterations_runner)
-        BaseVariant.__init__(self,
+        BaseVMDef.__init__(self,
                              fp_iterations_runner,
                              entry_point=entry_point,
                              subdir=subdir,
@@ -65,9 +65,9 @@ class GenericScriptingVariant(BaseVariant):
 
         return self._run_exec(args, use_env)
 
-class JavaVariant(BaseVariant):
+class JavaVMDef(BaseVMDef):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
-        BaseVariant.__init__(self,
+        BaseVMDef.__init__(self,
                              "IterationsRunner",
                              entry_point=entry_point,
                              subdir=subdir,
@@ -91,9 +91,9 @@ class JavaVariant(BaseVariant):
         return self._run_exec(args, new_env)
 
 
-class PythonVariant(GenericScriptingVariant):
+class PythonVMDef(GenericScriptingVMDef):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
-        GenericScriptingVariant.__init__(self,
+        GenericScriptingVMDef.__init__(self,
                                          "iterations_runner.py",
                                          entry_point=entry_point,
                                          subdir=subdir,
@@ -104,9 +104,9 @@ class PythonVariant(GenericScriptingVariant):
         # Python reads the rlimit structure to decide its heap limit.
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
-class LuaVariant(GenericScriptingVariant):
+class LuaVMDef(GenericScriptingVMDef):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
-        GenericScriptingVariant.__init__(self,
+        GenericScriptingVMDef.__init__(self,
                                          "iterations_runner.lua",
                                          entry_point=entry_point,
                                          subdir=subdir,
@@ -120,9 +120,9 @@ class LuaVariant(GenericScriptingVariant):
         #  * Stock lua doesn't seem to do anything special. Just realloc().
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
-class PHPVariant(GenericScriptingVariant):
+class PHPVMDef(GenericScriptingVMDef):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
-        GenericScriptingVariant.__init__(self,
+        GenericScriptingVMDef.__init__(self,
                                          "iterations_runner.php",
                                          entry_point=entry_point,
                                          subdir=subdir,
@@ -132,29 +132,29 @@ class PHPVariant(GenericScriptingVariant):
         vm_args = vm_args[:] + ["-d", "memory_limit=%sK" % heap_limit_kb]
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
-class RubyVariant(GenericScriptingVariant):
+class RubyVMDef(GenericScriptingVMDef):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
-        GenericScriptingVariant.__init__(self,
+        GenericScriptingVMDef.__init__(self,
                                          "iterations_runner.rb",
                                          entry_point=entry_point,
                                          subdir=subdir,
                                          extra_env=extra_env)
 
-class JRubyVariant(RubyVariant):
+class JRubyVMDef(RubyVMDef):
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
         vm_args = vm_args[:] + ["-J-Xmx%sK" % heap_limit_kb]
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
 
-class JavascriptVariant(GenericScriptingVariant):
+class JavascriptVMDef(GenericScriptingVMDef):
     def __init__(self, entry_point=None, subdir=None, extra_env=None):
-        GenericScriptingVariant.__init__(self,
+        GenericScriptingVMDef.__init__(self,
                                          "iterations_runner.js",
                                          entry_point=entry_point,
                                          subdir=subdir,
                                          extra_env=extra_env)
 
 
-class V8Variant(JavascriptVariant):
+class V8VMDef(JavascriptVMDef):
     def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
 
         # this is a best effort at limiting the heap space.

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -11,6 +11,9 @@ BENCHMARKS_DIR = "benchmarks"
 # Don't mutate any lists passed down from the user's config file!
 # !!!
 
+BASE_ENV = os.environ.copy()
+BASE_ENV.update({"LD_LIBRARY_PATH": os.path.join(DIR, "..", "libkruntime")})
+
 class BaseVMDef(object):
 
     def __init__(self, iterations_runner, extra_env=None):
@@ -21,104 +24,140 @@ class BaseVMDef(object):
         # tempting as it is to add a self.vm_path, we don't. If we were to add
         # natively compiled languages, then there is no "VM" to speak of.
 
-    def run_exec(self, entry_point, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+    def run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
         raise NotImplementedError("abstract")
 
-    def _run_exec(self, args, env=None):
+    def _run_exec(self, args, heap_lim_k, bench_env=None):
         """ Deals with actually shelling out """
-        if env is not None:
-            use_env = env.copy()
-        else:
-            use_env = {}
-        use_env.update(self.extra_env)
+
+        use_env = BASE_ENV.copy()
+        use_env.update(self.extra_env)  # VM specific env
+        if bench_env:
+            use_env.update(bench_env)   # bench specific env
+
+        # This is kind of awkward. We don't have the heap limit at
+        # VMDef construction time, so we have to substitute it in later.
+        actual_args = []
+        for a in args:
+            if hasattr(a, "__call__"):  # i.e. a function
+                a = a(heap_lim_k)
+            actual_args.append(a)
 
         if os.environ.get("BENCH_DEBUG"):
-            print("%s    DEBUG: cmdline='%s'%s" % (ANSI_GREEN, " ".join(args), ANSI_RESET))
-            print("%s    DEBUG: env='%s'%s" % (ANSI_GREEN, env, ANSI_RESET))
+            print("%s    DEBUG: cmdline='%s'%s" % (ANSI_GREEN, " ".join(actual_args), ANSI_RESET))
+            print("%s    DEBUG: env='%s'%s" % (ANSI_GREEN, use_env, ANSI_RESET))
 
         if os.environ.get("BENCH_DRYRUN") != None:
             print("%s    DEBUG: %s%s" % (ANSI_GREEN, "DRY RUN, SKIP", ANSI_RESET))
             return "[]"
 
         stdout, stderr = subprocess.Popen(
-                args, stdout=subprocess.PIPE, env=env).communicate()
+                actual_args, stdout=subprocess.PIPE, env=use_env).communicate()
         return stdout
 
 class GenericScriptingVMDef(BaseVMDef):
     def __init__(self, vm_path, iterations_runner, entry_point=None, subdir=None, extra_env=None):
         self.vm_path = vm_path
+        self.extra_vm_args = []
         fp_iterations_runner = os.path.join(ITERATIONS_RUNNER_DIR, iterations_runner)
         BaseVMDef.__init__(self, fp_iterations_runner, extra_env=extra_env)
 
-    def _generic_scripting_run_exec(self, entry_point, benchmark, iterations, param, vm_env, vm_args):
+    def _generic_scripting_run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
         script_path = os.path.join(BENCHMARKS_DIR, benchmark, entry_point.subdir, entry_point.target)
-        args = [self.vm_path] + vm_args + [self.iterations_runner, script_path, str(iterations), str(param)]
-
-        use_env = os.environ.copy()
-        use_env.update(vm_env)
-
-        return self._run_exec(args, use_env)
+        args = [self.vm_path] + self.extra_vm_args + [self.iterations_runner, script_path, str(iterations), str(param)]
+        return self._run_exec(args, heap_lim_k)
 
 class JavaVMDef(BaseVMDef):
     def __init__(self, vm_path, extra_env=None):
         self.vm_path = vm_path
+        self.extra_vm_args = [lambda heap_lim_k: "-Xmx%sK" % heap_lim_k]
         BaseVMDef.__init__(self, "IterationsRunner", extra_env=extra_env)
 
-    def run_exec(self, entry_point, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        vm_args = vm_args[:] + ["-Xmx%sK" % heap_limit_kb]
-        args = [self.vm_path] + vm_args + [self.iterations_runner, entry_point.target, str(iterations), str(param)]
+    def run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
+        args = [self.vm_path] + self.extra_vm_args + [self.iterations_runner, entry_point.target, str(iterations), str(param)]
         bench_dir = os.path.abspath(os.path.join(os.getcwd(), BENCHMARKS_DIR, benchmark, entry_point.subdir))
 
         # deal with CLASSPATH
+        # This has to be added here as it is benchmark specific
         cur_classpath = os.environ.get("CLASSPATH", "")
         paths = cur_classpath.split(os.pathsep)
         paths.append(ITERATIONS_RUNNER_DIR)
         paths.append(bench_dir)
 
-        new_env = os.environ.copy()
-        new_env["CLASSPATH"] = os.pathsep.join(paths)
-        new_env.update(vm_env)
+        new_env = BASE_ENV.copy()
+        new_env.update({"CLASSPATH": os.pathsep.join(paths)})
 
-        return self._run_exec(args, new_env)
+        args = [self.vm_path] + self.extra_vm_args + [self.iterations_runner, entry_point.target, str(iterations), str(param)]
+        return self._run_exec(args, heap_lim_k, bench_env=new_env)
+
+class GraalVMDef(JavaVMDef):
+    def __init__(self, vm_path, java_home, extra_env=None):
+        java_env = {"JAVA_HOME": java_home, "DEFAULT_VM": "server"}
+        if extra_env is None:
+            extra_env = java_env
+        else:
+            extra_env.update(java_env)
+
+        JavaVMDef.__init__(self, vm_path, extra_env)
+        assert(vm_path.endswith("mx"))
+        self.extra_vm_args.insert(0, "vm") # must come first!
 
 class PythonVMDef(GenericScriptingVMDef):
     def __init__(self, vm_path, extra_env=None):
         GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.py",
                                        extra_env=extra_env)
 
-    def run_exec(self, entry_point, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        # heap_limit_kb unused.
+    def run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
+        # heap_lim_k unused.
         # Python reads the rlimit structure to decide its heap limit.
-        return self._generic_scripting_run_exec(entry_point, benchmark, iterations, param, vm_env, vm_args)
+        return self._generic_scripting_run_exec(entry_point, benchmark,
+                                                iterations, param, heap_lim_k)
 
 class LuaVMDef(GenericScriptingVMDef):
     def __init__(self, vm_path, extra_env=None):
         GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.lua", extra_env=extra_env)
 
-    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+    def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k):
         # I was unable to find any special switches to limit lua's heap size.
         # Looking at implementationsi:
         #  * luajit uses anonymous mmap() to allocate memory, fiddling
         #    with rlimits prior.
         #  * Stock lua doesn't seem to do anything special. Just realloc().
-        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
+        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, heap_lim_k)
 
 class PHPVMDef(GenericScriptingVMDef):
     def __init__(self, vm_path, extra_env=None):
         GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.php", extra_env=extra_env)
+        self.extra_vm_args += ["-d", lambda heap_lim_k: "memory_limit=%sK" % heap_lim_k]
 
-    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        vm_args = vm_args[:] + ["-d", "memory_limit=%sK" % heap_limit_kb]
-        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
+    def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k):
+        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, heap_lim_k)
 
 class RubyVMDef(GenericScriptingVMDef):
     def __init__(self, vm_path, extra_env=None):
         GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.rb", extra_env=extra_env)
 
 class JRubyVMDef(RubyVMDef):
-    def run_exec(self, interpreter, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
-        vm_args = vm_args[:] + ["-J-Xmx%sK" % heap_limit_kb]
-        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, vm_env, vm_args)
+    def __init__(self, vm_path, extra_env=None):
+        RubyVMDef.__init__(self, vm_path, extra_env)
+        self.extra_vm_args += [lambda heap_lim_k: "-J-Xmx%sK" % heap_lim_k]
+
+    def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k):
+        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, heap_lim_k)
+
+class JRubyTruffleVMDef(JRubyVMDef):
+    def __init__(self, vm_path,java_path, extra_env=None):
+        java_env = {"JAVACMD": java_path}
+        if extra_env is None:
+            extra_env = java_env
+        else:
+            extra_env.update(java_env)
+        JRubyVMDef.__init__(self, vm_path, extra_env)
+
+        self.extra_vm_args += ['-X+T', '-J-server']
+
+    def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k):
+        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, heap_lim_k)
 
 class JavascriptVMDef(GenericScriptingVMDef):
     def __init__(self, vm_path, extra_env=None):
@@ -126,17 +165,19 @@ class JavascriptVMDef(GenericScriptingVMDef):
 
 
 class V8VMDef(JavascriptVMDef):
-    def run_exec(self, entry_point, benchmark, iterations, param, vm_env, vm_args, heap_limit_kb):
+    def __init__(self, vm_path, extra_env=None):
+        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.js", extra_env=extra_env)
 
         # this is a best effort at limiting the heap space.
         # V8 has a "new" and "old" heap. I can't see a way to limit the total of the two.
-        vm_args = vm_args[:] + ["--max_old_space_size", "%s" % int(heap_limit_kb / 1024)] # as MB
+        self.extra_vm_args += ["--max_old_space_size", lambda heap_lim_k: "%s" % int(heap_lim_k / 1024)] # as MB
+
+
+    def run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
+        # Duplicates generic implementation. Need to pass args differently.
 
         script_path = os.path.join(BENCHMARKS_DIR, benchmark, entry_point.subdir, entry_point.target)
-        args = [self.vm_path] + vm_args + \
+        args = [self.vm_path] + self.extra_vm_args + \
             [self.iterations_runner, '--', script_path, str(iterations), str(param)]
 
-        use_env = os.environ.copy()
-        use_env.update(vm_env)
-
-        return self._run_exec(args, use_env)
+        return self._run_exec(args, heap_lim_k)


### PR DESCRIPTION
Hey,

Please don't merge this.

This pull hides VM defails from the user and ensures that a benchmark variant really does only describe an entrypoint.

It works but I'm unhappy with it:
 * Handling of vm arguments and environments is a mess.
 * Updating environment dicts with dict.update() may flatten an existing entry in the environment.

Some of the issues regarding the former are due to the fact that the heap limit is not known when the VMDef is instantiated. I don't want the user to have to pass that in explicitly. I guess the proper fix is to make a proper config file format which is not evaluated by the python interpreter. Then after the file is parsed, the VMDefs could be instantiated passing in whatever we want.

To properly handle the latter we would need to provide krun with information about the environment. E.g. to properly update PATH without flattening the existing $PATH, krun would need to know that it is a colon separated collection of paths, and that to append another path, it should append `":%s" % another_path`.

I don't really want to spend this much time on krun at this stage. Do you see any easy improvements we can make?