### PR TITLE
Updated examples directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+examples/*.log
+examples/*.json
+examples/*.bz
 **/*.pyc
 **/*.swp
 **/__pycache__

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,141 @@
+# krun example
+
+This directory contains a simple experiment using krun.
+This is a good starting point for setting up your own krun configuration.
+
+The example here contains two benchmark programs (*nbody* and *dummy*),
+executed on two VMs (*cPython* and a standard *JVM* such as HotSpot).
+Each benchmark is run for 5 iterations on the same VM, then the VM is
+restarted and the benchmark is re-run for another 5 iterations.
+We say that the experiment runs 2 *executions* and 5 *iterations* of
+each benchmark.
+
+This configuration can be found in the file `examples/example.krun`.
+
+## Step 1: prepare the benchmarking machine
+
+krun currently only runs on Unix-like environments.
+To run this example experiment, you need superuser rights to the machine you are
+using, e.g. on Linux you should be able to run `sudo`.
+
+You need to have the following installed:
+
+  * Python
+  * a Java SDK (version 7)
+  * GNU make, a C compiler and libc (e.g. `sudo apt-get install build-essential`)
+  * cpufrequtils (e.g. `sudo apt-get install cpufrequtils`)
+  * cffi (e.g. `sudo apt-get install python-cffi`)
+
+If you are using a Linux system, you will need to set some kernel arguments.
+If your Linux bootloader is Grub, you can follow these steps:
+
+  * Edit /etc/default/grub (e.g. `sudo gedit /etc/default/grub`)
+  * Add `isolcpus=X` to `GRUB_CMDLINE_LINUX_DEFAULT` (where `X` is an integer > 0)
+  * Add `intel_pstate=disable` to `GRUB_CMDLINE_LINUX_DEFAULT`
+  * Run `sudo update-grub`
+
+Create a new user called `krun`, with minimal permissions:
+
+```bash
+sudo useradd krun
+```
+
+## Step 2: Fetch the krun source
+
+```bash
+$ git clone https://github.com/softdevteam/krun.git
+$ cd krun
+```
+
+## Step 3: set `JAVA_HOME`
+
+```bash
+$ export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/
+```
+## Step 4: Build krun
+
+The krun Makefile honours the standard variables: `CC`, `CPPFLAGS`, `CFLAGS`
+and `LDFLAGS`. For example, if you wish to use `clang` rather than `gcc` you
+can append `CC=/bin/clang` to the options here:
+
+```bash
+$ pwd
+.../krun
+$ make JAVA_CPPFLAGS='"-I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux"' \
+    JAVA_LDFLAGS=-L${JAVA_HOME}/lib ENABLE_JAVA=1
+```
+
+## Step 5: Build the benchmarks
+
+```bash
+$ cd examples/benchmarks
+$ pwd
+.../krun/examples/benchmarks
+$ make
+```
+
+## Step 6: Run the example experiment
+
+```bash
+$ cd ../
+$ pwd
+.../krun/examples
+$ PYTHONPATH=../ ../krun.py example.krun
+```
+
+You should see a log scroll past, and results will be stored in the file:
+`../krun/examples/example_results.json.bz2`.
+
+## Creating your own experiments
+
+The configuration file `examples/example.krun` controls the experiment here.
+To create your own experiments, you can start by expanding on this example.
+The directory structure for the
+
+```
+experiment/
+    experiment.krun
+    benchmarks/
+        Makefile
+        benchmark_1/
+            language_1/
+            benchmark_file.lang1
+    ...
+```
+
+The `Makefile` (or similar build configuration) should perform any necessary
+compilation or preprocessor steps.
+Each benchmark should expose a function (or method) called `run_iter`
+which is the entry point to the benchmark.
+In the case of compiled languages, it often makes sense to add an extra
+class to an existing benchmark, in order to provide an entry point.
+
+The example here uses Java and cPython.
+The following VMs are currently supported:
+
+  * Standard Java SDK (such as Hotspot)
+  * GraalVM
+  * cPython
+  * Lua
+  * PHP
+  * Ruby
+  * JRuby
+  * Truffle-JRuby
+  * Javascript V8
+
+To add a new VM definition, add a new class to `krun/vm_defs.py` and a
+new iteration runner to the `iterations_runners` directory.
+
+The following platforms are currently supported:
+
+  * Generic Linux
+  * Debian-based Linux
+
+To add a new platform definition, add a new class to `krun/platform.py`.
+
+## Licenses
+
+The *nbody* benchmark comes from the Computer Language Benchmarks Game, which
+are published under a revised BSD license:
+
+  http://shootout.alioth.debian.org/license.php

--- a/examples/benchmarks/Makefile
+++ b/examples/benchmarks/Makefile
@@ -1,0 +1,11 @@
+HERE !=		pwd
+JAVAC ?=	javac
+
+BENCHMARKS = dummy nbody
+
+all:
+	for i in ${BENCHMARKS}; do \
+		echo "Building java benchmark $${i}..."; \
+		cd ${HERE}/$${i}/java && \
+		CLASSPATH=../../../../../krun/iterations_runners/ ${JAVAC} *.java; \
+		done

--- a/examples/benchmarks/dummy/java/Bench.java
+++ b/examples/benchmarks/dummy/java/Bench.java
@@ -1,4 +1,7 @@
-public final class Dummy {
+/** Dummy benchmark.
+ * Each iteration sleeps for one second.
+ */
+public final class Bench {
 
     private static final int DELAY = 1000;  // milliseconds.
 
@@ -16,7 +19,7 @@ public final class Dummy {
      * This method is called by krun and runs one iteration of the benchmark.
      */
     public static void runIter(int n) {
-        Dummy.dummy();
+        Bench.dummy();
     }
 
 }

--- a/examples/benchmarks/dummy/java/Dummy.java
+++ b/examples/benchmarks/dummy/java/Dummy.java
@@ -1,0 +1,22 @@
+public final class Dummy {
+
+    private static final int DELAY = 1000;  // milliseconds.
+
+    /** The benchmark itself. */
+    private static void dummy() {
+        try {
+            Thread.sleep(DELAY);
+        } catch (InterruptedException e) {
+            System.out.println("Benchmark was interrupted.");
+            System.out.println("Measurements may be inaccurate.");
+        }
+    }
+
+    /** Entry point to the benchmark.
+     * This method is called by krun and runs one iteration of the benchmark.
+     */
+    public static void runIter(int n) {
+        Dummy.dummy();
+    }
+
+}

--- a/examples/benchmarks/dummy/java/KrunEntry.java
+++ b/examples/benchmarks/dummy/java/KrunEntry.java
@@ -1,6 +1,5 @@
-
 class KrunEntry implements BaseKrunEntry {
-  public void run_iter(int param) {
-      (new Dummy()).runIter(param);
-  }
+    public void run_iter(int param) {
+        (new Bench()).runIter(param);
+    }
 }

--- a/examples/benchmarks/dummy/java/KrunEntry.java
+++ b/examples/benchmarks/dummy/java/KrunEntry.java
@@ -1,0 +1,6 @@
+
+class KrunEntry implements BaseKrunEntry {
+  public void run_iter(int param) {
+      (new Dummy()).runIter(param);
+  }
+}

--- a/examples/benchmarks/dummy/python/bench.py
+++ b/examples/benchmarks/dummy/python/bench.py
@@ -1,0 +1,19 @@
+"""
+Dummy benchmark.
+Each iteration sleeps for one second.
+"""
+
+import time
+
+DELAY = 1  # second
+
+def dummy():
+    """The benchmark itself.
+    """
+    time.sleep(DELAY)
+
+def run_iter(n):
+    """Entry point to the benchmark.
+    This method is called by krun and runs one iteration of the benchmark.
+    """
+    dummy()

--- a/examples/benchmarks/nbody/java/KrunEntry.java
+++ b/examples/benchmarks/nbody/java/KrunEntry.java
@@ -1,0 +1,6 @@
+
+class KrunEntry implements BaseKrunEntry {
+  public void run_iter(int param) {
+      nbody.runIter(param);
+  }
+}

--- a/examples/benchmarks/nbody/java/nbody.java
+++ b/examples/benchmarks/nbody/java/nbody.java
@@ -1,0 +1,189 @@
+/* The Computer Language Benchmarks Game
+
+   http://shootout.alioth.debian.org/
+
+
+
+   contributed by Mark C. Lewis
+
+   modified slightly by Chad Whipkey
+
+*/
+
+public final class nbody {
+   static void init() {};
+   private static double checksum = 0;
+   private static final int N_ADVANCES = 100000;
+   private static final double EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625;
+   private static final double EPSILON = 0.0000000000001;
+
+   public static void runIter(int n) {
+      for (int i = 0; i < n; i++) {
+         inner_iter(N_ADVANCES);
+      }
+   }
+
+   private static void inner_iter(int n) {
+      checksum = 0;
+      NBodySystem bodies = new NBodySystem();
+      checksum += bodies.energy();
+      for (int i=0; i<n; ++i)
+         bodies.advance(0.01);
+      checksum += bodies.energy();
+
+      if (Math.abs(checksum - EXPECT_CHECKSUM) >= EPSILON) {
+         System.out.println("bad checksum: " + checksum + " vs " + EXPECT_CHECKSUM);
+         System.exit(1);
+      }
+   }
+}
+
+final class NBodySystem {
+   private Body[] bodies;
+
+   public NBodySystem(){
+      bodies = new Body[]{
+            Body.sun(),
+            Body.jupiter(),
+            Body.saturn(),
+            Body.uranus(),
+            Body.neptune()
+         };
+
+      double px = 0.0;
+      double py = 0.0;
+      double pz = 0.0;
+      for(int i=0; i < bodies.length; ++i) {
+         px += bodies[i].vx * bodies[i].mass;
+         py += bodies[i].vy * bodies[i].mass;
+         pz += bodies[i].vz * bodies[i].mass;
+      }
+      bodies[0].offsetMomentum(px,py,pz);
+   }
+
+   public void advance(double dt) {
+
+      for(int i=0; i < bodies.length; ++i) {
+         Body iBody = bodies[i];
+         for(int j=i+1; j < bodies.length; ++j) {
+            double dx = iBody.x - bodies[j].x;
+            double dy = iBody.y - bodies[j].y;
+            double dz = iBody.z - bodies[j].z;
+
+            double dSquared = dx * dx + dy * dy + dz * dz;
+            double distance = Math.sqrt(dSquared);
+            double mag = dt / (dSquared * distance);
+
+            iBody.vx -= dx * bodies[j].mass * mag;
+            iBody.vy -= dy * bodies[j].mass * mag;
+            iBody.vz -= dz * bodies[j].mass * mag;
+
+            bodies[j].vx += dx * iBody.mass * mag;
+            bodies[j].vy += dy * iBody.mass * mag;
+            bodies[j].vz += dz * iBody.mass * mag;
+         }
+      }
+
+      for ( Body body : bodies) {
+         body.x += dt * body.vx;
+         body.y += dt * body.vy;
+         body.z += dt * body.vz;
+      }
+   }
+
+   public double energy(){
+      double dx, dy, dz, distance;
+      double e = 0.0;
+
+      for (int i=0; i < bodies.length; ++i) {
+         Body iBody = bodies[i];
+         e += 0.5 * iBody.mass *
+              ( iBody.vx * iBody.vx
+                + iBody.vy * iBody.vy
+                + iBody.vz * iBody.vz );
+
+         for (int j=i+1; j < bodies.length; ++j) {
+            Body jBody = bodies[j];
+            dx = iBody.x - jBody.x;
+            dy = iBody.y - jBody.y;
+            dz = iBody.z - jBody.z;
+
+            distance = Math.sqrt(dx*dx + dy*dy + dz*dz);
+            e -= (iBody.mass * jBody.mass) / distance;
+         }
+      }
+      return e;
+   }
+}
+
+
+final class Body {
+   static final double PI = 3.141592653589793;
+   static final double SOLAR_MASS = 4 * PI * PI;
+   static final double DAYS_PER_YEAR = 365.24;
+
+   public double x, y, z, vx, vy, vz, mass;
+
+   public Body(){}
+
+   static Body jupiter(){
+      Body p = new Body();
+      p.x = 4.84143144246472090e+00;
+      p.y = -1.16032004402742839e+00;
+      p.z = -1.03622044471123109e-01;
+      p.vx = 1.66007664274403694e-03 * DAYS_PER_YEAR;
+      p.vy = 7.69901118419740425e-03 * DAYS_PER_YEAR;
+      p.vz = -6.90460016972063023e-05 * DAYS_PER_YEAR;
+      p.mass = 9.54791938424326609e-04 * SOLAR_MASS;
+      return p;
+   }
+
+   static Body saturn(){
+      Body p = new Body();
+      p.x = 8.34336671824457987e+00;
+      p.y = 4.12479856412430479e+00;
+      p.z = -4.03523417114321381e-01;
+      p.vx = -2.76742510726862411e-03 * DAYS_PER_YEAR;
+      p.vy = 4.99852801234917238e-03 * DAYS_PER_YEAR;
+      p.vz = 2.30417297573763929e-05 * DAYS_PER_YEAR;
+      p.mass = 2.85885980666130812e-04 * SOLAR_MASS;
+      return p;
+   }
+
+   static Body uranus(){
+      Body p = new Body();
+      p.x = 1.28943695621391310e+01;
+      p.y = -1.51111514016986312e+01;
+      p.z = -2.23307578892655734e-01;
+      p.vx = 2.96460137564761618e-03 * DAYS_PER_YEAR;
+      p.vy = 2.37847173959480950e-03 * DAYS_PER_YEAR;
+      p.vz = -2.96589568540237556e-05 * DAYS_PER_YEAR;
+      p.mass = 4.36624404335156298e-05 * SOLAR_MASS;
+      return p;
+   }
+
+   static Body neptune(){
+      Body p = new Body();
+      p.x = 1.53796971148509165e+01;
+      p.y = -2.59193146099879641e+01;
+      p.z = 1.79258772950371181e-01;
+      p.vx = 2.68067772490389322e-03 * DAYS_PER_YEAR;
+      p.vy = 1.62824170038242295e-03 * DAYS_PER_YEAR;
+      p.vz = -9.51592254519715870e-05 * DAYS_PER_YEAR;
+      p.mass = 5.15138902046611451e-05 * SOLAR_MASS;
+      return p;
+   }
+
+   static Body sun(){
+      Body p = new Body();
+      p.mass = SOLAR_MASS;
+      return p;
+   }
+
+   Body offsetMomentum(double px, double py, double pz){
+      vx = -px / SOLAR_MASS;
+      vy = -py / SOLAR_MASS;
+      vz = -pz / SOLAR_MASS;
+      return this;
+   }
+}

--- a/examples/benchmarks/nbody/python/bench.py
+++ b/examples/benchmarks/nbody/python/bench.py
@@ -1,0 +1,113 @@
+# The Computer Language Benchmarks Game
+# http://shootout.alioth.debian.org/
+#
+# originally by Kevin Carson
+# modified by Tupteq, Fredrik Johansson, and Daniel Nanz
+# modified by Maciej Fijalkowski
+
+import sys 
+
+def combinations(l):
+    result = []
+    for x in xrange(len(l) - 1):
+        ls = l[x+1:]
+        for y in ls:
+            result.append((l[x],y))
+    return result
+
+PI = 3.14159265358979323
+SOLAR_MASS = 4 * PI * PI
+DAYS_PER_YEAR = 365.24
+
+BODIES = {
+    'sun': ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0], SOLAR_MASS),
+
+    'jupiter': ([4.84143144246472090e+00,
+                 -1.16032004402742839e+00,
+                 -1.03622044471123109e-01],
+                [1.66007664274403694e-03 * DAYS_PER_YEAR,
+                 7.69901118419740425e-03 * DAYS_PER_YEAR,
+                 -6.90460016972063023e-05 * DAYS_PER_YEAR],
+                9.54791938424326609e-04 * SOLAR_MASS),
+
+    'saturn': ([8.34336671824457987e+00,
+                4.12479856412430479e+00,
+                -4.03523417114321381e-01],
+               [-2.76742510726862411e-03 * DAYS_PER_YEAR,
+                4.99852801234917238e-03 * DAYS_PER_YEAR,
+                2.30417297573763929e-05 * DAYS_PER_YEAR],
+               2.85885980666130812e-04 * SOLAR_MASS),
+
+    'uranus': ([1.28943695621391310e+01,
+                -1.51111514016986312e+01,
+                -2.23307578892655734e-01],
+               [2.96460137564761618e-03 * DAYS_PER_YEAR,
+                2.37847173959480950e-03 * DAYS_PER_YEAR,
+                -2.96589568540237556e-05 * DAYS_PER_YEAR],
+               4.36624404335156298e-05 * SOLAR_MASS),
+
+    'neptune': ([1.53796971148509165e+01,
+                 -2.59193146099879641e+01,
+                 1.79258772950371181e-01],
+                [2.68067772490389322e-03 * DAYS_PER_YEAR,
+                 1.62824170038242295e-03 * DAYS_PER_YEAR,
+                 -9.51592254519715870e-05 * DAYS_PER_YEAR],
+                5.15138902046611451e-05 * SOLAR_MASS) }
+
+
+SYSTEM = BODIES.values()
+PAIRS = combinations(SYSTEM)
+
+
+def advance(dt, n, bodies=SYSTEM, pairs=PAIRS):
+
+    for i in xrange(n):
+        for (([x1, y1, z1], v1, m1),
+             ([x2, y2, z2], v2, m2)) in pairs:
+            dx = x1 - x2
+            dy = y1 - y2
+            dz = z1 - z2
+            mag = dt * ((dx * dx + dy * dy + dz * dz) ** (-1.5))
+            b1m = m1 * mag
+            b2m = m2 * mag
+            v1[0] -= dx * b2m
+            v1[1] -= dy * b2m
+            v1[2] -= dz * b2m
+            v2[0] += dx * b1m
+            v2[1] += dy * b1m
+            v2[2] += dz * b1m
+        for (r, [vx, vy, vz], m) in bodies:
+            r[0] += dt * vx
+            r[1] += dt * vy
+            r[2] += dt * vz
+
+
+def report_energy(bodies=SYSTEM, pairs=PAIRS, e=0.0):
+
+    for (((x1, y1, z1), v1, m1),
+         ((x2, y2, z2), v2, m2)) in pairs:
+        dx = x1 - x2
+        dy = y1 - y2
+        dz = z1 - z2
+        e -= (m1 * m2) / ((dx * dx + dy * dy + dz * dz) ** 0.5)
+    for (r, [vx, vy, vz], m) in bodies:
+        e += m * (vx * vx + vy * vy + vz * vz) / 2.
+    #print "%.9f" % e
+    "%.9f" % e
+
+def offset_momentum(ref, bodies=SYSTEM, px=0.0, py=0.0, pz=0.0):
+
+    for (r, [vx, vy, vz], m) in bodies:
+        px -= vx * m
+        py -= vy * m
+        pz -= vz * m
+    (r, v, m) = ref
+    v[0] = px / m
+    v[1] = py / m
+    v[2] = pz / m
+
+def run_iter(n, ref='sun'):
+    offset_momentum(BODIES[ref])
+    report_energy()
+    advance(0.01, n)
+    report_energy()

--- a/examples/example.krun
+++ b/examples/example.krun
@@ -1,0 +1,49 @@
+import os
+from krun.vm_defs import (PythonVMDef, JavaVMDef)
+from krun import EntryPoint
+
+# Who to mail
+MAIL_TO = []
+
+# Maximum number of error emails to send per-run
+#MAX_MAILS = 2
+
+DIR = os.getcwd()
+JKRUNTIME_DIR = os.path.join(DIR, "krun", "libkruntime", "")
+
+HEAP_LIMIT = 2097152  # K == 2Gb
+
+# Variant name -> EntryPoint
+VARIANTS = {
+    "default-java": EntryPoint("KrunEntry", subdir="java"),
+    "default-python": EntryPoint("bench.py", subdir="python"),
+}
+
+ITERATIONS_ALL_VMS = 5  # Small number for testing.
+
+VMS = {
+    'Java': {
+        'vm_def': JavaVMDef('/usr/bin/java'),
+        'variants': ['default-java'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+    'CPython': {
+        'vm_def': PythonVMDef('/usr/bin/python2'),
+        'variants': ['default-python'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    }
+}
+
+
+BENCHMARKS = {
+    'dummy': 1000,
+    'nbody': 1000,
+}
+
+# list of "bench:vm:variant"
+SKIP=[
+    #"*:CPython:*",
+    #"*:Java:*",
+]
+
+N_EXECUTIONS = 2  # Number of fresh processes.


### PR DESCRIPTION
This is an updated version of the old `examples/` directory, which is a cut down version of the warmup benchmarks. The aim is to use this to test the work to resolve Issue #41 and `reboot mode`.

This isn't quite ready to merge, firstly it needs an `examples/README.md`. Secondly, running this on `bencher5` results in:

```bash
$ cd krun/examples/benchmarks
$ make
for i in richards nbody ; do \
	echo "Building java benchmark ${i}..."; \
	cd /home/snim2/krun/examples/benchmarks/${i}/java && \
	CLASSPATH=../../../krun/iterations_runners/ javac *.java; \
	done
Building java benchmark richards...
KrunEntry.java:2: error: cannot find symbol
class KrunEntry implements BaseKrunEntry {
                           ^
  symbol: class BaseKrunEntry
KrunEntry.java:4: error: cannot find symbol
      (new richards()).runIter(param);
           ^
  symbol:   class richards
  location: class KrunEntry
2 errors
Building java benchmark nbody...
KrunEntry.java:2: error: cannot find symbol
class KrunEntry implements BaseKrunEntry {
                           ^
  symbol: class BaseKrunEntry
1 error
Makefile:8: recipe for target 'all' failed
make: *** [all] Error 1
``` 

which looks like the `CLASSPATH` has been incorrectly set?