### PR TITLE
How many keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ printed to STDOUT.
 Valid debug levels are: `DEBUG`, `INFO`, `WARN`, `DEBUG`,
 `CRITICAL`, `ERROR`.
 
-The `--info` switch reports the total number of process executions and
-in-process iterations that would be run using the specified config file. It
-also prints the benchmark keys which would be skipped.
+The `--info` switch reports various statistics about the setup described in the
+specified config file, such as the total number of process executions and which
+benchmark keys will be skipped etc.
 
 ## Running in reboot and resume modes
 

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -102,6 +102,14 @@ def test_get_session_info0001():
     assert info["n_in_proc_iters"] == 40
     assert info["skipped_keys"] == set()
 
+    expect_non_skipped_keys = set([
+        "dummy:Java:default-java",
+        "nbody:Java:default-java",
+        "dummy:CPython:default-python",
+        "nbody:CPython:default-python",
+    ])
+    assert info["non_skipped_keys"] == expect_non_skipped_keys
+
 
 def test_get_session_info0002():
     path = os.path.join(TEST_DIR, "more_complicated.krun")
@@ -128,3 +136,55 @@ def test_get_session_info0002():
         "fannkuch_redux:CPython:default-python",
     ]
     assert info["skipped_keys"] == set(expect_skip_keys)
+
+    expect_non_skipped_keys = [
+        'richards:C:default-c',
+        'nbody:HHVM:default-php',
+        'binarytrees:C:default-c',
+        'binarytrees:PyPy:default-python',
+        'spectralnorm:Hotspot:default-java',
+        'fannkuch_redux:Graal:default-java',
+        'nbody:JRubyTruffle:default-ruby',
+        'fasta:Graal:default-java',
+        'binarytrees:Graal:default-java',
+        'fasta:C:default-c',
+        'binarytrees:JRubyTruffle:default-ruby',
+        'spectralnorm:HHVM:default-php',
+        'nbody:PyPy:default-python',
+        'fannkuch_redux:C:default-c',
+        'fannkuch_redux:JRubyTruffle:default-ruby',
+        'fannkuch_redux:Hotspot:default-java',
+        'spectralnorm:PyPy:default-python',
+        'fasta:PyPy:default-python',
+        'binarytrees:Hotspot:default-java',
+        'nbody:C:default-c',
+        'richards:JRubyTruffle:default-ruby',
+        'fasta:V8:default-javascript',
+        'nbody:V8:default-javascript',
+        'richards:V8:default-javascript',
+        'nbody:LuaJIT:default-lua',
+        'richards:Hotspot:default-java',
+        'fasta:LuaJIT:default-lua',
+        'binarytrees:LuaJIT:default-lua',
+        'fannkuch_redux:V8:default-javascript',
+        'fannkuch_redux:LuaJIT:default-lua',
+        'richards:Graal:default-java',
+        'binarytrees:V8:default-javascript',
+        'spectralnorm:LuaJIT:default-lua',
+        'spectralnorm:C:default-c',
+        'fannkuch_redux:HHVM:default-php',
+        'fannkuch_redux:PyPy:default-python',
+        'binarytrees:HHVM:default-php',
+        'fasta:HHVM:default-php',
+        'spectralnorm:V8:default-javascript',
+        'spectralnorm:Graal:default-java',
+        'nbody:Graal:default-java',
+        'richards:LuaJIT:default-lua',
+        'nbody:Hotspot:default-java',
+        'richards:PyPy:default-python',
+        'fasta:Hotspot:default-java'
+    ]
+    assert info["non_skipped_keys"] == set(expect_non_skipped_keys)
+
+    # There should be no overlap in the used and skipped keys
+    assert info["skipped_keys"].intersection(info["non_skipped_keys"]) == set()

--- a/krun/util.py
+++ b/krun/util.py
@@ -103,7 +103,7 @@ def get_session_info(config):
 
     platform = detect_platform(None)
     sched = ExecutionScheduler(config, None, platform)
-    skipped_keys = sched.build_schedule()
+    non_skipped_keys, skipped_keys = sched.build_schedule()
 
     n_proc_execs = 0
     n_in_proc_iters = 0
@@ -121,6 +121,7 @@ def get_session_info(config):
         "n_proc_execs": n_proc_execs,
         "n_in_proc_iters": n_in_proc_iters,
         "skipped_keys": skipped_keys,
+        "non_skipped_keys": non_skipped_keys,
     }
 
 
@@ -134,7 +135,17 @@ def print_session_info(config):
 
     print("Counts:")
     print("  Total process executions:    %10d" % info["n_proc_execs"])
-    print("  Total in-process iterations: %10d\n" % info["n_in_proc_iters"])
+    print("  Total in-process iterations: %10d" % info["n_in_proc_iters"])
+    print("  Total unique benchmark keys: %10d\n"
+          % len(info["non_skipped_keys"]))
+
+    print("Non-skipped keys:")
+    if len(info["non_skipped_keys"]) > 0:
+        for k in info["non_skipped_keys"]:
+            print("  %s" % k)
+    else:
+        print("  All keys skipped!")
+    print("")
 
     print("Skipped keys:")
     if len(info["skipped_keys"]) > 0:


### PR DESCRIPTION
In another part of the paper, we want to say how many (out of X) VM/benchmark pairs warmup up "as expected".

For our experiment, where each VM has exactly one benchmark variant (variants are only useful for language composition experiments), X is simply the number of unique benchmark keys in the scheduler queue. This PR adds that information to the `--info` output. Tests and docs are revised accordingly.

OK?
