### PR TITLE
Tweak clean targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,4 @@ clean:
 	cd iterations_runners && ${MAKE} clean
 	cd libkruntime && ${MAKE} clean
 	cd vm_sanity_checks && ${MAKE} clean
+	cd platform_sanity_checks && ${MAKE} clean

--- a/iterations_runners/Makefile
+++ b/iterations_runners/Makefile
@@ -24,5 +24,5 @@ iterations_runner_c: iterations_runner.c
 		${LDFLAGS}
 
 clean:
-	-rm BaseKrunEntry.class IterationsRunner.class
-	-rm iterations_runner_c
+	rm -f BaseKrunEntry.class IterationsRunner.class
+	rm -f iterations_runner_c

--- a/libkruntime/Makefile
+++ b/libkruntime/Makefile
@@ -14,4 +14,4 @@ libkruntime.so: libkruntime.c
 		-o libkruntime.so
 
 clean:
-	-rm libkruntime.so
+	rm -f libkruntime.so

--- a/platform_sanity_checks/Makefile
+++ b/platform_sanity_checks/Makefile
@@ -11,4 +11,4 @@ check_openbsd_malloc_options: check_openbsd_malloc_options.c
 		; fi
 
 clean:
-	-rm check_openbsd_malloc_options
+	rm -f check_openbsd_malloc_options


### PR DESCRIPTION
 * Clean in platform_sanity_checks
 * Use `rm -f` instead of `-rm`. Less noise if already cleaned.

OK?