### PR TITLE
Tickless

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,11 +34,39 @@ If your Linux bootloader is Grub, you can follow these steps:
   * Add `intel_pstate=disable` to `GRUB_CMDLINE_LINUX_DEFAULT`
   * Run `sudo update-grub`
 
-Create a new user called `krun`, with minimal permissions:
+Also for a Linux system, krun will insist that the kernel is running in
+"tickless" mode.  Tickless mode is a compile time kernel parameter, so if it is
+not enabled, you will need to build a custom kernel.  You can verify the
+tickless mode of the current kernel with:
+
+```
+cat /boot/config-`uname -r` | grep HZ
+```
+
+`CONFIG_NO_HZ_FULL` should be set to *y*. Krun will check this before
+running benchmarks.
+
+On a Debian machine, the easiest way to build a tickless kernel is to build
+installable deb packages. This process is described
+[here](https://debian-handbook.info/browse/stable/sect.kernel-compilation.html).
+When you run `make menuconfig` to configure the kernel, go into `General
+setup->Timers subsystem->Timer tick handling` and choose `Full dynticks system
+(tickless)`. You can then continue to build and package as usual. Once
+finished, you will find `.deb` files in the parent directory. To install them,
+use `dpkg install`.  This will automatically set the new kernel as the default
+boot kernel.
+
+For more information on tickless mode, see
+[the kernel docs](https://www.kernel.org/doc/Documentation/timers/NO_HZ.txt).
+
+You will need to create a new user called `krun`, with minimal permissions:
 
 ```bash
 sudo useradd krun
 ```
+
+You will want to add this user to the `sudoers` group and make sure that
+the user does not need a password for `sudo` as root.
 
 ## Step 2: Fetch the krun source
 

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -1,0 +1,91 @@
+import pytest
+import krun.platform
+import sys
+from StringIO import StringIO
+
+
+def mk_dummy_kernel_config_fn(options_dct):
+    @staticmethod
+    def wrap():
+        fh = StringIO()
+        for k, v in options_dct.iteritems():
+            fh.write("%s=%s\n" % (k, v))
+        fh.seek(0)
+        return fh
+    return wrap
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="not linux")
+class TestLinuxPlatform(object):
+    """Check stuff specific to the Linux in krun.platform"""
+
+    @pytest.fixture
+    def platform(self):
+        return krun.platform.detect_platform(None)
+
+    def test_tickless0001(self, monkeypatch, platform):
+        """A kernel config indicating full tickless should work"""
+
+        opts = {
+            "CONFIG_NO_HZ_PERIODIC": "n",
+            "CONFIG_NO_HZ_IDLE": "n",
+            "CONFIG_NO_HZ_FULL": "y",
+        }
+
+        mock_open_kernel_config_file = mk_dummy_kernel_config_fn(opts)
+        monkeypatch.setattr(krun.platform.LinuxPlatform,
+                            "_open_kernel_config_file",
+                            mock_open_kernel_config_file)
+
+        krun.platform.LinuxPlatform._check_tickless_kernel(platform)
+
+    def test_tickless0002(self, monkeypatch, platform):
+        """A kernel config indicating *not* full tickless should exit"""
+
+        opts = {
+            "CONFIG_NO_HZ_PERIODIC": "n",
+            "CONFIG_NO_HZ_IDLE": "y",
+            "CONFIG_NO_HZ_FULL": "n",
+        }
+
+        mock_open_kernel_config_file = mk_dummy_kernel_config_fn(opts)
+        monkeypatch.setattr(krun.platform.LinuxPlatform,
+                            "_open_kernel_config_file",
+                            mock_open_kernel_config_file)
+
+        with pytest.raises(SystemExit):
+            krun.platform.LinuxPlatform._check_tickless_kernel(platform)
+
+    def test_tickless0003(self, monkeypatch, platform):
+        """A kernel config indicating >1 active tickless mode should exit"""
+
+        opts = {
+            "CONFIG_NO_HZ_PERIODIC": "y",
+            "CONFIG_NO_HZ_IDLE": "y",
+            "CONFIG_NO_HZ_FULL": "n",
+        }
+
+        mock_open_kernel_config_file = mk_dummy_kernel_config_fn(opts)
+        monkeypatch.setattr(krun.platform.LinuxPlatform,
+                            "_open_kernel_config_file",
+                            mock_open_kernel_config_file)
+
+        with pytest.raises(SystemExit):
+            krun.platform.LinuxPlatform._check_tickless_kernel(platform)
+
+    def test_tickless0004(self, monkeypatch, platform):
+        """A kernel config indicating no active tickless mode should exit"""
+
+        opts = {
+            "CONFIG_NO_HZ_PERIODIC": "n",
+            "CONFIG_NO_HZ_IDLE": "n",
+            "CONFIG_NO_HZ_FULL": "n",
+        }
+
+        mock_open_kernel_config_file = mk_dummy_kernel_config_fn(opts)
+        monkeypatch.setattr(krun.platform.LinuxPlatform,
+                            "_open_kernel_config_file",
+                            mock_open_kernel_config_file)
+
+        with pytest.raises(SystemExit):
+            krun.platform.LinuxPlatform._check_tickless_kernel(platform)


### PR DESCRIPTION
Check for tickless Linux kernel.

Tested before and after build+install of a tickless kernel.

I thought about adding instructions on how to build the tickless kernel, but I'm not sure where to put them at this stage.

Fixes #60.

OK?