### PR TITLE
Add basic travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+
+script: py.test


### PR DESCRIPTION
There are some tests in `krun/tests/` which can be run with py.test, and some of the work for Issue #41 (such as appending to a JSON file) are testable. 

This PR adds a travis config to run these tests automatically.