### PR TITLE
Initialise platform instance early, so VM sanity checks can run.

### DIFF
--- a/krun/platform.py
+++ b/krun/platform.py
@@ -412,7 +412,7 @@ class DebianLinuxPlatform(LinuxPlatform):
               "%s" % (prefix, arg, suffix))
 
 
-def platform(mailer):
+def detect_platform(mailer):
     if os.path.exists("/etc/debian_version"):
         return DebianLinuxPlatform(mailer)
     else:


### PR DESCRIPTION
Our last merge broke some VM sanity checks (the config I was using for development did not include these VMs).

We need to setup the platform instance and distribute it to VM definitions early, so these checks can run.

Also renamed the `platform` function, as it was poorly named IMHO.

OK?