### PR TITLE
Improve dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Some options exist to help inspect the results file:
   * `--dump-etas`
   * `--dump-config`
   * `--dump-audits`
+  * `--dump-temps`
+  * `--dump-data`
 
 ```bash
 $ python krun.py --dump-config examples/example_results.json.bz2

--- a/krun.py
+++ b/krun.py
@@ -8,6 +8,7 @@ usage: runner.py <config_file.krun>
 
 import argparse, json, logging, os, sys
 from logging import debug, info, warn
+import locale
 
 import krun.util as util
 from krun.platform import detect_platform
@@ -165,9 +166,7 @@ def main(parser):
             if args.dump_config:
                 text = results['config']
             elif args.dump_audit:
-                text = json.dumps(results['audit'],
-                                  ensure_ascii=True, sort_keys=True,
-                                  indent=4, separators=(',\n', ':\t'))
+                text = util.dump_audit(results['audit'])
             elif args.dump_reboots:
                 text = str(results['reboots'])
             elif args.dump_etas:
@@ -177,7 +176,14 @@ def main(parser):
             else:
                 assert False  # unreachable
 
-            print(text)
+            # JSON is UTF-8 encoded.
+            # You can't load JSON in another encoding, so instead we decode the
+            # unicode to the user's preferred locale when we output. Annoyingly
+            # the decode function in Python is call "encode".
+            #
+            # Note that if you use less(1) or redirect the output (anything
+            # that uses a pipe) then you implicitely opt for an ASCII locale.
+            print(text.encode(locale.getpreferredencoding()))
             sys.exit(0)
 
     if not args.filename.endswith(".krun"):

--- a/krun.py
+++ b/krun.py
@@ -182,13 +182,12 @@ def dump_section(args):
     else:
         assert False  # unreachable
 
-    # JSON is UTF-8 encoded. Some of the audit may not be ACSCII.
-    # You can't load JSON in another encoding, so instead we decode the
-    # unicode to the user's preferred locale when we output. Annoyingly
-    # the decode function in Python is call "encode".
+    # String data read in from JSON are unicode objects. This matters for us
+    # as some data in the audit includes unicode characters. If it does,
+    # a simple print no longer suffices if the system locale is (e.g.) ASCII.
+    # In this case print will raise.
     #
-    # Note that if you use less(1) or redirect the output (anything
-    # that uses a pipe) then you implicitly opt for an ASCII locale.
+    # The correct thing to do is to encode() the unicode to the system locale.
     print(text.encode(locale.getpreferredencoding()))
 
 

--- a/krun/util.py
+++ b/krun/util.py
@@ -3,6 +3,7 @@ import json
 import os.path
 import sys
 import time
+from collections import OrderedDict
 from subprocess import Popen, PIPE
 from logging import error
 from krun import LOGFILE_FILENAME_TIME_FORMAT
@@ -154,3 +155,12 @@ def audits_same_platform(audit0, audit1):
     if ("uname" not in audit0) or ("uname" not in audit1):
         return False
     return audit0["uname"] == audit1["uname"]
+
+def dump_audit(audit):
+    s = ""
+    # important that the sections are sorted, for diffing
+    for key, text in OrderedDict(sorted(audit.iteritems())).iteritems():
+        s += "Audit Section: %s" % key + "\n"
+        s += "#" * 78 + "\n\n"
+        s += text + "\n\n"
+    return s


### PR DESCRIPTION
Add missing dumps and make `--dump-audit` work in the presence of unicode.

fixes #105 