### PR TITLE
Use rm -f instead of -rm.

### DIFF
--- a/vm_sanity_checks/Makefile
+++ b/vm_sanity_checks/Makefile
@@ -9,4 +9,4 @@ JavaCheckJVMCIServerEnabled.class: JavaCheckJVMCIServerEnabled.java
 	fi
 
 clean:
-	-rm *.class
+	rm -f *.class


### PR DESCRIPTION
One more clean tweak in krun that I missed in the last PR.

OK?