### PR TITLE
Check things exist

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -302,6 +302,11 @@ class TimeEstimateFormatter(object):
         else:
             return UNKNOWN_TIME_DELTA
 
+def sanity_checks(config):
+    # per-VM sanity checks
+    for vm_name, vm_info in config["VMS"].items():
+        vm_info["vm_def"].sanity_checks()
+
 def main():
     try:
         config_file = sys.argv[1]
@@ -321,6 +326,8 @@ def main():
     max_mails = config.get("MAX_MAILS", 5)
 
     attach_log_file(config_file)
+
+    sanity_checks(config)
 
     # Build job queue -- each job is an execution
     one_exec_scheduled = False

--- a/krun.py
+++ b/krun.py
@@ -307,6 +307,18 @@ def sanity_checks(config):
     for vm_name, vm_info in config["VMS"].items():
         vm_info["vm_def"].sanity_checks()
 
+    # check all necessary benchmark files exist
+    for bench, bench_param in config["BENCHMARKS"].items():
+        for vm_name, vm_info in config["VMS"].items():
+            for variant in vm_info["variants"]:
+                entry_point = config["VARIANTS"][variant]
+                key = "%s:%s:%s" % (bench, vm_name, variant)
+
+                if util.should_skip(config, key):
+                    continue  # won't execute, so no check needed
+
+                vm_info["vm_def"].check_benchmark_files(bench, entry_point)
+
 def main():
     try:
         config_file = sys.argv[1]

--- a/krun.py
+++ b/krun.py
@@ -305,6 +305,7 @@ class TimeEstimateFormatter(object):
 def sanity_checks(config):
     # per-VM sanity checks
     for vm_name, vm_info in config["VMS"].items():
+        debug("Running sanity check for VM %s" % vm_name)
         vm_info["vm_def"].sanity_checks()
 
     # check all necessary benchmark files exist
@@ -313,6 +314,7 @@ def sanity_checks(config):
             for variant in vm_info["variants"]:
                 entry_point = config["VARIANTS"][variant]
                 key = "%s:%s:%s" % (bench, vm_name, variant)
+                debug("Running sanity check for experiment %s" % key)
 
                 if util.should_skip(config, key):
                     continue  # won't execute, so no check needed


### PR DESCRIPTION
 * check all VM executables exist.
 * check all neccessary benchmark files exist.

Avoids cases where benchmarks run for some time, then crash out later because of typos in the config file. Better to check sooner rather than later.

Was going to implement this as part of the fix for #14, but since this is blocked, decided to split this unit of work out.

Fixes #18.

OK?