### PR TITLE
Fix gitignore. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 examples/*.log
 examples/*.json
-examples/*.bz
+examples/*.bz2
 **/*.pyc
 **/*.swp
 **/__pycache__


### PR DESCRIPTION
Zipped results files are saved as .bz2 (and should be ignored by git).