### PR TITLE
Check for CONFIG_NO_HZ_FULL_AUTO tickless kernel without overrides.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ python:
   - "2.7"
 
 install:
-  - pip install cffi
-  - pip install pytest-cov
-  - pip install pytest-capturelog
+  - pip install -r requirements.txt
 
 script: py.test --cov-report term --cov=krun  krun

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+cffi==1.5.0
+coverage==4.0.3
+py==1.4.31
+pycparser==2.14
+pytest==2.8.5
+pytest-capturelog==0.7
+pytest-cov==2.2.0


### PR DESCRIPTION
This properly checks for a tickless kernel (with all CPUs in adaptive-tick mode apart from the boot CPU, since at-least one CPU must not be adaptive-tick).

Our prior tickless check was not correct -- we had enabled tickless functionality, but not enabled it on any CPUs.

Also added a frozen requirements.txt.

OK?