### PR TITLE
Implement --info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The example here contains two benchmark programs (*nbody* and *dummy*),
 executed on two VMs (*cPython* and a standard *JVM* such as HotSpot).
 Each benchmark is run for 5 iterations on the same VM, then the VM is
 restarted and the benchmark is re-run for another 5 iterations.
-We say that the experiment runs 2 *executions* and 5 *iterations* of
+We say that the experiment runs 2 *process executions* and 5 *in-process iterations* of
 each benchmark.
 
 This configuration can be found in the file `examples/example.krun`.
@@ -123,7 +123,7 @@ You should see a log scroll past, and results will be stored in the file:
 
 ## Using a Krun results file
 
-Krun generates a bzipped JSON file containing results of all executions.
+Krun generates a bzipped JSON file containing results of all process executions.
 The structure of the JSON results is as follows:
 
 ```python
@@ -131,8 +131,8 @@ The structure of the JSON results is as follows:
     'audit': '',  # A dict containing platform information
     'config': '', # A unicode object containing your Krun configuration
     'data': {     # A dict object containing timing results
-        u'bmark:VM:variant': [  # A list of lists of timing results
-            [ ... ], ...        # One list per execution
+        u'bmark:VM:variant': [  # A list of lists of in-process iteration times
+            [ ... ], ...        # One list per process execution
         ]
     },
     'reboots': N, # An int containing the number of reboots that have
@@ -141,14 +141,14 @@ The structure of the JSON results is as follows:
                   # benchmarking machine has rebooted the correct number
                   # of times. It can be safely ignored by users.
     'starting_temperatures': [ ... ], # Temperatures recorded at the beginning
-                  # of the experiment. Used before each execution to decide if
+                  # of the experiment. Used before each process execution to decide if
                   # the system is running much hotter than before. In this
                   # case we wait to allow the system to cool. The ordering
                   # and meanings of the temperatures in the list are platform
                   # and system specific. This information can be safely
                   # ignored by users.
     'eta_estimates': {u"bmark:VM:variant": [t_0, t_1, ...], ...} # A dict mapping
-                  # benchmark keys to rough execution times. Used internally,
+                  # benchmark keys to rough process execution times. Used internally,
                   # users can ignore this.
 }
 ```
@@ -210,19 +210,23 @@ printed to STDOUT.
 Valid debug levels are: `DEBUG`, `INFO`, `WARN`, `DEBUG`,
 `CRITICAL`, `ERROR`.
 
+The `--info` switch reports the total number of process executions and
+in-process iterations that would be run using the specified config file. It
+also prints the benchmark keys which would be skipped.
+
 ## Running in reboot and resume modes
 
 Krun can resume an interrupted benchmark by passing in the `--resume`
 flag.
-This will read and re-use results from previous executions of your
-benchmarks, and run the remaining executions detailed in your configuration
+This will read and re-use results from previous process executions of your
+benchmarks, and run the remaining process executions detailed in your configuration
 file.
 
 ```bash
 $ PYTHONPATH=../ ../krun.py --resume example.krun
 ```
 
-You may wish to use this facility to reboot after every execution.
+You may wish to use this facility to reboot after every process execution.
 To do this, you can pass in the `--reboot` flag when you start Krun:
 
 ```bash

--- a/krun.py
+++ b/krun.py
@@ -130,6 +130,9 @@ def create_arg_parser():
     parser.add_argument("--develop", action="store_true",
                         dest="develop", required=False,
                         help=("Enable developer mode"))
+    parser.add_argument("--info", action="store_true",
+                        help=("Print session info for specified "
+                              "config file and exit")),
     filename_help = ("Krun configuration or results file. FILENAME should" +
                      " be a configuration file when running benchmarks " +
                      "(e.g. experiment.krun) and a results file " +
@@ -175,6 +178,13 @@ def main(parser):
         util.fatal('Krun configuration file %s does not exist.' % args.filename)
 
     config = Config(args.filename)
+
+    if args.info:
+        # Info mode doesn't run the experiment.
+        # Just prints some metrics and exits.
+        util.print_session_info(config)
+        return
+
     attach_log_file(config, args.resume)
 
     out_file = config.results_filename()

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -179,6 +179,12 @@ class ExecutionScheduler(object):
         self.results.eta_estimates[key].append(exec_time)
 
     def build_schedule(self):
+        """Builds a queue of process execution jobs.
+
+        Returns a set of keys which were skipped."""
+
+        skipped = set()
+
         one_exec_scheduled = False
         eta_avail_job = None
         for exec_n in xrange(self.config.N_EXECUTIONS):
@@ -193,6 +199,7 @@ class ExecutionScheduler(object):
                                 self.set_eta_avail()
                             self.add_job(job)
                         else:
+                            skipped |= set([job.key])
                             if not one_exec_scheduled:
                                 debug("%s is in skip list. Not scheduling." %
                                       job.key)
@@ -217,6 +224,7 @@ class ExecutionScheduler(object):
                     util.log_and_mail(self.mailer, error,
                                       "Fatal Krun Error",
                                       msg, bypass_limiter=True, exit=True)
+        return skipped
 
     def _remove_previous_execs_from_schedule(self):
         for key in self.results.data:


### PR DESCRIPTION
In the warmup paper draft we want to write something like:

```
Our experiment runs X unique process executions giving a total
of Y in-process iteration readings.
```

Since we will need to recompute X and Y each time we change the SKIP list (we will certainly unskip CPython and maybe some of the explicitly skipped slow benchmark keys at a later date) it makes sense to automate this.

The new parser switch `--info` prints these counts and also lists the keys that were skipped (the latter is just something I personally find useful). After printing this stuff, Krun exits.

E.g.:

```
$ ./krun/krun.py --info warmup.krun 
[2016-01-26 11:14:49 INFO] Krun starting...

Session Info
============

Counts:
  Total process executions:           450
  Total in-process iterations:     900000

Skipped keys:
  fasta:JRubyTruffle:default-ruby
  fannkuch_redux:CPython:default-python
  fasta:CPython:default-python
  richards:HHVM:default-php
  spectralnorm:CPython:default-python
  spectralnorm:JRubyTruffle:default-ruby
  richards:CPython:default-python
  binarytrees:CPython:default-python
  nbody:CPython:default-python
```

Much opportunity for commit squashing and please don't merge until I have updated the documentation.

Otherwise looks good?