### PR TITLE
More robust paths in tests.

### DIFF
--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -22,25 +22,29 @@ def test_str():
     assert config.text == str(config)
 
 def test_eq():
-    example_config = Config("krun/tests/example.krun")
+    path = os.path.join(TEST_DIR, "example.krun")
+    example_config = Config(path)
     assert example_config == example_config
     assert not example_config == None
     assert not example_config == Config("krun/tests/quick.krun")
 
 
 def test_log_filename(monkeypatch):
-    example_config = Config("krun/tests/example.krun")
+    path = os.path.join(TEST_DIR, "example.krun")
+    example_config = Config(path)
     tstamp = time.strftime(LOGFILE_FILENAME_TIME_FORMAT)
-    assert example_config.log_filename(False) == "krun/tests/example" + "_" + tstamp + ".log"
+    expect_path = os.path.join(TEST_DIR, "example_%s.log" % tstamp)
+    assert example_config.log_filename(False) == expect_path
     def mock_mtime(path):
         return 1445964109.9363003
     monkeypatch.setattr(os.path, 'getmtime', mock_mtime)
     tstamp = '20151027_164149'
-    assert example_config.log_filename(True) == "krun/tests/example" + "_" + tstamp + ".log"
+    expect_path = os.path.join(TEST_DIR, "example_%s.log" % tstamp)
+    assert example_config.log_filename(True) == expect_path
 
 
 def test_read_config_from_file():
-    path = "krun/tests/example.krun"
+    path = os.path.join(TEST_DIR, "example.krun")
     config0 = Config(path)
     config1 = Config(None)
     config1.read_from_file(path)
@@ -48,7 +52,7 @@ def test_read_config_from_file():
 
 
 def test_read_config_from_string():
-    path = "krun/tests/example.krun"
+    path = os.path.join(TEST_DIR, "example.krun")
     config0 = Config(path)
     config1 = Config(None)
     with open(path) as fp:
@@ -58,7 +62,7 @@ def test_read_config_from_string():
 
 
 def test_read_corrupt_config_from_string():
-    path = "krun/tests/corrupt.krun"
+    path = os.path.join(TEST_DIR, "corrupt.krun")
     config = Config(None)
     with pytest.raises(Exception):
         with open(path) as fp:
@@ -67,7 +71,7 @@ def test_read_corrupt_config_from_string():
 
 @pytest.mark.skipif(JAVA is None, reason="No Java found")
 def test_config_init():
-    path = "examples/example.krun"
+    path = os.path.join(TEST_DIR, "example.krun")
     config = Config(path)
     assert config is not None
     assert config.BENCHMARKS == {"dummy": 1000, "nbody": 1000}
@@ -79,7 +83,7 @@ def test_config_init():
 
 
 def test_read_corrupt_config():
-    path = "krun/tests/corrupt.krun"
+    path = os.path.join(TEST_DIR, "corrupt.krun")
     with pytest.raises(Exception):
         Config(path)
 
@@ -93,7 +97,8 @@ def test_results_filename():
 
 
 def test_skip0001():
-    config = Config("krun/tests/skips.krun")
+    path = os.path.join(TEST_DIR, "skips.krun")
+    config = Config(path)
     expected = ["*:PyPy:*",
                 "*:CPython:*",
                 "*:Hotspot:*",


### PR DESCRIPTION
Pretty boring changes. All paths should be relative to `TEST_DIR` to avoid accidentally picking up the wrong file.

OK?