### PR TITLE
Add -a to uname in the platform audit.

### DIFF
--- a/krun/platform.py
+++ b/krun/platform.py
@@ -183,7 +183,7 @@ class BasePlatform(object):
 
     # And you may want to extend this
     def collect_audit(self):
-        self.audit["uname"] = run_shell_cmd("uname")[0]
+        self.audit["uname"] = run_shell_cmd("uname -a")[0]
         self.audit["dmesg"] = run_shell_cmd("dmesg")[0]
 
     def bench_cmdline_adjust(self, args, env_dct):


### PR DESCRIPTION
Add -a to uname in the platform audit.

E.g.:

```
"uname": "OpenBSD wilfred.dlink.com 5.8 GENERIC.MP#1733 amd64"
```