### PR TITLE
Fix Config.should_skip().

### DIFF
--- a/krun/config.py
+++ b/krun/config.py
@@ -74,6 +74,8 @@ class Config(object):
         return self.filename[:-5] + "_results.json.bz2"
 
     def should_skip(self, this_key):
+        """Decides if 'this_key' is a benchmark key that will be skipped"""
+
         this_elems = this_key.split(":")
         if len(this_elems) != 3:
             raise ValueError("bad benchmark key: %s" % this_key)
@@ -84,11 +86,14 @@ class Config(object):
             # Should be triples of: bench * vm * variant
             assert len(skip_elems) == 3 and len(this_elems) == 3
 
+            # Don't mutate this_elems directly, as we need it
+            # fresh for future iterations.
+            this_elems_copy = this_elems[:]
             for i in range(3):
                 if skip_elems[i] == "*":
-                    this_elems[i] = "*"
+                    this_elems_copy[i] = "*"
 
-            if skip_elems == this_elems:
+            if skip_elems == this_elems_copy:
                 return True # skip
 
         return False

--- a/krun/tests/__init__.py
+++ b/krun/tests/__init__.py
@@ -2,6 +2,10 @@ from krun.tests.mocks import MockPlatform, MockMailer
 from abc import ABCMeta
 from krun.platform import detect_platform
 import pytest
+import os
+
+
+TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 def subst_env_arg(lst, var):

--- a/krun/tests/more_complicated.krun
+++ b/krun/tests/more_complicated.krun
@@ -1,0 +1,95 @@
+import os
+import sys
+from krun.vm_defs import (PythonVMDef, LuaVMDef, JavaVMDef, GraalVMDef,
+		          PHPVMDef, JRubyTruffleVMDef, V8VMDef, NativeCodeVMDef,
+			  find_internal_jvmci_java_bin, PyPyVMDef)
+from krun import EntryPoint
+
+MAIL_TO = []
+MAX_MAILS = 2
+
+JDK8_HOME = "dummy"
+JDK8_BIN = os.path.join(JDK8_HOME, "bin", "java")
+
+HEAP_LIMIT = 2097152  # K == 2Gb
+STACK_LIMIT = 8192  # K
+
+VARIANTS = {
+    "default-c": EntryPoint("bench.so", subdir="c"),
+    "default-java": EntryPoint("KrunEntry", subdir="java"),
+    "default-lua": EntryPoint("bench.lua", subdir="lua"),
+    "default-python": EntryPoint("bench.py", subdir="python"),
+    "default-php": EntryPoint("bench.php", subdir="php"),
+    "default-ruby": EntryPoint("bench.rb", subdir="ruby"),
+    "default-javascript": EntryPoint("bench.js", subdir="javascript"),
+}
+
+ITERATIONS_ALL_VMS = 2000
+
+VMS = {
+    'C': {
+        'vm_def': NativeCodeVMDef(),
+        'variants': ['default-c'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+
+    },
+	'PyPy': {
+		'vm_def': PyPyVMDef('work/pypy/pypy/goal/pypy-c'),
+		'variants': ['default-python'],
+		'n_iterations': ITERATIONS_ALL_VMS,
+	},
+	'Hotspot': {
+		'vm_def': JavaVMDef(JDK8_BIN),
+		'variants': ['default-java'],
+		'n_iterations': ITERATIONS_ALL_VMS,
+	},
+	'LuaJIT': {
+		'vm_def': LuaVMDef('work/luajit/src/luajit'),
+		'variants': ['default-lua'],
+		'n_iterations': ITERATIONS_ALL_VMS,
+	},
+	'V8': {
+		'vm_def': V8VMDef('work/v8/out/native/d8'),
+		'variants': ['default-javascript'],
+		'n_iterations': ITERATIONS_ALL_VMS,
+	},
+	'CPython': {
+		'vm_def': PythonVMDef('work/cpython-inst/bin/python'),
+		'variants': ['default-python'],
+		'n_iterations': ITERATIONS_ALL_VMS,
+	},
+    'Graal': {
+        'vm_def': "dummy",
+        'variants': ['default-java'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+    'HHVM': {
+        'vm_def': PHPVMDef('work/hhvm/hphp/hhvm/php'),
+        'variants': ['default-php'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+    'JRubyTruffle' : {
+        'vm_def': JRubyTruffleVMDef('work/jruby/bin/jruby', java_path="dummy"),
+        'variants': ['default-ruby'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+}
+
+
+BENCHMARKS = {
+    'binarytrees': 25,
+    'richards': 500,
+    'spectralnorm': 3,
+    'nbody': 15,
+    'fasta': 100,
+    'fannkuch_redux': 200,
+}
+
+SKIP= [
+    "fasta:JRubyTruffle:default-ruby",
+    "richards:HHVM:default-php",
+    "spectralnorm:JRubyTruffle:default-ruby",
+    "*:CPython:*",
+]
+
+N_EXECUTIONS = 2

--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -164,3 +164,44 @@ def test_skip0007():
         config.should_skip("wobble")
 
     assert e.value.message == "bad benchmark key: wobble"
+
+def test_skip0008():
+    config = Config()
+    config.SKIP = ["*:SomeVM:*", "fasta:JRubyTruffle:default-ruby"]
+
+    assert config.should_skip("fasta:JRubyTruffle:default-ruby")
+
+def test_skip0009():
+    config = Config()
+    config.SKIP = ["*:SomeVM:*",
+                   "fasta:JRubyTruffle:default-ruby",
+                   "bench:*:*",
+                   "bench:vm:skipvariant",
+                   "*:*:skipvariant",
+                   ]
+
+    assert config.should_skip("fasta:JRubyTruffle:default-ruby")
+    assert not config.should_skip("fasta:JRubyTruffle:default-ruby2")
+    assert config.should_skip("bench:lala:hihi")
+    assert config.should_skip("bench:lala:hihi2")
+    assert not config.should_skip("bench1:lala:hihi")
+    assert config.should_skip("bench1:lala:skipvariant")
+    assert config.should_skip("bench1:lala2:skipvariant")
+
+def test_skip0010():
+    config = Config()
+    config.SKIP = ["*:SomeVM:*",
+                   "fasta:JRubyTruffle:default-ruby",
+                   "bench:*:*",
+                   "bench:vm:skipvariant",
+                   "*:*:skipvariant",
+                   "*:*:*",  # everything should be skipped due to this
+                   ]
+
+    import uuid
+    def rand_str():
+        return uuid.uuid4().hex
+
+    for i in xrange(25):
+        key = "%s:%s:%s" % tuple([rand_str() for x in xrange(3)])
+        assert config.should_skip(key)

--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -8,7 +8,7 @@ from distutils.spawn import find_executable
 
 
 JAVA = find_executable("java")
-TEST_DIR = os.path.abspath(os.path.dirname(__file__))
+from krun.tests import TEST_DIR
 
 def touch(fname):
     with open(fname, 'a'):

--- a/krun/tests/test_scheduler.py
+++ b/krun/tests/test_scheduler.py
@@ -24,7 +24,7 @@ class TestScheduler(BaseKrunTest):
 
 
     def test_add_del_job(self, mock_platform):
-        sched = ExecutionScheduler(Config("krun/tests/example.krun"),
+        sched = ExecutionScheduler(Config(os.path.join(TEST_DIR, "example.krun")),
                                    mock_platform.mailer,
                                    mock_platform, resume=False,
                                    reboot=True, dry_run=False,
@@ -40,7 +40,7 @@ class TestScheduler(BaseKrunTest):
 
 
     def test_build_schedule(self, mock_platform):
-        sched = ExecutionScheduler(Config("krun/tests/example.krun"),
+        sched = ExecutionScheduler(Config(os.path.join(TEST_DIR, "example.krun")),
                                    mock_platform.mailer,
                                    mock_platform, resume=False,
                                    reboot=True, dry_run=True,
@@ -60,7 +60,7 @@ class TestScheduler(BaseKrunTest):
 
 
     def test_part_complete_schedule(self, mock_platform):
-        sched = ExecutionScheduler(Config("krun/tests/quick.krun"),
+        sched = ExecutionScheduler(Config(os.path.join(TEST_DIR, "quick.krun")),
                                    mock_platform.mailer,
                                    mock_platform, resume=True,
                                    reboot=True, dry_run=True,
@@ -72,7 +72,7 @@ class TestScheduler(BaseKrunTest):
     def test_etas_dont_agree_with_schedule(self, mock_platform):
         """ETAs don't exist for all jobs for which there is iterations data"""
 
-        sched = ExecutionScheduler(Config("krun/tests/broken_etas.krun"),
+        sched = ExecutionScheduler(Config(os.path.join(TEST_DIR, "broken_etas.krun")),
                                    mock_platform.mailer, mock_platform,
                                    resume=True, reboot=False, dry_run=True,
                                    started_by_init=False)
@@ -85,12 +85,12 @@ class TestScheduler(BaseKrunTest):
 
 
     def test_run_schedule(self, monkeypatch, mock_platform):
-        json_file = "krun/tests/example_results.json.bz2"
+        json_file = os.path.join(TEST_DIR, "example_results.json.bz2")
         def dummy_shell_cmd(text):
             pass
         monkeypatch.setattr(subprocess, 'call', dummy_shell_cmd)
         monkeypatch.setattr(krun.util, 'run_shell_cmd', dummy_shell_cmd)
-        config = Config("krun/tests/example.krun")
+        config = Config(os.path.join(TEST_DIR, "example.krun"))
         krun.util.assign_platform(config, mock_platform)
         sched = ExecutionScheduler(config,
                                    mock_platform.mailer,
@@ -102,7 +102,7 @@ class TestScheduler(BaseKrunTest):
         sched.run()
         assert len(sched) == 0
 
-        results = Results(Config("krun/tests/example.krun"),
+        results = Results(Config(os.path.join(TEST_DIR, "example.krun")),
                           mock_platform, results_file=json_file)
 
         for k, execs in results.data.iteritems():
@@ -132,7 +132,7 @@ class TestScheduler(BaseKrunTest):
         monkeypatch.setattr(os, "execv", dummy_execv)
         monkeypatch.setattr(subprocess, "call", dummy_shell_cmd)
         monkeypatch.setattr(krun.util, "run_shell_cmd", dummy_shell_cmd)
-        config = Config("krun/tests/example.krun")
+        config = Config(os.path.join(TEST_DIR, "example.krun"))
         krun.util.assign_platform(config, mock_platform)
         sched = ExecutionScheduler(config,
                                    mock_platform.mailer,
@@ -144,7 +144,7 @@ class TestScheduler(BaseKrunTest):
         with pytest.raises(AssertionError):
             sched.run()
         assert len(sched) == 7
-        os.unlink("krun/tests/example_results.json.bz2")
+        os.unlink(os.path.join(TEST_DIR, "example_results.json.bz2"))
 
     def test_queue_len0001(self, mock_platform):
         config_path = os.path.join(TEST_DIR, "more_complicated.krun")

--- a/krun/tests/test_scheduler.py
+++ b/krun/tests/test_scheduler.py
@@ -6,7 +6,7 @@ from krun.tests import BaseKrunTest
 import krun.util
 
 import os, pytest, subprocess
-
+from krun.tests import TEST_DIR
 
 class TestScheduler(BaseKrunTest):
     """Test the job scheduler."""
@@ -145,3 +145,13 @@ class TestScheduler(BaseKrunTest):
             sched.run()
         assert len(sched) == 7
         os.unlink("krun/tests/example_results.json.bz2")
+
+    def test_queue_len0001(self, mock_platform):
+        config_path = os.path.join(TEST_DIR, "more_complicated.krun")
+        sched = ExecutionScheduler(Config(config_path),
+                                   mock_platform.mailer,
+                                   mock_platform, resume=False,
+                                   reboot=True, dry_run=False,
+                                   started_by_init=False)
+        sched.build_schedule()
+        assert len(sched) == 90  # tking into account skips


### PR DESCRIPTION
If a star appeared in SKIP in the config file, it screws up
should_skip() for later elemets in SKIP.

Did not affect our full experiment by pure chance.

Threw in some more test cases for good measure.

Please don't merge just yet. Want to double check something.