### PR TITLE
Refactor configuration and results information

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -254,7 +254,8 @@ def main(parser):
         # output file must exist, due to check above
         assert(out_file_exists)
         current = Results(config, platform, results_file=out_file)
-        if not util.audits_same_platform(platform.audit, current.audit):
+        from krun.audit import Audit
+        if not Audit(platform.audit) == current.audit:
             util.fatal(error_msg)
 
         debug("Using pre-recorded initial temperature readings")

--- a/krun/__init__.py
+++ b/krun/__init__.py
@@ -4,6 +4,12 @@ UNKNOWN_TIME_DELTA = "?:??:??"
 UNKNOWN_ABS_TIME = "????-??-?? ??:??:??"
 
 class EntryPoint(object):
+
     def __init__(self, target, subdir=None):
         self.target = target
         self.subdir = subdir
+
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__) and
+                (self.target == other.target) and
+                (self.subdir == other.subdir))

--- a/krun/audit.py
+++ b/krun/audit.py
@@ -1,0 +1,45 @@
+from collections import OrderedDict
+
+class Audit(object):
+
+    def __init__(self, audit_dict):
+        assert isinstance(audit_dict, dict)
+        self._audit = audit_dict
+
+    def __contains__(self, key):
+        return key in self._audit
+
+    def __getitem__(self, key):
+        return self._audit[key]
+
+    def __setitem__(self, key, value):
+        self._audit[key] = value
+
+    def __unicode__(self):
+        s = ""
+        # important that the sections are sorted, for diffing
+        for key, text in OrderedDict(sorted(self._audit.iteritems())).iteritems():
+            s += "Audit Section: %s" % key + "\n"
+            s += "#" * 78 + "\n\n"
+            s += unicode(text) + "\n\n"
+        return s
+
+    def __len__(self):
+        return len(self._audit)
+
+    @property
+    def audit(self):
+        return self._audit
+
+    @audit.setter
+    def audit(self, audit_dict):
+        self._audit = audit_dict
+
+    def __eq__(self, other):
+        if ((not isinstance(other, self.__class__)) or
+            (not len(self) == len(other))):
+            return False
+        for key in self._audit:
+            if ((key not in other._audit) or (other[key] != self[key])):
+                return False
+        return True

--- a/krun/audit.py
+++ b/krun/audit.py
@@ -1,4 +1,6 @@
 from collections import OrderedDict
+from logging import debug
+
 
 class Audit(object):
 
@@ -40,6 +42,9 @@ class Audit(object):
             (not len(self) == len(other))):
             return False
         for key in self._audit:
+            if key == "packages" and (key in self) and (key in other):
+                continue
             if ((key not in other._audit) or (other[key] != self[key])):
+                debug("%s keys differed in audit" % key)
                 return False
         return True

--- a/krun/config.py
+++ b/krun/config.py
@@ -84,11 +84,11 @@ class Config(object):
     def __eq__(self, other):
         # Equality should ignore filename.
         return (isinstance(other, self.__class__) and
-               (self.text == other.text) and
+                (self.text == other.text) and
                 (self.MAIL_TO == other.MAIL_TO) and
                 (self.MAX_MAILS == other.MAX_MAILS) and
                 (self.VMS == other.VMS) and
-                # (self.VARIANTS == other.VARIANTS) and
+                (self.VARIANTS == other.VARIANTS) and
                 (self.BENCHMARKS == other.BENCHMARKS) and
                 (self.SKIP == other.SKIP) and
                 (self.N_EXECUTIONS == other.N_EXECUTIONS))

--- a/krun/config.py
+++ b/krun/config.py
@@ -1,0 +1,94 @@
+from logging import error
+
+import os.path
+import time
+
+from krun import LOGFILE_FILENAME_TIME_FORMAT
+
+
+class Config(object):
+    """All configuration for a Krun benchmark.
+    Includes CLI args as well as configuration from .krun files.
+    """
+
+    def __init__(self, config_file=None):
+        self.MAIL_TO = list()
+        self.MAX_MAILS = 5
+        self.VMS = dict()
+        self.VARIANTS = dict()
+        self.BENCHMARKS = dict()
+        self.SKIP = list()
+        self.N_EXECUTIONS = 1
+        self.filename = config_file
+        if config_file is not None:
+            self.read_from_file(config_file)
+
+    def read_from_string(self, config_str):
+        config_dict = {}
+        try:
+            exec(config_str, config_dict)
+        except Exception as e:
+            error("error importing config file:\n%s" % str(e))
+            raise
+        self.__dict__.update(config_dict)
+        self.filename = ""
+        self.text = config_str
+
+    def read_from_file(self, config_file):
+        assert config_file.endswith(".krun")
+        config_dict = {}
+        try:
+            execfile(config_file, config_dict)
+        except Exception as e:
+            error("error importing config file:\n%s" % str(e))
+            raise
+        self.__dict__.update(config_dict)
+        self.filename = config_file
+        with open(config_file, "r") as fp:
+            self.text = fp.read()
+
+    def log_filename(self, resume=False):
+        assert self.filename.endswith(".krun")
+        if resume:
+            config_mtime = time.gmtime(os.path.getmtime(self.filename))
+            tstamp = time.strftime(LOGFILE_FILENAME_TIME_FORMAT, config_mtime)
+        else:
+            tstamp = time.strftime(LOGFILE_FILENAME_TIME_FORMAT)
+        return self.filename[:-5] + "_%s.log" % tstamp
+
+    def results_filename(self):  # FIXME: was called output_name in util
+        """Makes a result file name based upon the config file name."""
+        assert self.filename.endswith(".krun")
+        return self.filename[:-5] + "_results.json.bz2"
+
+    def should_skip(self, this_key):
+        for skip_key in self.SKIP:
+            skip_elems = skip_key.split(":")
+            this_elems = this_key.split(":")
+
+            # Should be triples of: bench * vm * variant
+            assert len(skip_elems) == 3 and len(this_elems) == 3
+
+            for i in range(3):
+                if skip_elems[i] == "*":
+                    this_elems[i] = "*"
+
+            if skip_elems == this_elems:
+                return True # skip
+
+        return False
+
+    def __str__(self):
+        return self.text
+
+    def __eq__(self, other):
+        # Equality should ignore filename.
+        return (isinstance(other, self.__class__) and
+               (self.text == other.text) and
+                (self.MAIL_TO == other.MAIL_TO) and
+                (self.MAX_MAILS == other.MAX_MAILS) and
+                (self.VMS == other.VMS) and
+                # (self.VARIANTS == other.VARIANTS) and
+                (self.BENCHMARKS == other.BENCHMARKS) and
+                (self.SKIP == other.SKIP) and
+                (self.N_EXECUTIONS == other.N_EXECUTIONS))

--- a/krun/results.py
+++ b/krun/results.py
@@ -9,19 +9,24 @@ class Results(object):
     """Results of a Krun benchmarking session.
     Can be serialised to disk.
     """
+
     def __init__(self, config, platform, results_file=None):
         self.config = config
+
         # Maps key to results:
         # "bmark:vm:variant" -> [[e0i0, e0i1, ...], [e1i0, e1i1, ...], ...]
         self.data = dict()
         self.reboots = 0
+
         # Record how long execs are taking so we can give the user a rough ETA.
         # Maps "bmark:vm:variant" -> [t_0, t_1, ...]
         self.eta_estimates = dict()
+
         # error_flag is flipped when a (non-fatal) error or warning occurs.
         # When Krun finishes and this flag is true, a message is printed,
         # thus prompting the user to investigate.
         self.error_flag = False
+
         # Fill in attributes from the config, platform and prior results.
         if self.config is not None:
             self.filename = self.config.results_filename()
@@ -32,6 +37,7 @@ class Results(object):
         else:
             self.starting_temperatures = list()
             self.audit = dict()
+
         # Import data from a Results object serialised on disk.
         if results_file is not None:
             self.read_from_file(results_file)
@@ -91,10 +97,10 @@ class Results(object):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return (self.config == other.config and \
-                self.data == other.data and \
-                self.audit == other.audit and \
-                self.reboots == other.reboots and \
-                self.starting_temperatures == other.starting_temperatures and \
-                self.eta_estimates == other.eta_estimates and \
+        return (self.config == other.config and
+                self.data == other.data and
+                self.audit == other.audit and
+                self.reboots == other.reboots and
+                self.starting_temperatures == other.starting_temperatures and
+                self.eta_estimates == other.eta_estimates and
                 self.error_flag == other.error_flag)

--- a/krun/results.py
+++ b/krun/results.py
@@ -1,62 +1,86 @@
+from krun.audit import Audit
+from krun.config import Config
+
 import bz2  # decent enough compression with Python 2.7 compatibility.
 import json
 
-import krun.util as util
 
 class Results(object):
     """Results of a Krun benchmarking session.
     Can be serialised to disk.
     """
-    def __init__(self, results_file=None, config_file=None):
+    def __init__(self, config, platform, results_file=None):
+        self.config = config
         # Maps key to results:
         # "bmark:vm:variant" -> [[e0i0, e0i1, ...], [e1i0, e1i1, ...], ...]
         self.data = dict()
-        self.audit = dict()
-        self.config = u""  # FIXME: Should be a krun.config.Config object.
         self.reboots = 0
         # Record how long execs are taking so we can give the user a rough ETA.
         # Maps "bmark:vm:variant" -> [t_0, t_1, ...]
-        self.etas = dict()
-        self.starting_temperatures = list()
+        self.eta_estimates = dict()
         # error_flag is flipped when a (non-fatal) error or warning occurs.
         # When Krun finishes and this flag is true, a message is printed,
         # thus prompting the user to investigate.
         self.error_flag = False
+        # Fill in attributes from the config, platform and prior results.
+        if self.config is not None:
+            self.filename = self.config.results_filename()
+            self.init_from_config()
+        if platform is not None:
+            self.starting_temperatures = platform.starting_temperatures
+            self._audit = Audit(platform.audit)
+        else:
+            self.starting_temperatures = list()
+            self.audit = dict()
+        # Import data from a Results object serialised on disk.
         if results_file is not None:
             self.read_from_file(results_file)
-        if config_file is not None:
-            self.init_from_config(config_file)
 
-    def init_from_config(self, config_file):
+    @property
+    def audit(self):
+        return self._audit
+
+    @audit.setter
+    def audit(self, audit_dict):
+        self._audit = Audit(audit_dict)
+
+    def init_from_config(self):
         """Scaffold dictionaries based on a given configuration.
         """
-        with open(config_file, "r") as fp:
-            self.config = fp.read()
-        config = util.read_config(config_file)
         # Initialise dictionaries based on config information.
-        # FIXME! self.config should be an object.
-        for vm_name, vm_info in config["VMS"].items():
-            for bmark, _ in config["BENCHMARKS"].items():
+        for vm_name, vm_info in self.config.VMS.items():
+            for bmark, _ in self.config.BENCHMARKS.items():
                 for variant in vm_info["variants"]:
                     key = ":".join((bmark, vm_name, variant))
-                    if key in self.data:
-                        continue
-                    self.data[key] = [list() for _ in range(config["N_EXECUTIONS"])]
-                    self.etas[key] = []
+                    self.data[key] = []
+                    self.eta_estimates[key] = []
 
     def read_from_file(self, results_file):
         """Initialise object from serialised file on disk.
         """
-        results = None
         with bz2.BZ2File(results_file, "rb") as f:
             results = json.loads(f.read())
-        self.__dict__ = results
+            self.__dict__.update(results)
+            # Ensure that self.audir and self.config have correct types.
+            self.config = Config(None)
+            self.config.read_from_string(results["config"])
+            self.audit = results["audit"]
 
-    def write_to_file(self, results_file):
+    def write_to_file(self):
         """Serialise object on disk.
         """
-        with bz2.BZ2File(results_file, "w") as f:
-            f.write(self.__repr__())
+        to_write = {
+            "config": self.config.text,
+            "data": self.data,
+            "audit": self.audit.audit,
+            "reboots": self.reboots,
+            "starting_temperatures": self.starting_temperatures,
+            "eta_estimates": self.eta_estimates,
+            "error_flag": self.error_flag,
+        }
+        with bz2.BZ2File(self.filename, "w") as f:
+            f.write(json.dumps(to_write,
+                               indent=1, sort_keys=True, encoding='utf-8'))
 
     def jobs_completed(self, key):
         """Return number of executions for which we have data for a given
@@ -65,8 +89,12 @@ class Results(object):
         return len(self.data[key])
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
-
-    def __repr__(self):
-        return json.dumps(self.__dict__,
-                          indent=1, sort_keys=True, encoding='utf-8')
+        if not isinstance(other, self.__class__):
+            return False
+        return (self.config == other.config and \
+                self.data == other.data and \
+                self.audit == other.audit and \
+                self.reboots == other.reboots and \
+                self.starting_temperatures == other.starting_temperatures and \
+                self.eta_estimates == other.eta_estimates and \
+                self.error_flag == other.error_flag)

--- a/krun/results.py
+++ b/krun/results.py
@@ -1,0 +1,72 @@
+import bz2  # decent enough compression with Python 2.7 compatibility.
+import json
+
+import krun.util as util
+
+class Results(object):
+    """Results of a Krun benchmarking session.
+    Can be serialised to disk.
+    """
+    def __init__(self, results_file=None, config_file=None):
+        # Maps key to results:
+        # "bmark:vm:variant" -> [[e0i0, e0i1, ...], [e1i0, e1i1, ...], ...]
+        self.data = dict()
+        self.audit = dict()
+        self.config = u""  # FIXME: Should be a krun.config.Config object.
+        self.reboots = 0
+        # Record how long execs are taking so we can give the user a rough ETA.
+        # Maps "bmark:vm:variant" -> [t_0, t_1, ...]
+        self.etas = dict()
+        self.starting_temperatures = list()
+        # error_flag is flipped when a (non-fatal) error or warning occurs.
+        # When Krun finishes and this flag is true, a message is printed,
+        # thus prompting the user to investigate.
+        self.error_flag = False
+        if results_file is not None:
+            self.read_from_file(results_file)
+        if config_file is not None:
+            self.init_from_config(config_file)
+
+    def init_from_config(self, config_file):
+        """Scaffold dictionaries based on a given configuration.
+        """
+        with open(config_file, "r") as fp:
+            self.config = fp.read()
+        config = util.read_config(config_file)
+        # Initialise dictionaries based on config information.
+        # FIXME! self.config should be an object.
+        for vm_name, vm_info in config["VMS"].items():
+            for bmark, _ in config["BENCHMARKS"].items():
+                for variant in vm_info["variants"]:
+                    key = ":".join((bmark, vm_name, variant))
+                    if key in self.data:
+                        continue
+                    self.data[key] = [list() for _ in range(config["N_EXECUTIONS"])]
+                    self.etas[key] = []
+
+    def read_from_file(self, results_file):
+        """Initialise object from serialised file on disk.
+        """
+        results = None
+        with bz2.BZ2File(results_file, "rb") as f:
+            results = json.loads(f.read())
+        self.__dict__ = results
+
+    def write_to_file(self, results_file):
+        """Serialise object on disk.
+        """
+        with bz2.BZ2File(results_file, "w") as f:
+            f.write(self.__repr__())
+
+    def jobs_completed(self, key):
+        """Return number of executions for which we have data for a given
+        benchmark / vm / variant triplet.
+        """
+        return len(self.data[key])
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def __repr__(self):
+        return json.dumps(self.__dict__,
+                          indent=1, sort_keys=True, encoding='utf-8')

--- a/krun/tests/skips.krun
+++ b/krun/tests/skips.krun
@@ -1,0 +1,55 @@
+import os
+from krun.vm_defs import (PythonVMDef, JavaVMDef)
+from krun import EntryPoint
+
+# Who to mail
+MAIL_TO = []
+
+# Maximum number of error emails to send per-run
+#MAX_MAILS = 2
+
+DIR = os.getcwd()
+JKRUNTIME_DIR = os.path.join(DIR, "krun", "libkruntime", "")
+
+HEAP_LIMIT = 2097152  # K == 2Gb
+
+# Variant name -> EntryPoint
+VARIANTS = {
+    "default-java": EntryPoint("KrunEntry", subdir="java"),
+    "default-python": EntryPoint("bench.py", subdir="python"),
+}
+
+ITERATIONS_ALL_VMS = 1  # Small number for testing.
+
+VMS = {
+    'Java': {
+        'vm_def': JavaVMDef('/usr/bin/java'),
+        'variants': ['default-java'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+    'CPython': {
+        'vm_def': PythonVMDef('/usr/bin/python2'),
+        'variants': ['default-python'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    }
+}
+
+
+BENCHMARKS = {
+    'dummy': 1000,
+    'nbody': 1000,
+}
+
+# list of "bench:vm:variant"
+SKIP=[
+    "*:PyPy:*",
+    "*:CPython:*",
+    "*:Hotspot:*",
+    "*:Graal:*",
+    "*:LuaJIT:*",
+    "*:HHVM:*",
+    "*:JRubyTruffle:*",
+    "*:V8:*",
+]
+
+N_EXECUTIONS = 1  # Number of fresh processes.

--- a/krun/tests/test_audit.py
+++ b/krun/tests/test_audit.py
@@ -1,0 +1,49 @@
+from krun.audit import Audit
+
+
+def test_eq():
+    audit = Audit({"a":100, "b":200})
+    empty = Audit(dict())
+    assert audit == audit
+    assert empty == empty
+    assert not empty == audit
+    assert not list() == audit
+    audit["c"] = 300
+    audit_ = Audit({"a":100, "b":200, "c":400})
+    assert not audit == audit_
+
+
+def test_get_set_item():
+    audit = Audit({"a":100, "b":200})
+    empty = Audit(dict())
+    assert  audit["a"] == 100
+    assert  audit["b"] == 200
+    empty["a"] = 100
+    empty["b"] = 200
+    assert audit == empty
+
+
+def test_contains():
+    audit = Audit({"a":100, "b":200})
+    assert "a" in audit
+    assert not "c" in audit
+
+
+def test_property():
+    audit = Audit({"a":100, "b":200})
+    assert audit.audit == {"a":100, "b":200}
+    empty = Audit(dict())
+    empty.audit = {"a":100, "b":200}
+    assert empty == audit
+
+
+def test_unicode():
+    audit = Audit({"a":100, "b":200})
+    spacer = "#" * 78
+    expected = "Audit Section: a\n"
+    expected += spacer + u"\n\n"
+    expected += "100\n\n"
+    expected += "Audit Section: b\n"
+    expected += spacer + "\n\n"
+    expected += "200\n\n"
+    assert unicode(expected) == unicode(audit)

--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -1,0 +1,112 @@
+from krun import LOGFILE_FILENAME_TIME_FORMAT
+from krun.config import Config
+
+import os
+import pytest
+import time
+
+
+def touch(fname):
+    with open(fname, 'a'):
+        os.utime(fname, None)
+
+
+def test_str():
+    config = Config("krun/tests/example.krun")
+    assert config.text == str(config)
+
+def test_eq():
+    example_config = Config("krun/tests/example.krun")
+    assert example_config == example_config
+    assert not example_config == None
+    assert not example_config == Config("krun/tests/quick.krun")
+
+
+def test_log_filename(monkeypatch):
+    example_config = Config("krun/tests/example.krun")
+    touch("krun/tests/.krun")
+    empty_config = Config("krun/tests/.krun")
+    tstamp = time.strftime(LOGFILE_FILENAME_TIME_FORMAT)
+    assert example_config.log_filename(False) == "krun/tests/example" + "_" + tstamp + ".log"
+    assert empty_config.log_filename(False) == "krun/tests/_" + tstamp + ".log"
+    def mock_mtime(path):
+        return 1445964109.9363003
+    monkeypatch.setattr(os.path, 'getmtime', mock_mtime)
+    tstamp = '20151027_164149'
+    assert example_config.log_filename(True) == "krun/tests/example" + "_" + tstamp + ".log"
+    assert empty_config.log_filename(True) == "krun/tests/_" + tstamp + ".log"
+    os.unlink("krun/tests/.krun")
+
+
+def test_read_config_from_file():
+    path = "krun/tests/example.krun"
+    config0 = Config(path)
+    config1 = Config(None)
+    config1.read_from_file(path)
+    assert config0 == config1
+
+
+def test_read_config_from_string():
+    path = "krun/tests/example.krun"
+    config0 = Config(path)
+    config1 = Config(None)
+    with open(path) as fp:
+        config_string = fp.read()
+        config1.read_from_string(config_string)
+        assert config0 == config1
+
+
+def test_read_corrupt_config_from_string():
+    path = "krun/tests/corrupt.krun"
+    config = Config(None)
+    with pytest.raises(Exception):
+        with open(path) as fp:
+            config_string = fp.read()
+            config.read_from_string(config_string)
+
+
+def test_config_init():
+    path = "examples/example.krun"
+    config = Config(path)
+    assert config is not None
+    assert config.BENCHMARKS == {"dummy": 1000, "nbody": 1000}
+    assert config.N_EXECUTIONS == 2
+    assert config.SKIP == []
+    assert config.MAIL_TO == []
+    assert config.ITERATIONS_ALL_VMS == 5
+    assert config.HEAP_LIMIT == 2097152
+
+
+def test_read_corrupt_config():
+    path = "krun/tests/corrupt.krun"
+    with pytest.raises(Exception):
+        Config(path)
+
+
+def test_results_filename():
+    empty, example = ".krun", "example.krun"
+    touch(empty)
+    touch(example)
+    empty_config = Config(empty)
+    example_config = Config(example)
+    assert empty_config.results_filename() == "_results.json.bz2"
+    assert example_config.results_filename() == "example_results.json.bz2"
+    os.unlink(empty)
+    os.unlink(example)
+
+
+def test_should_skip():
+    config = Config("krun/tests/skips.krun")
+    expected = ["*:PyPy:*",
+                "*:CPython:*",
+                "*:Hotspot:*",
+                "*:Graal:*",
+                "*:LuaJIT:*",
+                "*:HHVM:*",
+                "*:JRubyTruffle:*",
+                "*:V8:*",
+    ]
+    for triplet in expected:
+        assert config.should_skip(triplet)
+    assert config.should_skip("nbody:HHVM:default-php")
+    assert not config.should_skip("nbody:MYVM:default-php")

--- a/krun/tests/test_entry_point.py
+++ b/krun/tests/test_entry_point.py
@@ -1,0 +1,10 @@
+from krun import EntryPoint
+
+
+def test_eq():
+    ep0 = EntryPoint("test0", subdir="/root/")
+    ep1 = EntryPoint("test1", subdir="/home/krun/")
+    assert ep0 == ep0
+    assert ep1 == ep1
+    assert not ep0 == ep1
+    assert not ep0 == list()

--- a/krun/tests/test_results.py
+++ b/krun/tests/test_results.py
@@ -1,19 +1,40 @@
+from krun.config import Config
 from krun.results import Results
+from krun.tests.mocks import MockPlatform, MockMailer
 
 import os
 
 
+def test_eq():
+    results = Results(None, None,
+                      results_file="krun/tests/quick_results.json.bz2")
+    assert results == results
+    assert not results == None
+    assert not results == Results(Config("krun/tests/example.krun"),
+                                  MockPlatform(MockMailer()))
+
+
+def test_dump_config():
+    """Simulates krun.py --dump-config RESULTS_FILE.json.bz2
+    """
+    results = Results(None, None,
+                      results_file="krun/tests/quick_results.json.bz2")
+    with open("krun/tests/quick.krun") as fp:
+        config = fp.read()
+        assert config == results.config.text
+
+
 def test_read_results_from_disk():
-    results = Results(results_file='krun/tests/quick_results.json.bz2')
+    config = Config("krun/tests/quick.krun")
+    results = Results(None, None,
+                      results_file="krun/tests/quick_results.json.bz2")
     expected = {u'nbody:CPython:default-python': [[0.022256]],
                 u'dummy:CPython:default-python': [[1.005115]],
                 u'nbody:Java:default-java': [[26.002632]],
                 u'dummy:Java:default-java': [[1.000941]]}
-    with open('krun/tests/quick.krun', 'rb') as config_fp:
-        config = config_fp.read()
     assert results.config == config
-    assert results.audit['uname'] == u'Linux'
-    assert results.audit['debian_version'] == u'jessie/sid'
+    assert results.audit[u'uname'] == u'Linux'
+    assert results.audit[u'debian_version'] == u'jessie/sid'
     assert results.data == expected
     assert results.starting_temperatures == [4355, 9879]
     assert results.eta_estimates == \
@@ -26,18 +47,17 @@ def test_read_results_from_disk():
 
 
 def test_write_results_to_disk():
+    config = Config("krun/tests/example.krun")
     out_file = "krun/tests/example_results.json.bz2"
-    results0 = Results()
-    results0.audit = "example audit (py.test)"
+    results0 = Results(config, MockPlatform(MockMailer()))
+    results0.audit = dict()
     results0.starting_temperatures = [4355, 9879]
-    results0.data = {"dummy:Java:default-java": [[1.000726]]}
-    results0.etas = {"dummy:Java:default-java": [1.1]}
+    results0.data = {u"dummy:Java:default-java": [[1.000726]]}
+    results0.eta_estimates = {u"dummy:Java:default-java": [1.1]}
     results0.reboots = 5
     results0.error_flag = False
-    with open("krun/tests/example.krun", "r") as fp:
-        results0.config = fp.read()
-    results0.write_to_file(out_file)
-    results1 = Results(results_file=out_file)
+    results0.write_to_file()
+    results1 = Results(config, None, results_file=out_file)
     assert results0 == results1
     # Clean-up generated file.
     os.unlink(out_file)

--- a/krun/tests/test_results.py
+++ b/krun/tests/test_results.py
@@ -1,0 +1,43 @@
+from krun.results import Results
+
+import os
+
+
+def test_read_results_from_disk():
+    results = Results(results_file='krun/tests/quick_results.json.bz2')
+    expected = {u'nbody:CPython:default-python': [[0.022256]],
+                u'dummy:CPython:default-python': [[1.005115]],
+                u'nbody:Java:default-java': [[26.002632]],
+                u'dummy:Java:default-java': [[1.000941]]}
+    with open('krun/tests/quick.krun', 'rb') as config_fp:
+        config = config_fp.read()
+    assert results.config == config
+    assert results.audit['uname'] == u'Linux'
+    assert results.audit['debian_version'] == u'jessie/sid'
+    assert results.data == expected
+    assert results.starting_temperatures == [4355, 9879]
+    assert results.eta_estimates == \
+        {
+            u'nbody:CPython:default-python': [0.022256],
+            u'dummy:CPython:default-python': [1.005115],
+            u'nbody:Java:default-java': [26.002632],
+            u'dummy:Java:default-java': [1.000941]
+        }
+
+
+def test_write_results_to_disk():
+    out_file = "krun/tests/example_results.json.bz2"
+    results0 = Results()
+    results0.audit = "example audit (py.test)"
+    results0.starting_temperatures = [4355, 9879]
+    results0.data = {"dummy:Java:default-java": [[1.000726]]}
+    results0.etas = {"dummy:Java:default-java": [1.1]}
+    results0.reboots = 5
+    results0.error_flag = False
+    with open("krun/tests/example.krun", "r") as fp:
+        results0.config = fp.read()
+    results0.write_to_file(out_file)
+    results1 = Results(results_file=out_file)
+    assert results0 == results1
+    # Clean-up generated file.
+    os.unlink(out_file)

--- a/krun/tests/test_scheduler.py
+++ b/krun/tests/test_scheduler.py
@@ -96,8 +96,6 @@ def test_run_schedule(monkeypatch):
                                platform, resume=False,
                                reboot=False, dry_run=True,
                                started_by_init=False)
-    # for vm_name, vm_info in sched.config.VMS.items():
-    #     vm_info["vm_def"].set_platform(platform)
     sched.build_schedule()
     assert len(sched) == 8
     sched.run()
@@ -140,8 +138,6 @@ def test_run_schedule_reboot(monkeypatch):
                                platform, resume=False,
                                reboot=True, dry_run=True,
                                started_by_init=True)
-    # for vm_name, vm_info in sched.config.VMS.items():
-    #     vm_info["vm_def"].set_platform(platform)
     sched.build_schedule()
     assert len(sched) == 8
     with pytest.raises(AssertionError):

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -1,7 +1,7 @@
 from krun.util import (format_raw_exec_results,
                        log_and_mail, fatal,
                        check_and_parse_execution_results,
-                       run_shell_cmd, audits_same_platform,
+                       run_shell_cmd,
                        ExecutionFailed)
 from krun.tests.mocks import MockMailer
 
@@ -87,20 +87,3 @@ stderr:
 --------------------------------------------------
 """
     assert excinfo.value.message == expected
-
-
-def test_audit_compare():
-    audit0 = dict([("cpuinfo", u"processor\t: 0\nvendor_id\t: GenuineIntel"),
-                   ("uname", u"Linux"),
-                   ("debian_version", u"jessie/sid"),
-                   ("packages", u"1:1.2.8.dfsg-2ubuntu1"),
-                   ("dmesg", u"")])
-    audit1 = dict([("cpuinfo", u"processor\t: 0\nvendor_id\t: GenuineIntel"),
-                   ("uname", u"BSD"),
-                   ("packages", u"1:1.2.8.dfsg-2ubuntu1"),
-                   ("dmesg", u"")])
-    assert audits_same_platform(audit0, audit0)
-    assert audits_same_platform(audit1, audit1)
-    assert not audits_same_platform([], [])
-    assert not audits_same_platform(audit0, audit1)
-    assert not audits_same_platform(audit1, audit0)

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -1,61 +1,12 @@
-from krun import LOGFILE_FILENAME_TIME_FORMAT
-from krun.util import (should_skip, format_raw_exec_results, output_name,
-                       log_and_mail, log_name, fatal, read_config,
+from krun.util import (format_raw_exec_results,
+                       log_and_mail, fatal,
                        check_and_parse_execution_results,
                        run_shell_cmd, audits_same_platform,
                        ExecutionFailed)
 from krun.tests.mocks import MockMailer
 
-import json, os, pytest, time
-
-
-def test_should_skip():
-    config = dict([("SKIP", ["*:PyPy:*",
-                             "*:CPython:*",
-                             "*:Hotspot:*",
-                             "*:Graal:*",
-                             "*:LuaJIT:*",
-                             "*:HHVM:*",
-                             "*:JRubyTruffle:*",
-                             "*:V8:*",
-    ])])
-    assert should_skip(config, "nbody:HHVM:default-php")
-    assert not should_skip(dict([("SKIP", [])]), "nbody:HHVM:default-php")
-
-
-def test_read_config():
-    path = "examples/example.krun"
-    config = read_config(path)
-    assert config is not None
-    assert config["BENCHMARKS"] == {"dummy": 1000, "nbody": 1000}
-    assert config["N_EXECUTIONS"] == 2
-    assert config["SKIP"] == []
-    assert config["MAIL_TO"] == []
-    assert config["ITERATIONS_ALL_VMS"] == 5
-    assert config["HEAP_LIMIT"] == 2097152
-
-
-def test_read_corrupt_config():
-    path = "krun/tests/corrupt.krun"
-    with pytest.raises(Exception):
-        _ = read_config(path)
-
-
-def test_output_name():
-    assert output_name(".krun") == "_results.json.bz2"
-    assert output_name("example.krun") == "example_results.json.bz2"
-
-
-def test_log_name(monkeypatch):
-    tstamp = time.strftime(LOGFILE_FILENAME_TIME_FORMAT)
-    assert log_name("example.krun", False) == "example" + "_" + tstamp + ".log"
-    assert log_name(".krun", False) == "_" + tstamp + ".log"
-    def mock_mtime(path):
-        return 1445964109.9363003
-    monkeypatch.setattr(os.path, 'getmtime', mock_mtime)
-    tstamp = '20151027_164149'
-    assert log_name("example.krun", True) == "example" + "_" + tstamp + ".log"
-    assert log_name(".krun", True) == "_" + tstamp + ".log"
+import json
+import pytest
 
 
 def test_fatal(capsys):
@@ -99,7 +50,6 @@ def test_run_shell_cmd_fatal(capsys):
         assert rc != 0
         assert err == cmd + ": command not found"
         assert out == ""
-
 
 
 def test_check_and_parse_execution_results():

--- a/krun/util.py
+++ b/krun/util.py
@@ -58,20 +58,3 @@ def check_and_parse_execution_results(stdout, stderr, rc):
         raise ExecutionFailed(err_s)
 
     return iterations_results
-
-
-def audits_same_platform(audit0, audit1):
-    """Check whether two platform audits are from identical machines.
-    A machine audit is a dictionary with the following keys:
-
-        * cpuinfo (Linux only)
-        * packages (Debian-based systems only)
-        * debian_version (Debian-based systems only)
-        * uname (all platforms)
-        * dmesg (all platforms)
-
-    Platform information may be Unicode.
-    """
-    if ("uname" not in audit0) or ("uname" not in audit1):
-        return False
-    return audit0["uname"] == audit1["uname"]

--- a/krun/util.py
+++ b/krun/util.py
@@ -1,4 +1,3 @@
-import bz2  # decent enough compression with Python 2.7 compatibility.
 import json
 import os.path
 import sys
@@ -91,32 +90,6 @@ def run_shell_cmd(cmd, failure_fatal=True):
     if failure_fatal and rc != 0:
         fatal("Shell command failed: '%s'" % cmd)
     return stdout.strip(), stderr.strip(), rc
-
-
-def dump_results(sched):
-    """Dump results (and a few other bits) into a bzip2 json file."""
-    with open(sched.config_file, "r") as f:
-        config_text = f.read()
-
-    to_write = {
-        "config": config_text,
-        "data": sched.results,
-        "audit": sched.platform.audit,
-        "reboots": sched.nreboots,
-        "starting_temperatures": sched.platform.starting_temperatures,
-        "eta_estimates": sched.eta_estimates,
-        "error_flag": sched.error_flag,
-    }
-
-    with bz2.BZ2File(sched.out_file, "w") as f:
-        f.write(json.dumps(to_write, indent=1, sort_keys=True))
-
-
-def read_results(results_file):
-    results = None
-    with bz2.BZ2File(results_file, "rb") as f:
-        results = json.loads(f.read())
-    return results
 
 
 def check_and_parse_execution_results(stdout, stderr, rc):

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -219,6 +219,9 @@ class BaseVMDef(object):
                   "return code: %s\nstdout:%s\nstderr: %s" %
                   (entry_point.target, rc, stdout, stderr))
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__)
+
 
 class NativeCodeVMDef(BaseVMDef):
     """Not really a "VM definition" at all. Runs native code."""


### PR DESCRIPTION
This PR:

  * Creates three new objects `krun.audit.Audit`, `krun.config.Config`, `krun.results.Results`
  * Simplifies the 'dump' CLI options considerably. 
  * Removes some complex logic from the scheduler, since results from previous executions are loaded directly into `krun.results.Results` objects from disk.
  * Remove `krun.util.audits_same_platform`, since `krun.audit.Audit` objects can now be compared directly with `==`. 
  * `unicode(Audit(...))` is correctly formatted for `--dump-audit`.
  * `ExecutionScheduler` objects now initialise VM definition objects, simplifying the logic in `krun.py` and making it less likely that clients of the library will forget to correctly initialise the objects.
  * `krun.results.Results` objects can serialise themselves on disk, `krun.config.Config` objects can read from config files on disk or from a string.

Fixes #75