### PR TITLE
Eliminate duplicate log messages.

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -262,7 +262,7 @@ def setup_logging(parser):
     stream = logging.StreamHandler()
     stream.setLevel(level)
     stream.setFormatter(CONSOLE_FORMATTER)
-    logging.root.addHandler(stream)
+    logging.root.handlers = [stream]
 
 
 def attach_log_file(config_filename, resume):


### PR DESCRIPTION
I notice that some logging messages are printed twice. This is because `setup_logging` adds another log stream handler to the already existing one.

Here is the fix. Tested on both OpenBSD and Linux.

OK?

Example duplicate log messages:
```
$ ../krun.py example.krun --resume
INFO:root:Krun starting...
[2015-11-03 14:55:24 INFO] Krun starting...
ERROR:root:No results file to resume. Expected 'example_results.json.bz2'
[2015-11-03 14:55:24 ERROR] No results file to resume. Expected 'example_results.json.bz2'
```