### PR TITLE
OpenBSD temperature sensors

### DIFF
--- a/krun/tests/__init__.py
+++ b/krun/tests/__init__.py
@@ -1,5 +1,6 @@
 from krun.tests.mocks import MockPlatform, MockMailer
 from abc import ABCMeta
+from krun.platform import detect_platform
 import pytest
 
 
@@ -11,3 +12,8 @@ class BaseKrunTest(object):
     @pytest.fixture
     def mock_platform(self):
         return MockPlatform(MockMailer())
+
+    @pytest.fixture
+    def platform(self):
+        return detect_platform(MockMailer())
+

--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -4,6 +4,10 @@ from krun.config import Config
 import os
 import pytest
 import time
+from distutils.spawn import find_executable
+
+
+JAVA = find_executable("java")
 
 
 def touch(fname):
@@ -64,7 +68,7 @@ def test_read_corrupt_config_from_string():
             config_string = fp.read()
             config.read_from_string(config_string)
 
-
+@pytest.mark.skipif(JAVA is None, reason="No Java found")
 def test_config_init():
     path = "examples/example.krun"
     config = Config(path)

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -1,5 +1,6 @@
 import pytest
 import krun.platform
+from krun.tests import BaseKrunTest
 import sys
 from StringIO import StringIO
 
@@ -16,12 +17,8 @@ def mk_dummy_kernel_config_fn(options_dct):
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="not linux")
-class TestLinuxPlatform(object):
+class TestLinuxPlatform(BaseKrunTest):
     """Check stuff specific to the Linux in krun.platform"""
-
-    @pytest.fixture
-    def platform(self):
-        return krun.platform.detect_platform(None)
 
     def test_tickless0001(self, monkeypatch, platform):
         """A kernel config indicating full tickless should work"""

--- a/krun/tests/test_openbsdplatform.py
+++ b/krun/tests/test_openbsdplatform.py
@@ -1,0 +1,62 @@
+import pytest
+import krun.platform
+import sys
+from krun.tests import BaseKrunTest
+
+def make_dummy_get_sysctl_temperature_output_fn(sysctl_output):
+    def _get_sysctl_temperature_output(self):
+        return sysctl_output
+    return _get_sysctl_temperature_output
+
+
+@pytest.mark.skipif(not sys.platform.startswith("openbsd"), reason="not OpenBSD")
+class TestOpenBSDPlatform(BaseKrunTest):
+    """Check stuff specific to OpenBSD in krun.platform"""
+
+    def test_read_temperatures0001(self, platform):
+        temps = platform.take_temperature_readings()
+        assert type(temps) is dict
+        assert len(temps) > 0  # likely every system has at least one sensor
+        assert all([x.startswith("hw.sensors.") for x in temps.iterkeys()])
+        # check temperature readings are within reasonable parameters
+        assert all([10 <= v <= 100 for v in temps.itervalues()])
+
+
+    def test_read_broken_temperatures0001(self, monkeypatch, platform, caplog):
+        # Unit is missing (expect degC suffix)
+        broken_sysctl_output = "hw.sensors.some_temp0=10"
+
+        monkey_func = make_dummy_get_sysctl_temperature_output_fn(broken_sysctl_output)
+        monkeypatch.setattr(krun.platform.OpenBSDPlatform,
+                            "_get_sysctl_temperature_output", monkey_func)
+
+        with pytest.raises(SystemExit):
+            platform.take_temperature_readings()
+
+        assert "odd non-degC value" in caplog.text()
+
+    def test_read_broken_temperatures0002(self, monkeypatch, platform, caplog):
+        # value (prior to degC) should be float()able
+        broken_sysctl_output = "hw.sensors.some_temp0=inferno degC"
+
+        monkey_func = make_dummy_get_sysctl_temperature_output_fn(broken_sysctl_output)
+        monkeypatch.setattr(krun.platform.OpenBSDPlatform,
+                            "_get_sysctl_temperature_output", monkey_func)
+
+        with pytest.raises(SystemExit):
+            platform.take_temperature_readings()
+
+        assert "non-numeric value" in caplog.text()
+
+    def test_read_broken_temperatures0003(self, monkeypatch, platform, caplog):
+        # Weird unit (not degC)
+        broken_sysctl_output = "hw.sensors.some_temp0=66 kravits"
+
+        monkey_func = make_dummy_get_sysctl_temperature_output_fn(broken_sysctl_output)
+        monkeypatch.setattr(krun.platform.OpenBSDPlatform,
+                            "_get_sysctl_temperature_output", monkey_func)
+
+        with pytest.raises(SystemExit):
+            platform.take_temperature_readings()
+
+        assert "odd non-degC value" in caplog.text()


### PR DESCRIPTION
This implements support for temperature sensor reading on OpenBSD. Tested by using the example and spinning up CPU eating tasks. Seems it works great:

```
...
[2015-11-18 15:04:48 INFO] Intermediate results dumped to example_results.json.bz2
[2015-11-18 15:04:49 DEBUG] Temp poll 1/60
[2015-11-18 15:04:49 DEBUG] start temperatures: {'hw.sensors.cpu0.temp0': 53.0, 'hw.sensors.acpitz0.temp0': 50.0}
[2015-11-18 15:04:49 DEBUG] temp thresholds: {'hw.sensors.cpu0.temp0': 58, 'hw.sensors.acpitz0.temp0': 55}
[2015-11-18 15:04:49 DEBUG] temp reading: {'hw.sensors.cpu0.temp0': 66.0, 'hw.sensors.acpitz0.temp0': 51.0}
[2015-11-18 15:04:49 INFO] System is running hot.
[2015-11-18 15:04:49 INFO] Temperature reading 'hw.sensors.cpu0.temp0' started at 53 but is now 66. Needs to cool to within 10% (58)
[2015-11-18 15:04:49 INFO] Waiting to cool
[2015-11-18 15:04:59 DEBUG] Temp poll 2/60
[2015-11-18 15:04:59 DEBUG] start temperatures: {'hw.sensors.cpu0.temp0': 53.0, 'hw.sensors.acpitz0.temp0': 50.0}
[2015-11-18 15:04:59 DEBUG] temp thresholds: {'hw.sensors.cpu0.temp0': 58, 'hw.sensors.acpitz0.temp0': 55}
[2015-11-18 15:04:59 DEBUG] temp reading: {'hw.sensors.cpu0.temp0': 55.0, 'hw.sensors.acpitz0.temp0': 65.0}
[2015-11-18 15:05:09 DEBUG] Temp poll 3/60
[2015-11-18 15:05:09 DEBUG] start temperatures: {'hw.sensors.cpu0.temp0': 53.0, 'hw.sensors.acpitz0.temp0': 50.0}
[2015-11-18 15:05:09 DEBUG] temp thresholds: {'hw.sensors.cpu0.temp0': 58, 'hw.sensors.acpitz0.temp0': 55}
[2015-11-18 15:05:09 DEBUG] temp reading: {'hw.sensors.cpu0.temp0': 53.0, 'hw.sensors.acpitz0.temp0': 51.0}
[2015-11-18 15:05:09 INFO] 3 jobs left in scheduler queue
[2015-11-18 15:05:09 INFO] Estimated completion     : ????-??-?? ??:??:?? (?:??:?? from now)
...
```

Also a few test tweaks.

OK?