### PR TITLE
Pause before taking initial temperature readings.

### DIFF
--- a/examples/example.krun
+++ b/examples/example.krun
@@ -59,3 +59,8 @@ SKIP=[
 ]
 
 N_EXECUTIONS = 2  # Number of fresh processes.
+
+# No. of seconds to wait before taking the initial temperature reading.
+# You should set this high enough for the system to cool down a bit.
+# The default (if omitted) is 60 seconds.
+TEMP_READ_PAUSE = 1

--- a/krun.py
+++ b/krun.py
@@ -9,6 +9,7 @@ usage: runner.py <config_file.krun>
 import argparse, json, logging, os, sys
 from logging import debug, info, warn
 import locale
+import time
 
 import krun.util as util
 from krun.config import Config
@@ -245,6 +246,16 @@ def main(parser):
         _, _, rc = util.run_shell_cmd("touch " + args.filename)
         if rc != 0:
             util.fatal("Could not touch config file: " + args.filename)
+
+
+        info(("Wait %s secs to allow system to cool prior to "
+             "collecting initial temperature readings") %
+             config.TEMP_READ_PAUSE)
+
+        if args.develop or args.dry_run:
+            info("SIMULATED: time.sleep(%s)" % config.TEMP_READ_PAUSE)
+        else:
+            time.sleep(config.TEMP_READ_PAUSE)
 
         debug("Taking fresh initial temperature readings")
         platform.starting_temperatures = platform.take_temperature_readings()

--- a/krun/config.py
+++ b/krun/config.py
@@ -26,6 +26,7 @@ class Config(object):
         self.filename = config_file
         self.HEAP_LIMIT = None
         self.STACK_LIMIT = None
+        self.TEMP_READ_PAUSE = 60
 
         if config_file is not None:
             self.read_from_file(config_file)

--- a/krun/tests/example.krun
+++ b/krun/tests/example.krun
@@ -48,3 +48,5 @@ SKIP=[
 ]
 
 N_EXECUTIONS = 2  # Number of fresh processes.
+
+TEMP_READ_PAUSE = 1

--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -205,3 +205,11 @@ def test_skip0010():
     for i in xrange(25):
         key = "%s:%s:%s" % tuple([rand_str() for x in xrange(3)])
         assert config.should_skip(key)
+
+def test_temp_read_pause0001():
+    config = Config()
+    assert config.TEMP_READ_PAUSE == 60  # default
+
+def test_temp_read_pause0002():
+    config = Config(os.path.join(TEST_DIR, "example.krun"))
+    assert config.TEMP_READ_PAUSE == 1


### PR DESCRIPTION
The idea is to allow the system to cool down before the initial temperature readings are taken. Configurable via config file, but defaults to 20 seconds.

OK?