### PR TITLE
Use std lib logging API for printing runner messages, warnings and errors.

### DIFF
--- a/krun/__init__.py
+++ b/krun/__init__.py
@@ -1,9 +1,3 @@
-ANSI_RED = '\033[91m'
-ANSI_GREEN = '\033[92m'
-ANSI_MAGENTA = '\033[95m'
-ANSI_CYAN = '\033[36m'
-ANSI_RESET = '\033[0m'
-
 ABS_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 UNKNOWN_TIME_DELTA = "?:??:??"
 UNKNOWN_ABS_TIME = "????-??-?? ??:??:??"

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -7,6 +7,7 @@ import difflib
 from collections import OrderedDict
 from krun import ABS_TIME_FORMAT
 from krun.util import fatal, collect_cmd_output
+from logging import warn, info
 from time import localtime
 
 class BasePlatform(object):
@@ -42,10 +43,9 @@ class BasePlatform(object):
 
         if lines:
             # dmesg changed!
-            print("dmesg seems to have changed! Diff follows:\n")
+            warn("dmesg seems to have changed! Diff follows:")
             diff = "\n".join(lines)
-            print(diff)
-            print("")
+            warn(diff)
 
             self.dmesg_changes.append(diff)
             self.last_dmesg = new_dmesg
@@ -55,15 +55,13 @@ class BasePlatform(object):
         if not self.dmesg_changes:
             return
 
-        print("dmesg output changed during benchmarking!")
-        print("It is advisable to check for performance critical errors and warnings")
-        print("")
+        warn("dmesg output changed during benchmarking!")
+        warn("It is advisable to check for performance critical errors and warnings")
 
         n_changes = len(self.dmesg_changes)
         for i in range(n_changes):
-            print("dmesg change %d/%d:" % (i + 1, n_changes))
-            print(self.dmesg_changes[i])
-            print("")
+            warn("dmesg change %d/%d:" % (i + 1, n_changes))
+            warn(self.dmesg_changes[i])
 
     def wait_until_cpu_cool(self):
         time.sleep(BasePlatform.CPU_TEMP_MANDATORY_WAIT)
@@ -76,21 +74,16 @@ class BasePlatform(object):
 
             # if we get here, CPU is too hot!
             if not msg_shown:
-                print("CPU is running hot.")
-                print(reason)
-                sys.stdout.write("Waiting to cool")
-                sys.stdout.flush()
+                info("CPU is running hot.")
+                info(reason)
+                info("Waiting to cool")
                 msg_shown = True
 
             trys += 1
             if trys >= BasePlatform.CPU_TEMP_POLLS_BEFORE_MELTDOWN:
-                print("")
                 fatal("CPU didn't cool down")
 
             time.sleep(BasePlatform.CPU_TEMP_POLL_FREQ)
-            sys.stdout.write(".")
-            sys.stdout.flush()
-        print("")
 
     # When porting to a new platform, implement the following:
     def take_cpu_temp_readings(self):

--- a/krun/util.py
+++ b/krun/util.py
@@ -1,5 +1,6 @@
 import sys
 from subprocess import Popen, PIPE
+from logging import error
 
 def should_skip(config, this_key):
     skips = config["SKIP"]
@@ -27,8 +28,7 @@ def read_config(path):
     try:
         execfile(path, dct)
     except:
-        print("*** error importing config file!\n")
-        raise
+        fatal("error importing config file")
 
     return dct
 
@@ -39,7 +39,7 @@ def output_name(config_path):
 
 
 def fatal(msg):
-    sys.stderr.write("krun: fatal: %s\n" % msg)
+    error(msg)
     sys.exit(1)
 
 

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -1,7 +1,7 @@
 import subprocess
 import os
 
-from krun import ANSI_GREEN, ANSI_RESET
+from logging import info, debug
 
 DIR = os.path.abspath(os.path.dirname(__file__))
 ITERATIONS_RUNNER_DIR = os.path.abspath(os.path.join(DIR, "..", "iterations_runners"))
@@ -43,12 +43,11 @@ class BaseVMDef(object):
                 a = a(heap_lim_k)
             actual_args.append(a)
 
-        if os.environ.get("BENCH_DEBUG"):
-            print("%s    DEBUG: cmdline='%s'%s" % (ANSI_GREEN, " ".join(actual_args), ANSI_RESET))
-            print("%s    DEBUG: env='%s'%s" % (ANSI_GREEN, use_env, ANSI_RESET))
+        debug("cmdline='%s'" % " ".join(actual_args))
+        debug("env='%s'" % use_env)
 
         if os.environ.get("BENCH_DRYRUN") != None:
-            print("%s    DEBUG: %s%s" % (ANSI_GREEN, "DRY RUN, SKIP", ANSI_RESET))
+            info("Dry run. Skipping.")
             return "[]"
 
         stdout, stderr = subprocess.Popen(


### PR DESCRIPTION
Note I was able to remove some messages altogether since the logger is already printing the current time.