### PR TITLE
Absolute threshold tolerance in degrees

### DIFF
--- a/krun/tests/test_genericplatform.py
+++ b/krun/tests/test_genericplatform.py
@@ -4,12 +4,10 @@ class TestGenericPlatform(BaseKrunTest):
     """Platform tests that can be run on any platform"""
 
     def test_temperature_thresholds(self, mock_platform):
-        temps = {"x": 3000, "y": 1234, "z": 666}
+        temps = {"x": 30.0, "y": 12.34, "z": 666.0}
         mock_platform.starting_temperatures = temps
 
         for k, v in temps.iteritems():
-            # should be 10% higher
-            assert mock_platform.temperature_thresholds[k] ==\
-                int(temps[k] *  1.1)
+            assert mock_platform.temperature_thresholds[k] == temps[k] + 5
 
 


### PR DESCRIPTION
Use an absolute threshold tolerance in degrees instead of a percentage, as taking a percentage of degrees centigrade makes little sense, as the scale doesn't start from zero. E.g. 15dC is not half as hot as 30dC.

Will need a squash. OK?