### PR TITLE
Documenting how to consume Krun results files

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -120,6 +120,32 @@ $ PYTHONPATH=../ ../krun.py example.krun
 You should see a log scroll past, and results will be stored in the file:
 `../krun/examples/example_results.json.bz2`.
 
+## Using a Krun results file
+
+Krun generates a bzipped Json file containing results of all executions.
+This directory (`examples/`) contains two Python scripts which show
+how to consume results in Krun format:
+
+  * `results2csv.py` which converts the results data to `.csv` files
+  * `chart_results.py` which shows a number of interactive charts
+
+`results2csv.py` only requires the Python standard library.
+`chart_results.py` requires maptplotlib and statsmodels v0.6 or higher.
+
+The structure of the Json results is as follows:
+
+```python
+{
+    'audit': '',  # A unicode object containing platform information
+    'config': '', # A unicode object containing your Krun configuration
+    'data': {     # A dict object containing timing results
+        u'bmark:VM:variant': [  # A list of lists of timing results
+            [ ... ], ...        # One list per execution
+        ]
+  }
+}
+```
+
 ## Testing your configurations
 
 It is often useful to test a configuration file, without actually

--- a/examples/README.md
+++ b/examples/README.md
@@ -122,17 +122,8 @@ You should see a log scroll past, and results will be stored in the file:
 
 ## Using a Krun results file
 
-Krun generates a bzipped Json file containing results of all executions.
-This directory (`examples/`) contains two Python scripts which show
-how to consume results in Krun format:
-
-  * `results2csv.py` which converts the results data to `.csv` files
-  * `chart_results.py` which shows a number of interactive charts
-
-`results2csv.py` only requires the Python standard library.
-`chart_results.py` requires maptplotlib and statsmodels v0.6 or higher.
-
-The structure of the Json results is as follows:
+Krun generates a bzipped JSON file containing results of all executions.
+The structure of the JSON results is as follows:
 
 ```python
 {
@@ -145,6 +136,38 @@ The structure of the Json results is as follows:
   }
 }
 ```
+
+Often it is useful to check the audit or configuration that a result
+file was generated with.
+To do this, call Krun with the `--dump-audit` or `--dump-config` options:
+
+```bash
+$ python krun.py --dump-config examples/example_results.json.bz2
+INFO:root:Krun starting...
+[2015-11-02 14:23:31: INFO] Krun starting...
+import os
+from krun.vm_defs import (PythonVMDef, JavaVMDef)
+from krun import EntryPoint
+
+# Who to mail
+MAIL_TO = []
+...
+
+$ python krun.py --dump-audit examples/example_results.json.bz2
+{
+    "cpuinfo":  "processor\t: 0\nvendor_id\t: GenuineIntel\ncpu family\t:
+...
+```
+
+This directory (`examples/`) contains two Python scripts which show
+how to consume results in Krun format:
+
+  * `results2csv.py` which converts the results data to `.csv` files
+  * `chart_results.py` which shows a number of interactive charts
+
+`results2csv.py` only requires the Python standard library.
+`chart_results.py` requires maptplotlib and statsmodels v0.6 or higher.
+
 
 ## Testing your configurations
 

--- a/examples/chart_results.py
+++ b/examples/chart_results.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.7
 """
 usage:
-    mk_graphs.py <json results file>
+    chart_results.py <json results file>
 """
 
 import bz2

--- a/examples/results2csv.py
+++ b/examples/results2csv.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python2.7
+"""
+usage:
+    results2csv.py <json results file>
+"""
+
+import bz2, csv, json, sys
+
+
+def usage():
+    print(__doc__)
+    sys.exit(1)
+
+
+def make_csv_filename(benchmark):
+    return benchmark.replace(':', '_') + '.csv'
+
+
+def main(data_dct):
+    results = data_dct['data']
+    for benchmark in results:
+        fname = make_csv_filename(benchmark)
+        iterations = len(results[benchmark][0])
+        with open(fname, 'w') as csvfile:
+            zipped = zip(*results[benchmark])
+            writer = csv.writer(csvfile)
+            for index in range(iterations):
+                writer.writerow(zipped[index])
+
+
+def read_results_file(results_file):
+    results = None
+    with bz2.BZ2File(results_file, "rb") as f:
+        results = json.loads(f.read())
+    return results
+
+
+if __name__ == '__main__':
+    try:
+        json_file = sys.argv[1]
+    except IndexError:
+        usage()
+    data_dct = read_results_file(json_file)
+    main(data_dct)


### PR DESCRIPTION
This PR adds documentation and example scripts to show the user how to consume a results file produced by Krun. The `mk_graphs` script has been fixed and moved into `examples/`. A simpler script which just iterates over the results and creates `.csv` files has also been added.

Fixes #48
Fixes #76
Fixes #79