### PR TITLE
Use sensors framework on Linux for temperatures.

### DIFF
--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -140,26 +140,35 @@ class TestLinuxPlatform(BaseKrunTest):
 
         temps = platform.take_temperature_readings()
         assert type(temps) is dict
-        assert all([x.startswith("thermal_zone") for x in temps.iterkeys()])
+        assert all([x.startswith("/sys/class/hwmon/hwmon") \
+                    for x in temps.iterkeys()])
         # check temperature readings are within reasonable parameters
         assert all([type(v) == float for v in temps.itervalues()])
         assert all([10 <= v <= 100 for v in temps.itervalues()])
 
     def test_take_temperature_readings0002(self, platform, monkeypatch):
-        platform.zones = ["zone1", "zone2", "zone3"]
+        platform.temp_sensors = [
+            "/sys/class/hwmon/hwmon1/temp1_input",
+            "/sys/class/hwmon/hwmon2/temp1_input",
+            "/sys/class/hwmon/hwmon2/temp2_input",
+        ]
 
         def fake_read_zone(self, zone):
-            if zone == "zone1":
+            if zone == "/sys/class/hwmon/hwmon1/temp1_input":
                 return 66123
-            elif zone == "zone2":
+            elif zone == "/sys/class/hwmon/hwmon2/temp1_input":
                 return 0
             else:
                 return 100000
 
         monkeypatch.setattr(krun.platform.LinuxPlatform,
-                            "_read_zone", fake_read_zone)
+                            "_read_temperature_sensor", fake_read_zone)
 
-        expect = {"zone1": 66.123, "zone2": 0.0, "zone3": 100.0}
+        expect = {
+            "/sys/class/hwmon/hwmon1/temp1_input": 66.123,
+            "/sys/class/hwmon/hwmon2/temp1_input": 0.0,
+            "/sys/class/hwmon/hwmon2/temp2_input": 100.0
+        }
         got = platform.take_temperature_readings()
 
         assert expect == got


### PR DESCRIPTION
On Linux, use the sensor framework for temperatures instead of the thermal framework.

Fixes #155.

OK?