### PR TITLE
Remove pointless set_method

### DIFF
--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -70,7 +70,7 @@ class ExecutionJob(object):
 
         entry_point = self.config["VARIANTS"][self.variant]
         vm_def = self.vm_info["vm_def"]
-        vm_def.set_dry_run(dry_run)
+        vm_def.dry_run = dry_run
 
         info("Running '%s(%d)' (%s variant) under '%s'" %
                     (self.benchmark, self.parameter, self.variant, self.vm_name))

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -71,11 +71,7 @@ class BaseVMDef(object):
 
         # Do not execute the benchmark program
         # (useful for testing configurations.).
-        # Set later by set_dry_run().
         self.dry_run = False
-
-    def set_dry_run(self, dry_run=False):
-        self.dry_run = dry_run
 
     def _get_benchmark_path(self, benchmark, entry_point, sanity_check=False):
         if not sanity_check:


### PR DESCRIPTION
Remove a `set_method` to make the scheduler that little bit more Pythonic (and consistent with the rest of the code base). 