### PR TITLE
Fix oracle VMs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,29 @@
-all: java libkruntime
+HERE != pwd
+ITERATIONS_RUNNERS_DIR = ${HERE}/iterations_runners
 
-.PHONY: java libkruntime clean-java clean-libkruntime clean
+all: iterations-runners libkruntime vm-sanity-checks
 
-java:
+.PHONY: iterations-runners libkruntime clean-iterations-runners
+.PHONY: clean-libkruntime clean-vm-sanity-checks clean
+
+iterations-runners:
 	cd iterations_runners && javac *.java
 
 libkruntime:
 	cd libkruntime && ${MAKE} JAVA_CPPFLAGS=${JAVA_CPPFLAGS} \
 		JAVA_CFLAGS=${JAVA_CFLAGS} JAVA_LDFLAGS=${JAVA_LDFLAGS}
 
-clean: clean-java clean-libkruntime
+vm-sanity-checks:
+	cd vm_sanity_checks && \
+		CLASSPATH=${ITERATIONS_RUNNERS_DIR} javac *.java
 
-clean-java:
+clean: clean-iterations-runners clean-libkruntime
+
+clean-iterations-runners:
 	cd krun/iteration_runners && rm *.class
+
+clean-vm-sanity-checks:
+	cd krun/vm_sanity_checks && rm *.class
 
 clean-libkruntime:
 	cd libkruntime && ${MAKE} clean

--- a/iterations_runners/iterations_runner.py
+++ b/iterations_runners/iterations_runner.py
@@ -7,7 +7,7 @@ Executes a benchmark many times within a single process.
 In Kalibera terms, this script represents one executions level run.
 """
 
-import cffi, sys, imp
+import cffi, sys, imp, os
 
 ffi = cffi.FFI()
 ffi.cdef("double clock_gettime_monotonic();")
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     iters, param = int(iters), int(param)
 
     assert benchmark.endswith(".py")
-    bench_mod_name = benchmark[:-3].replace("/", ".") # doesn't really matter
+    bench_mod_name = os.path.basename(benchmark[:-3])
     bench_mod = imp.load_source(bench_mod_name, benchmark)
 
     # The benchmark should provide a function called "run_iter" which

--- a/iterations_runners/iterations_runner.rb
+++ b/iterations_runners/iterations_runner.rb
@@ -29,7 +29,7 @@ if __FILE__ == $0
     param = Integer(param)
 
     assert benchmark.end_with?(".rb")
-    require("#{Dir.pwd}/#{benchmark}")
+    require("#{benchmark}")
 
     STDOUT.write "["
     krun_iter_num = 0

--- a/krun/util.py
+++ b/krun/util.py
@@ -30,7 +30,8 @@ def read_config(path):
     try:
         execfile(path, dct)
     except Exception as e:
-        fatal("error importing config file:\n%s" % str(e))
+        error("error importing config file:\n%s" % str(e))
+        raise
 
     return dct
 

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -2,11 +2,15 @@ import subprocess
 import os
 
 from logging import info, debug
+from krun import EntryPoint
 from krun.util import fatal
 
 DIR = os.path.abspath(os.path.dirname(__file__))
 ITERATIONS_RUNNER_DIR = os.path.abspath(os.path.join(DIR, "..", "iterations_runners"))
-BENCHMARKS_DIR = "benchmarks"
+BENCHMARKS_DIR = os.path.abspath(os.path.join(os.getcwd(), "benchmarks"))
+VM_SANITY_CHECKS_DIR = os.path.join(DIR, "..", "vm_sanity_checks")
+SANITY_CHECK_HEAP_KB = 1024 * 1024  # 1GB
+
 
 # !!!
 # Don't mutate any lists passed down from the user's config file!
@@ -15,26 +19,63 @@ BENCHMARKS_DIR = "benchmarks"
 BASE_ENV = os.environ.copy()
 BASE_ENV.update({"LD_LIBRARY_PATH": os.path.join(DIR, "..", "libkruntime")})
 
-class BaseVMDef(object):
 
-    def __init__(self, iterations_runner, extra_env=None):
+class EnvChange(object):
+    def __init__(self, var, val):
+        self.var, self.val = var, val
+
+class EnvChangeSet(EnvChange):
+    pass
+
+class EnvChangeAppend(EnvChange):
+    pass
+
+
+def _apply_env_changes(env, changes):
+    for change in changes:
+        cur_val = env.get(change.var, None)
+        if isinstance(change, EnvChangeSet):
+            if cur_val is not None:
+                fatal("Environment %s is already defined" % change.var)
+            else:
+                env[change.var] = change.val
+        elif isinstance(change, EnvChangeAppend):
+            if cur_val is None:
+                env[change.var] = change.val
+            else:
+                env[change.var] = "%s%s%s" % (cur_val, os.pathsep, change.val)
+        else:
+            assert False  # unreachable
+
+
+class BaseVMDef(object):
+    def __init__(self, iterations_runner):
         self.iterations_runner = iterations_runner
-        if extra_env is None:
-            extra_env = {}
-        self.extra_env = extra_env
+
+        # List of EnvChange instances to apply prior to each experiment.
+        # These should be benchmark agnostic. Look elsewhere for
+        # environment changes specific to a benchmark.
+        self.common_env_changes = []
+
         # tempting as it is to add a self.vm_path, we don't. If we were to add
         # natively compiled languages, then there is no "VM" to speak of.
+
+    def add_env_change(self, change):
+        self.common_env_changes.append(change)
 
     def run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
         raise NotImplementedError("abstract")
 
-    def _run_exec(self, args, heap_lim_k, bench_env=None):
+    def _run_exec(self, args, heap_lim_k, bench_env_changes=None):
         """ Deals with actually shelling out """
 
         use_env = BASE_ENV.copy()
-        use_env.update(self.extra_env)  # VM specific env
-        if bench_env:
-            use_env.update(bench_env)   # bench specific env
+        # Apply vm specific environment changes
+        _apply_env_changes(use_env, self.common_env_changes)
+
+        # Apply benchmark specific environment changes
+        if bench_env_changes:
+            _apply_env_changes(use_env, bench_env_changes)
 
         # This is kind of awkward. We don't have the heap limit at
         # VMDef construction time, so we have to substitute it in later.
@@ -62,19 +103,47 @@ class BaseVMDef(object):
     def check_benchmark_files(self, ep):
         raise NotImplementedError("abstract")
 
+    def run_vm_sanity_check(self, entry_point):
+        """Runs a VM specific sanity check (fake benchmark)."""
+
+        # Use the same mechanism as the real benchmarks would use.
+        iterations, param = 1, 666
+        stdout, stderr = self.run_exec(entry_point, None, iterations, param,
+                                       SANITY_CHECK_HEAP_KB, sanity_check=True)
+
+        err = False
+        try:
+            ls = eval(stdout)
+        except:
+            err = True
+
+        if not err and not isinstance(ls, list):
+            err = True
+
+        if err:
+            fatal("VM sanity check failed '%s'\n"
+                  "stdout:%s\nstderr: %s" % (entry_point.target, stdout, stderr))
+
 class GenericScriptingVMDef(BaseVMDef):
-    def __init__(self, vm_path, iterations_runner, entry_point=None, subdir=None, extra_env=None):
+    def __init__(self, vm_path, iterations_runner, entry_point=None, subdir=None):
         self.vm_path = vm_path
         self.extra_vm_args = []
         fp_iterations_runner = os.path.join(ITERATIONS_RUNNER_DIR, iterations_runner)
-        BaseVMDef.__init__(self, fp_iterations_runner, extra_env=extra_env)
+        BaseVMDef.__init__(self, fp_iterations_runner)
 
-    def _get_script_path(self, benchmark, entry_point):
-        return os.path.join(BENCHMARKS_DIR, benchmark, entry_point.subdir,
-                            entry_point.target)
+    def _get_script_path(self, benchmark, entry_point, sanity_check=False):
+        if not sanity_check:
+            return os.path.join(BENCHMARKS_DIR, benchmark, entry_point.subdir,
+                                entry_point.target)
+        else:
+            print(VM_SANITY_CHECKS_DIR)
+            print(entry_point.target)
+            return os.path.join(VM_SANITY_CHECKS_DIR, entry_point.target)
 
-    def _generic_scripting_run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
-        script_path = self._get_script_path(benchmark, entry_point)
+    def _generic_scripting_run_exec(self, entry_point, benchmark, iterations,
+                                    param, heap_lim_k, sanity_check=False):
+        script_path = self._get_script_path(benchmark, entry_point,
+                                            sanity_check=sanity_check)
         args = [self.vm_path] + self.extra_vm_args + [self.iterations_runner, script_path, str(iterations), str(param)]
         return self._run_exec(args, heap_lim_k)
 
@@ -90,27 +159,31 @@ class GenericScriptingVMDef(BaseVMDef):
             fatal("Benchmark file non-existent: %s" % script_path)
 
 class JavaVMDef(BaseVMDef):
-    def __init__(self, vm_path, extra_env=None):
+    def __init__(self, vm_path):
         self.vm_path = vm_path
         self.extra_vm_args = [lambda heap_lim_k: "-Xmx%sK" % heap_lim_k]
-        BaseVMDef.__init__(self, "IterationsRunner", extra_env=extra_env)
+        BaseVMDef.__init__(self, "IterationsRunner")
 
-    def run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
+    def run_exec(self, entry_point, benchmark, iterations,
+                 param, heap_lim_k, sanity_check=False):
         args = [self.vm_path] + self.extra_vm_args + [self.iterations_runner, entry_point.target, str(iterations), str(param)]
-        bench_dir = os.path.abspath(os.path.join(os.getcwd(), BENCHMARKS_DIR, benchmark, entry_point.subdir))
+
+        if not sanity_check:
+            bench_dir = os.path.abspath(
+                os.path.join(os.getcwd(), BENCHMARKS_DIR, benchmark, entry_point.subdir))
+        else:
+            bench_dir = VM_SANITY_CHECKS_DIR
 
         # deal with CLASSPATH
         # This has to be added here as it is benchmark specific
-        cur_classpath = os.environ.get("CLASSPATH", "")
-        paths = cur_classpath.split(os.pathsep)
-        paths.append(ITERATIONS_RUNNER_DIR)
-        paths.append(bench_dir)
-
-        new_env = BASE_ENV.copy()
-        new_env.update({"CLASSPATH": os.pathsep.join(paths)})
+        bench_env_changes = [
+            EnvChangeAppend("CLASSPATH", ITERATIONS_RUNNER_DIR),
+            EnvChangeAppend("CLASSPATH", bench_dir),
+        ]
 
         args = [self.vm_path] + self.extra_vm_args + [self.iterations_runner, entry_point.target, str(iterations), str(param)]
-        return self._run_exec(args, heap_lim_k, bench_env=new_env)
+        return self._run_exec(args, heap_lim_k,
+                              bench_env_changes=bench_env_changes)
 
     def sanity_checks(self):
         BaseVMDef.sanity_checks(self)
@@ -128,26 +201,35 @@ class JavaVMDef(BaseVMDef):
             fatal("Benchmark file non-existent: %s" % classfile_path)
 
 class GraalVMDef(JavaVMDef):
-    def __init__(self, vm_path, java_home, extra_env=None):
-        java_env = {"JAVA_HOME": java_home, "DEFAULT_VM": "server"}
-        if extra_env is None:
-            extra_env = java_env
-        else:
-            extra_env.update(java_env)
+    def __init__(self, vm_path, java_home=None):
+        JavaVMDef.__init__(self, vm_path)
+        if java_home is not None:
+            self.add_env_change(EnvChangeSet("JAVA_HOME", java_home))
 
-        JavaVMDef.__init__(self, vm_path, extra_env)
-        self.extra_vm_args.insert(0, "vm") # must come first!
+        self.extra_vm_args.append("-jvmci")
+
+    def run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k, sanity_check=False):
+        return JavaVMDef.run_exec(self, entry_point, benchmark,
+                                  iterations, param, heap_lim_k, sanity_check=sanity_check)
+
+    def _check_jvmci_server_enabled(self):
+        """Runs fake benchmark crashing if the Graal JVMCI JIT is disabled"""
+
+        info("Running JavaCheckJVMCIServerEnabled sanity check")
+        ep = EntryPoint("JavaCheckJVMCIServerEnabled")
+        self.run_vm_sanity_check(ep)
 
     def sanity_checks(self):
         JavaVMDef.sanity_checks(self)
 
-        if not self.vm_path.endswith("mx"):
-            fatal("Graal vm_path should be a path to 'mx'")
+        if not self.vm_path.endswith("java"):
+            fatal("Graal vm_path should be a path to a jvmci enabled java binary")
+
+        self._check_jvmci_server_enabled()
 
 class PythonVMDef(GenericScriptingVMDef):
-    def __init__(self, vm_path, extra_env=None):
-        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.py",
-                                       extra_env=extra_env)
+    def __init__(self, vm_path):
+        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.py")
 
     def run_exec(self, entry_point, benchmark, iterations, param, heap_lim_k):
         # heap_lim_k unused.
@@ -156,8 +238,8 @@ class PythonVMDef(GenericScriptingVMDef):
                                                 iterations, param, heap_lim_k)
 
 class LuaVMDef(GenericScriptingVMDef):
-    def __init__(self, vm_path, extra_env=None):
-        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.lua", extra_env=extra_env)
+    def __init__(self, vm_path):
+        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.lua")
 
     def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k):
         # I was unable to find any special switches to limit lua's heap size.
@@ -168,47 +250,57 @@ class LuaVMDef(GenericScriptingVMDef):
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, heap_lim_k)
 
 class PHPVMDef(GenericScriptingVMDef):
-    def __init__(self, vm_path, extra_env=None):
-        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.php", extra_env=extra_env)
+    def __init__(self, vm_path):
+        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.php")
         self.extra_vm_args += ["-d", lambda heap_lim_k: "memory_limit=%sK" % heap_lim_k]
 
     def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k):
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, heap_lim_k)
 
 class RubyVMDef(GenericScriptingVMDef):
-    def __init__(self, vm_path, extra_env=None):
-        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.rb", extra_env=extra_env)
+    def __init__(self, vm_path):
+        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.rb")
 
 class JRubyVMDef(RubyVMDef):
-    def __init__(self, vm_path, extra_env=None):
-        RubyVMDef.__init__(self, vm_path, extra_env)
+    def __init__(self, vm_path):
+        RubyVMDef.__init__(self, vm_path)
         self.extra_vm_args += [lambda heap_lim_k: "-J-Xmx%sK" % heap_lim_k]
 
     def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k):
         return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, heap_lim_k)
 
 class JRubyTruffleVMDef(JRubyVMDef):
-    def __init__(self, vm_path,java_path, extra_env=None):
-        java_env = {"JAVACMD": java_path}
-        if extra_env is None:
-            extra_env = java_env
-        else:
-            extra_env.update(java_env)
-        JRubyVMDef.__init__(self, vm_path, extra_env)
+    def __init__(self, vm_path, java_path):
+        JRubyVMDef.__init__(self, vm_path)
+        self.add_env_change(EnvChangeAppend("JAVACMD", java_path))
 
         self.extra_vm_args += ['-X+T', '-J-server']
 
-    def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k):
-        return self._generic_scripting_run_exec(interpreter, benchmark, iterations, param, heap_lim_k)
+    def run_exec(self, interpreter, benchmark, iterations, param, heap_lim_k,
+                 sanity_check=False):
+        return self._generic_scripting_run_exec(
+            interpreter, benchmark, iterations, param, heap_lim_k,
+            sanity_check=sanity_check)
+
+    def _check_truffle_enabled(self):
+        """Runs fake benchmark crashing if the Truffle is disabled in JRuby"""
+
+        info("Running jruby_check_truffled_enabled sanity check")
+        ep = EntryPoint("jruby_check_graal_enabled.rb")
+        self.run_vm_sanity_check(ep)
+
+    def sanity_checks(self):
+        JRubyVMDef.sanity_checks(self)
+        self._check_truffle_enabled()
 
 class JavascriptVMDef(GenericScriptingVMDef):
-    def __init__(self, vm_path, extra_env=None):
-        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.js", extra_env=extra_env)
+    def __init__(self, vm_path):
+        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.js")
 
 
 class V8VMDef(JavascriptVMDef):
-    def __init__(self, vm_path, extra_env=None):
-        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.js", extra_env=extra_env)
+    def __init__(self, vm_path):
+        GenericScriptingVMDef.__init__(self, vm_path, "iterations_runner.js")
 
         # this is a best effort at limiting the heap space.
         # V8 has a "new" and "old" heap. I can't see a way to limit the total of the two.


### PR DESCRIPTION
Includes sanity checks that run prior to real benchmarking. These are
checking that graal and truffle and enabled.

Environment handling also improved. (Sorry this is mingled in with the other change. In the beginning, fixing the oracle vms depended upon this, but I found a simpler way to invoke the VMs which didn't need the environment cleanups. Nevertheless, I am happy that handling has been simplified.)

Fix #14. Fix #5.