### PR TITLE
Scaffold OpenBSD Support

### DIFF
--- a/examples/example.krun
+++ b/examples/example.krun
@@ -1,6 +1,17 @@
 import os
 from krun.vm_defs import (PythonVMDef, JavaVMDef)
 from krun import EntryPoint
+from krun.util import fatal
+from distutils.spawn import find_executable
+
+# For a real experiment you would certainly use absolute paths
+PYTHON27_BIN = find_executable("python2.7")
+if PYTHON27_BIN is None:
+    fatal("Python binary not found in path")
+
+JAVA_BIN = find_executable("java")
+if JAVA_BIN is None:
+    fatal("Java binary not found in path")
 
 # Who to mail
 MAIL_TO = []
@@ -23,12 +34,12 @@ ITERATIONS_ALL_VMS = 5  # Small number for testing.
 
 VMS = {
     'Java': {
-        'vm_def': JavaVMDef('/usr/bin/java'),
+        'vm_def': JavaVMDef(JAVA_BIN),
         'variants': ['default-java'],
         'n_iterations': ITERATIONS_ALL_VMS,
     },
     'CPython': {
-        'vm_def': PythonVMDef('/usr/bin/python2'),
+        'vm_def': PythonVMDef(PYTHON27_BIN),
         'variants': ['default-python'],
         'n_iterations': ITERATIONS_ALL_VMS,
     }

--- a/misc_sanity_checks/check_user_change.py
+++ b/misc_sanity_checks/check_user_change.py
@@ -7,10 +7,16 @@ KRUN_USER = "krun"
 
 
 def run_iter(n):
-    env_user = os.environ["USER"]
+    env_user = os.environ.get("USER", None)
     syscall_user = pwd.getpwuid(os.geteuid())[0]
 
-    ok = env_user == syscall_user == KRUN_USER
+    ok = True
+    # OpenBSD doas(1) doesn't allow $USER through by default.
+    if env_user is not None and env_user != KRUN_USER:
+        ok = False
+
+    if syscall_user != KRUN_USER:
+        ok = False
 
     if not ok:
         raise RuntimeError(


### PR DESCRIPTION
This is a bare minimum effort to get Krun atleast running on OpenBSD. Support is not complete, but enough to get me developing on my OpenBSD laptop (up until now all development was done on Linux over SSH).

Places where proper implementations are missing have been marked with an XXX, and Krun will also emit a warning at runtime. This should make missing functionality hard to forget.

Also fix a bug in Linux support where the wrong superclass constructor was being called.

OK?