### PR TITLE
Attempt to limit the heap using a wrapper script.

### DIFF
--- a/krun/platform.py
+++ b/krun/platform.py
@@ -16,7 +16,6 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from krun.env import EnvChangeSet, EnvChange, EnvChangeAppend
 
 NICE_PRIORITY = -20
-BENCHMARK_USER = "krun"  # user is expected to have made this
 DIR = os.path.abspath(os.path.dirname(__file__))
 LIBKRUNTIME_DIR = os.path.join(DIR, "..", "libkruntime")
 
@@ -190,18 +189,19 @@ class BasePlatform(object):
         """Prepends various arguments to benchmark invocation.
 
         Currently deals with:
-          * Changing user
           * CPU pinning (if available)
           * Adding libkruntime to linker path
-          * Process priority"""
+          * Process priority
+
+        It does not deal with changing user, as this is done one
+        level up in the wrapper script."""
 
         # platform specific env changes to apply (if any)
         combine_env = env_dct.copy()
         changes = self.bench_env_changes()
         EnvChange.apply_all(changes, combine_env)
 
-        return self.change_user_args(BENCHMARK_USER) + \
-            self.process_priority_args() + self.isolate_process_args() + \
+        return self.process_priority_args() + self.isolate_process_args() + \
             self.adjust_env_cmd(combine_env) + args
 
     @abstractmethod

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -88,7 +88,7 @@ class TestLinuxPlatform(BaseKrunTest):
             krun.platform.LinuxPlatform._check_tickless_kernel(platform)
 
     def test_bench_cmdline_adjust0001(self, platform):
-        expect = ['sudo', '-u', 'krun', 'nice', '-20', 'taskset', '0x8',
+        expect = ['nice', '-20', 'taskset', '0x8',
                   'env', 'LD_LIBRARY_PATH=']
 
         platform.isolated_cpu = 3
@@ -97,7 +97,7 @@ class TestLinuxPlatform(BaseKrunTest):
         assert args == expect
 
     def test_bench_cmdline_adjust0002(self, platform):
-        expect = ['sudo', '-u', 'krun', 'nice', '-20', 'taskset', '0x8',
+        expect = ['nice', '-20', 'taskset', '0x8',
                   'env', 'MYENV=some_value', 'LD_LIBRARY_PATH=', 'myarg']
 
         platform.isolated_cpu = 3

--- a/krun/tests/test_openbsdplatform.py
+++ b/krun/tests/test_openbsdplatform.py
@@ -103,15 +103,14 @@ class TestOpenBSDPlatform(BaseKrunTest):
         # Would have been "manual" if we were still in "high-performance" mode.
 
     def test_bench_cmdline_adjust0001(self, platform):
-        expect = ['doas', '-u', 'krun', 'nice', '-20', 'env',
+        expect = ['nice', '-20', 'env',
                   'LD_LIBRARY_PATH=', 'MALLOC_OPTIONS=sfghjpru']
 
         args = subst_env_arg(platform.bench_cmdline_adjust([], {}), "LD_LIBRARY_PATH")
         assert args == expect
 
     def test_bench_cmdline_adjust0002(self, platform):
-        expect = ['doas', '-u', 'krun', 'nice', '-20', 'env',
-                  'MYENV=some_value',
+        expect = ['nice', '-20', 'env', 'MYENV=some_value',
                   'LD_LIBRARY_PATH=', 'MALLOC_OPTIONS=sfghjpru', 'myarg']
 
         args = subst_env_arg(platform.bench_cmdline_adjust(

--- a/krun/tests/test_vmdef.py
+++ b/krun/tests/test_vmdef.py
@@ -1,0 +1,23 @@
+import pytest
+from krun.vm_defs import BaseVMDef
+from distutils.spawn import find_executable
+
+class TestVMDef(object):
+    """Test stuff in VM definitions"""
+
+    def test_make_wrapper_script0001(self):
+        args = ["arg1", "arg2", "arg3"]
+        heap_lim_k = 1024 * 1024 * 1024  # 1GB
+        dash = find_executable("dash")
+        assert dash is not None
+
+        expect = [
+            '#!%s' % dash,
+            'ulimit -d 1073741824 || exit $?',
+            'arg1 arg2 arg3',
+            'exit $?'
+        ]
+
+        got = BaseVMDef.make_wrapper_script(args, heap_lim_k)
+        assert expect == got
+

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -10,10 +10,12 @@ from krun import EntryPoint
 from krun.util import fatal, spawn_sanity_check, VM_SANITY_CHECKS_DIR
 from krun.env import EnvChangeAppend, EnvChangeSet, EnvChange
 from krun.util import SANITY_CHECK_HEAP_KB
+from distutils.spawn import find_executable
 
 DIR = os.path.abspath(os.path.dirname(__file__))
 ITERATIONS_RUNNER_DIR = os.path.abspath(os.path.join(DIR, "..", "iterations_runners"))
 BENCHMARKS_DIR = os.path.abspath(os.path.join(os.getcwd(), "benchmarks"))
+BENCHMARK_USER = "krun"  # user is expected to have made this
 
 # Pipe buffer sizes vary. I've seen reports on the Internet ranging from a
 # page size (Linux pre-2.6.11) to 64K (Linux in 2015). Ideally we would
@@ -26,6 +28,10 @@ PIPE_BUF_SZ = 1024 * 16
 
 SELECT_TIMEOUT = 1.0
 
+WRAPPER_SCRIPT = os.sep + os.path.join("tmp", "krun_wrapper.dash")
+DASH = find_executable("dash")
+if DASH is None:
+    fatal("dash shell not found")
 
 # !!!
 # Don't mutate any lists passed down from the user's config file!
@@ -97,6 +103,19 @@ class BaseVMDef(object):
                  force_dir=None):
         pass
 
+    @staticmethod
+    def make_wrapper_script(args, heap_lim_k):
+        """Make lines for the wrapper script.
+        Separate for testing purposes"""
+
+        return [
+            "#!%s" % DASH,
+            "ulimit -d %s || exit $?" % heap_lim_k,
+            # XXX stack limit
+            " ".join(args),
+            "exit $?",
+        ]
+
     def _run_exec(self, args, heap_lim_k, bench_env_changes=None):
         """ Deals with actually shelling out """
 
@@ -114,24 +133,38 @@ class BaseVMDef(object):
         EnvChange.apply_all(bench_env_changes, new_user_env)
 
         # Apply platform specific argument transformations.
-        actual_args = self.platform.bench_cmdline_adjust(args, new_user_env)
-
-        debug("cmdline='%s'" % " ".join(actual_args))
+        args = self.platform.bench_cmdline_adjust(args, new_user_env)
 
         if self.dry_run:
             info("Dry run. Skipping.")
             return ("", "", 0)
+
+        # We write out a wrapper script whose job is to enforce ulimits
+        # before executing the VM.
+        debug("Writing out wrapper script to %s" % WRAPPER_SCRIPT)
+        lines = BaseVMDef.make_wrapper_script(args, heap_lim_k)
+        with open(WRAPPER_SCRIPT, "w") as fh:
+            for line in lines:
+                fh.write(line + "\n")
+
+        debug("Wrapper script:\n%s" % ("\n".join(lines)))
+
+        wrapper_args = self.platform.change_user_args(BENCHMARK_USER) + \
+            [DASH, WRAPPER_SCRIPT]
 
         # We pass the empty environment dict here.
         # This is the *outer* environment that the current user will invoke the
         # command with. Command line arguments will have been appended *inside*
         # to adjust the new user's environment once the user switch has
         # occurred.
+        debug("Execute wrapper: %s" % (" ".join(wrapper_args)))
         p = subprocess.Popen(
-            actual_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            wrapper_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             env={})
 
-        return self._run_exec_capture(p)
+        rv = self._run_exec_capture(p)
+        os.unlink(WRAPPER_SCRIPT)
+        return rv
 
     def _run_exec_capture(self, child_pipe):
         """Allows the subprocess (whose pipes we have handles on) to run


### PR DESCRIPTION
Basically addresses #133. As discussed in person with @snim2 and @ltratt, Linux is very slack about honoring the heap limit, and there is little we can do about it. We simply impose the ulimit and that's all we can do.

Snippet from krun debug log demonstrates how the wrapper script works (e.g. for a Java benchmark on OpenBSD):

```
[2015-12-17 15:03:18 DEBUG] Writing out wrapper script to /tmp/krun_wrapper.dash
[2015-12-17 15:03:18 DEBUG] Wrapper script:
#!/usr/local/bin/dash
ulimit -d 2097152 || exit $?
nice -20 env CLASSPATH=/home/vext01/research/warmup_experiment/krun/iterations_runners:/home/vext01/research/wa
rmup_experiment/benchmarks/spectralnorm/java LD_LIBRARY_PATH=/home/vext01/research/warmup_experiment/krun/krun/
../libkruntime MALLOC_OPTIONS=sfghjpru /home/vext01/research/warmup_experiment/work/openjdk/build/bsd-x86_64-no
rmal-server-release/images/j2sdk-image/bin/java IterationsRunner KrunEntry 1 3
exit $?
[2015-12-17 15:03:18 DEBUG] Execute wrapper: doas -u krun /usr/local/bin/dash /tmp/krun_wrapper.dash
```

Looks good?

If so, we just need to do the same with the stack.