### PR TITLE
Run as a different user.

### DIFF
--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -13,7 +13,6 @@ ITERATIONS_RUNNER_DIR = os.path.abspath(os.path.join(DIR, "..", "iterations_runn
 BENCHMARKS_DIR = os.path.abspath(os.path.join(os.getcwd(), "benchmarks"))
 VM_SANITY_CHECKS_DIR = os.path.join(DIR, "..", "vm_sanity_checks")
 SANITY_CHECK_HEAP_KB = 1024 * 1024  # 1GB
-NICE_PRIORITY = -20
 
 # Pipe buffer sizes vary. I've seen reports on the Internet ranging from a
 # page size (Linux pre-2.6.11) to 64K (Linux in 2015). Ideally we would
@@ -31,8 +30,8 @@ SELECT_TIMEOUT = 1.0
 # Don't mutate any lists passed down from the user's config file!
 # !!!
 
-BASE_ENV = os.environ.copy()
-BASE_ENV.update({"LD_LIBRARY_PATH": os.path.join(DIR, "..", "libkruntime")})
+# start empty! Note the the user change command (e.g. sudo/doas) will introduce some.
+BASE_ENV = {}
 
 
 class EnvChange(object):
@@ -141,7 +140,7 @@ class BaseVMDef(object):
 
         # This is kind of awkward. We don't have the heap limit at
         # VMDef construction time, so we have to substitute it in later.
-        actual_args = ["nice", NICE_PRIORITY]
+        actual_args = []
         for a in args:
             if hasattr(a, "__call__"):  # i.e. a function
                 a = a(heap_lim_k)

--- a/misc_sanity_checks/check_user_change.py
+++ b/misc_sanity_checks/check_user_change.py
@@ -1,0 +1,18 @@
+# Fake benchmark that checks we are running as the krun user.
+
+import os
+import pwd
+
+KRUN_USER = "krun"
+
+
+def run_iter(n):
+    env_user = os.environ["USER"]
+    syscall_user = pwd.getpwuid(os.geteuid())[0]
+
+    ok = env_user == syscall_user == KRUN_USER
+
+    if not ok:
+        raise RuntimeError(
+            "krun user check failed: env=%s, getuid()=%s, expect=%s" %
+            (env_user, syscall_user, KRUN_USER))


### PR DESCRIPTION
In doing so, move process priority change code to platform.py. It occurs to me that `nice` is a unix utility, and should we (god forbid) ever need this to work on windows, we will be forced to think about what to do thanks to `ABCMeta` abstract methods.

Also adds a sanity check for the user change.

A typical benchmark invocation looks like this now:
```
[2015-10-22 11:20:10 DEBUG] cmdline='sudo -u krun nice -20 taskset 0x2 env LD_LIBRARY_PATH=/home/vext01/research/warmup_experiment/krun/krun/../libkruntime work/pypy/pypy/goal/pypy-c /home/vext01/research/warmup_experiment/krun/iterations_runners/iterations_runner.py /home/vext01/research/warmup_experiment/benchmarks/nbody/python/bench.py 2 3'
[2015-10-22 11:20:10 DEBUG] env='{}'
```

Note the now empty environment (prior to`sudo`) and the use of `sudo` to switch user. `LD_LIBRARY_PATH` is needed so the VMs can pick up my implementation of `clock_gettime_monotonic()` in `libkruntime`.

Looks OK?