### PR TITLE
Remove CPU pinning support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ If you are using a Linux system, you will need to set some kernel arguments.
 If your Linux bootloader is Grub, you can follow these steps:
 
   * Edit /etc/default/grub (e.g. `sudo gedit /etc/default/grub`)
-  * Add `isolcpus=X` to `GRUB_CMDLINE_LINUX_DEFAULT` (where `X` is an integer > 0)
   * Add `intel_pstate=disable` to `GRUB_CMDLINE_LINUX_DEFAULT`
   * Run `sudo update-grub`
 
@@ -306,7 +305,6 @@ will cause Krun to run with the following modifications:
   * Krun will not run the system prerequisite checks. Checks relating to CPU
     governers,  CPU scalers, CPU temperatures, tickless kernel, etc.
   * Krun will not attempt to switch user to run benchmarks.
-  * Krun will not force the benchmark on to an isolated core.
 
 This makes it easier to develop krun on (e.g.) a personal laptop which has not
 been prepared for reliable benchmarking.

--- a/krun.py
+++ b/krun.py
@@ -215,7 +215,7 @@ def main(parser):
         platform.check_preliminaries()
     else:
         # Needed to skip the use of certain tools and techniques.
-        # E.g. taskset on Linux, and switching user.
+        # E.g. switching user.
         warn("Not checking platform prerequisites due to developer mode")
         platform.developer_mode = True
 

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -59,9 +59,6 @@ class MockPlatform(BasePlatform):
     def change_user_args(self, user="root"):
         return "sudo"
 
-    def isolate_process_args(self):
-        pass
-
     def process_priority_args(self):
         return []
 
@@ -69,9 +66,6 @@ class MockPlatform(BasePlatform):
         return ""
 
     def _change_user_args(self):
-        return []
-
-    def _isolate_process_args(self):
         return []
 
     def _save_power(self):

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -88,19 +88,14 @@ class TestLinuxPlatform(BaseKrunTest):
             krun.platform.LinuxPlatform._check_tickless_kernel(platform)
 
     def test_bench_cmdline_adjust0001(self, platform):
-        expect = ['nice', '-20', 'taskset', '0x8',
-                  'env', 'LD_LIBRARY_PATH=']
-
-        platform.isolated_cpu = 3
+        expect = ['nice', '-20', 'env', 'LD_LIBRARY_PATH=']
 
         args = subst_env_arg(platform.bench_cmdline_adjust([], {}), "LD_LIBRARY_PATH")
         assert args == expect
 
     def test_bench_cmdline_adjust0002(self, platform):
-        expect = ['nice', '-20', 'taskset', '0x8',
-                  'env', 'MYENV=some_value', 'LD_LIBRARY_PATH=', 'myarg']
-
-        platform.isolated_cpu = 3
+        expect = ['nice', '-20', 'env', 'MYENV=some_value',
+                  'LD_LIBRARY_PATH=', 'myarg']
 
         args = subst_env_arg(platform.bench_cmdline_adjust(
             ["myarg"], {"MYENV": "some_value"}), "LD_LIBRARY_PATH")


### PR DESCRIPTION
CPU pinning seemed like a good idea, but in reality it negatively
impacts VMs which use separate threads (or processes)for (e.g.)
compilation.

When the VMs create such threads these children inherit the CPU affinity
(the CPUs on which they can run) from the parent. The result is that we
create artificial CPU contention, thus slowing the VM down.

We found that the initial iterations of some JRubyTruffle benchmarks
were impacted by a >2x slowdown.