### PR TITLE
Avoid I/O during benchmarking.

### DIFF
--- a/iterations_runners/iterations_runner.java
+++ b/iterations_runners/iterations_runner.java
@@ -19,13 +19,15 @@ class IterationsRunner {
     public static void main(String args[]) throws
         ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, java.lang.reflect.InvocationTargetException {
 
-        if (args.length != 3) { // not 4 since java doesn't put the program name in args[0]
-            System.out.println("usage: iterations_runner <benchmark> <# of iterations> <benchmark param>\n");
+        if (args.length != 4) {
+            System.out.println("usage: iterations_runner <benchmark> "
+                    "<# of iterations> <benchmark param> <debug flag>\n");
             System.exit(1);
         }
         String benchmark = args[0];
         int iterations = Integer.parseInt(args[1]);
         int param = Integer.parseInt(args[2]);
+        bool debug = Integer.parseInt(args[3]) > 0;
 
         // reflectively call the benchmark's run_iter
         Class<?> cls = Class.forName(benchmark);
@@ -37,7 +39,9 @@ class IterationsRunner {
         System.out.print("[");
         // Please, no refelction inside the timed code!
         for (int i = 0; i < iterations; i++) {
-            System.err.println("[iterations_runner.java] iteration: " + (i + 1) + "/" + iterations);
+            if (debug) {
+                System.err.println("[iterations_runner.java] iteration: " + (i + 1) + "/" + iterations);
+            }
 
             double startTime = IterationsRunner.JNI_clock_gettime_monotonic();
             ke.run_iter(param);

--- a/iterations_runners/iterations_runner.js
+++ b/iterations_runners/iterations_runner.js
@@ -1,24 +1,28 @@
 // NOTE: you need to provide clock_gettime_monotonic.
 
-if (this.arguments.length != 3) {
-    throw "usage: iterations_runner.js <benchmark> <# of iterations> <benchmark param>";
+if (this.arguments.length != 4) {
+    throw "usage: iterations_runner.js <benchmark> <# of iterations> <benchmark param> <debug flag>";
 }
 
 var BM_entry_point = this.arguments[0];
 var BM_n_iters = parseInt(this.arguments[1]);
 var BM_param = parseInt(this.arguments[2]);
+var BM_debug = parseInt(this.arguments[3]) > 0;
 
 load(BM_entry_point);
 
 print("[");
 for (BM_i = 0; BM_i < BM_n_iters; BM_i++) {
-	print_err("[iterations_runner.js] iteration " + (BM_i + 1) + "/" + BM_n_iters);
-	var BM_start_time = clock_gettime_monotonic();
-	run_iter(BM_param);
-	var BM_stop_time = clock_gettime_monotonic();
+    if (BM_debug) {
+        print_err("[iterations_runner.js] iteration " + (BM_i + 1) + "/" + BM_n_iters);
+    }
 
-	var BM_intvl = BM_stop_time - BM_start_time;
-	print(BM_intvl);
+    var BM_start_time = clock_gettime_monotonic();
+    run_iter(BM_param);
+    var BM_stop_time = clock_gettime_monotonic();
+
+    var BM_intvl = BM_stop_time - BM_start_time;
+    print(BM_intvl);
     if (BM_i < BM_n_iters - 1) {
         print(", ")
     }

--- a/iterations_runners/iterations_runner.lua
+++ b/iterations_runners/iterations_runner.lua
@@ -11,9 +11,10 @@ local kruntime = ffi.load("kruntime")
 local BM_benchmark = arg[1]
 local BM_iters = tonumber(arg[2])
 local BM_param = tonumber(arg[3])
+local BM_debug = tonumber(arg[4]) > 0
 
-if #arg ~= 3 then
-    print("usage: iterations_runner.lua <benchmark> <# of iterations> <benchmark param>")
+if #arg ~= 4 then
+    print("usage: iterations_runner.lua <benchmark> <# of iterations> <benchmark param> <debug flag>")
     os.exit(1)
 end
 
@@ -22,7 +23,9 @@ dofile(BM_benchmark)
 io.stdout:write("[")
 io.stdout:flush()
 for BM_i = 1, BM_iters, 1 do -- inclusive upper bound in lua
-    io.stderr:write(string.format("[iterations_runner.lua] iteration %d/%d\n", BM_i, BM_iters))
+    if BM_debug then
+        io.stderr:write(string.format("[iterations_runner.lua] iteration %d/%d\n", BM_i, BM_iters))
+    end
 
     local BM_start_time = kruntime.clock_gettime_monotonic()
     run_iter(BM_param) -- run one iteration of benchmark

--- a/iterations_runners/iterations_runner.php
+++ b/iterations_runners/iterations_runner.php
@@ -11,14 +11,15 @@
  */
 
 # main
-if ($argc != 4) {
-	echo "usage: iterations_runner.php <benchmark> <# of iterations> <benchmark param>\n";
+if ($argc != 5) {
+	echo "usage: iterations_runner.php <benchmark> <# of iterations> <benchmark param> <debug flag>\n";
 	exit(1);
 }
 
 $BM_benchmark = $argv[1];
 $BM_iters = $argv[2];
 $BM_param = (int) $argv[3]; // parameter sent to benchmark.
+$BM_debug = ((int) $argv[4]) > 0;
 
 if (!file_exists($BM_benchmark)) {
 	throw new RuntimeException("Can't find $BM_benchmark");
@@ -38,7 +39,9 @@ if (!function_exists("run_iter")) {
 
 echo "["; // we are going to print a JSON list.
 for ($BM_i = 0; $BM_i < $BM_iters; $BM_i++) {
-    fprintf(STDERR, "[iterations_runner.php] iteration %d/%d\n", $BM_i + 1, $BM_iters);
+    if ($BM_debug) {
+        fprintf(STDERR, "[iterations_runner.php] iteration %d/%d\n", $BM_i + 1, $BM_iters);
+    }
 
 	$start_time = clock_gettime_monotonic();
 	run_iter($BM_param);

--- a/iterations_runners/iterations_runner.py
+++ b/iterations_runners/iterations_runner.py
@@ -17,14 +17,13 @@ clock_gettime_monotonic = libkruntime.clock_gettime_monotonic
 
 # main
 if __name__ == "__main__":
-
-    if len(sys.argv) != 4:
+    if len(sys.argv) != 5:
         print("usage: iterations_runner.py "
-        "<benchmark> <# of iterations> <benchmark param>\n")
+        "<benchmark> <# of iterations> <benchmark param> <debug flag>\n")
         sys.exit(1)
 
-    benchmark, iters, param = sys.argv[1:]
-    iters, param = int(iters), int(param)
+    benchmark, iters, param, debug = sys.argv[1:]
+    iters, param, debug = int(iters), int(param), int(debug)
 
     assert benchmark.endswith(".py")
     bench_mod_name = os.path.basename(benchmark[:-3])
@@ -38,8 +37,9 @@ if __name__ == "__main__":
 
     sys.stdout.write("[") # we are going to print a JSON list
     for i in xrange(iters):
-        sys.stderr.write(
-            "[iterations_runner.py] iteration %d/%d\n" % (i + 1, iters))
+        if debug:
+            sys.stderr.write(
+                "[iterations_runner.py] iteration %d/%d\n" % (i + 1, iters))
 
         start_time = clock_gettime_monotonic()
         bench_func(param)

--- a/iterations_runners/iterations_runner.rb
+++ b/iterations_runners/iterations_runner.rb
@@ -29,22 +29,25 @@ end
 
 # main
 if __FILE__ == $0
-    if ARGV.length != 3
-        puts "usage: iterations_runner.rb <benchmark> <#iterations> <benchmark_param>\n"
+    if ARGV.length != 4
+        puts "usage: iterations_runner.rb <benchmark> <#iterations> <benchmark_param> <debug flag>\n"
         Kernel.exit(1)
     end
 
-    benchmark, iters, param = ARGV
+    benchmark, iters, param, debug = ARGV
     iters = Integer(iters)
     param = Integer(param)
+    debug = Integer(debug) > 0
 
     assert benchmark.end_with?(".rb")
     require("#{benchmark}")
 
     STDOUT.write "["
     for krun_iter_num in 0..iters - 1 do  # inclusive upper bound
-        STDERR.write "[iterations_runner.rb] iteration #{krun_iter_num + 1}/#{iters}\n"
-	STDERR.flush  # JRuby doesn't flush on newline.
+        if debug then
+            STDERR.write "[iterations_runner.rb] iteration #{krun_iter_num + 1}/#{iters}\n"
+            STDERR.flush  # JRuby doesn't flush on newline.
+        end
 
         start_time = clock_gettime_monotonic()
         run_iter(param)

--- a/krun.py
+++ b/krun.py
@@ -40,7 +40,7 @@ def usage(parser):
 
 
 def sanity_checks(config, platform):
-    info("Running sanity checks")
+    debug("Running sanity checks")
 
     vms_that_will_run = []
     # check all necessary benchmark files exist
@@ -222,7 +222,7 @@ def main(parser):
     platform = detect_platform(mailer)
 
     if not args.develop:
-        info("Checking platform preliminaries")
+        debug("Checking platform preliminaries")
         platform.check_preliminaries()
     else:
         # Needed to skip the use of certain tools and techniques.
@@ -256,7 +256,6 @@ def main(parser):
         _, _, rc = util.run_shell_cmd("touch " + args.filename)
         if rc != 0:
             util.fatal("Could not touch config file: " + args.filename)
-
 
         info(("Wait %s secs to allow system to cool prior to "
              "collecting initial temperature readings") %
@@ -316,12 +315,12 @@ def attach_log_file(config, resume):
     fh = logging.FileHandler(log_filename, mode=mode)
     fh.setFormatter(PLAIN_FORMATTER)
     logging.root.addHandler(fh)
-    info("Attached log file: %s" % log_filename)
+    debug("Attached log file: %s" % log_filename)
 
 
 if __name__ == "__main__":
+    debug("Krun starting...")
     debug("arguments: %s"  % " ".join(sys.argv[1:]))
     parser = create_arg_parser()
     setup_logging(parser)
-    info("Krun starting...")
     main(parser)

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -144,9 +144,9 @@ class BasePlatform(object):
 
             # if we get here, too hot!
             if not msg_shown:
-                info("System is running hot.")
-                info(reason)
-                info("Waiting to cool")
+                debug("System is running hot.")
+                debug(reason)
+                debug("Waiting to cool")
                 msg_shown = True
 
             trys += 1
@@ -328,7 +328,7 @@ class OpenBSDPlatform(UnixLikePlatform):
         return run_shell_cmd("apm")[0]
 
     def _check_apm_state(self):
-        info("Checking APM state is geared for high-performance")
+        debug("Checking APM state is geared for high-performance")
         adjust = False
 
         out = self._get_apm_output()
@@ -353,7 +353,7 @@ class OpenBSDPlatform(UnixLikePlatform):
             adjust = True
 
         if adjust:
-            info("adjusting performance mode")
+            debug("adjusting performance mode")
             out, _, _ = run_shell_cmd("apm -H")
             self._check_apm_state()  # should work this time
 
@@ -630,7 +630,7 @@ class LinuxPlatform(UnixLikePlatform):
                 v = fh.read().strip()
 
             if v != "performance":
-                info("changing CPU governor for CPU %s" % cpu_n)
+                debug("changing CPU governor for CPU %s" % cpu_n)
                 cmd = "%s cpufreq-set -c %d -g performance" % \
                     (self.change_user_cmd, cpu_n)
                 stdout, stderr, rc = run_shell_cmd(cmd, failure_fatal=False)
@@ -691,7 +691,7 @@ class LinuxPlatform(UnixLikePlatform):
             return  # OK!
         else:
             # ASLR is off, but we can try to enable it
-            info("Turning ASLR off")
+            debug("Turning ASLR off")
             cmd = "%s sh -c 'echo 0 > %s'" % \
                 (self.change_user_cmd, self.ASLR_FILE)
             stdout, stderr, rc = run_shell_cmd(cmd, failure_fatal=False)

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -79,3 +79,6 @@ class MockPlatform(BasePlatform):
 
     def sanity_checks(self):
         pass
+
+    def sync_disks(self):
+        pass

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -183,12 +183,18 @@ class BaseVMDef(object):
         wrapper_args = self.platform.change_user_args(BENCHMARK_USER) + \
             [DASH, WRAPPER_SCRIPT]
 
+        debug("Execute wrapper: %s" % (" ".join(wrapper_args)))
+
+        # Do an OS-level sync. Forces pending writes on to the physical disk.
+        # We do this in an attempt to prevent disk commits happening during
+        # benchmarking.
+        self.platform.sync_disks()
+
         # We pass the empty environment dict here.
         # This is the *outer* environment that the current user will invoke the
         # command with. Command line arguments will have been appended *inside*
         # to adjust the new user's environment once the user switch has
         # occurred.
-        debug("Execute wrapper: %s" % (" ".join(wrapper_args)))
         p = subprocess.Popen(
             wrapper_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             env={})

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -159,6 +159,13 @@ class BaseVMDef(object):
         # Apply platform specific argument transformations.
         args = self.platform.bench_cmdline_adjust(args, new_user_env)
 
+        # Tack on the debug flag: 0 or 1
+        import logging
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            args.append("1")
+        else:
+            args.append("0")
+
         if self.dry_run:
             info("Dry run. Skipping.")
             return ("", "", 0)

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -167,7 +167,7 @@ class BaseVMDef(object):
             args.append("0")
 
         if self.dry_run:
-            info("Dry run. Skipping.")
+            info("SIMULATED: Benchmark process execution")
             return ("", "", 0)
 
         # We write out a wrapper script whose job is to enforce ulimits
@@ -491,7 +491,7 @@ class JRubyTruffleVMDef(JRubyVMDef):
     def _check_truffle_enabled(self):
         """Runs fake benchmark crashing if the Truffle is disabled in JRuby"""
 
-        info("Running jruby_check_truffle_enabled sanity check")
+        debug("Running jruby_check_truffle_enabled sanity check")
         ep = EntryPoint("jruby_check_graal_enabled.rb")
         spawn_sanity_check(self.platform, ep, self,
                            "jruby_check_graal_enabled.rb", force_dir=VM_SANITY_CHECKS_DIR)


### PR DESCRIPTION
Hi,

The following commits avoid I/O during benchmarking. 

Move a lot of info-level logging to debug-level (we won't see those in production) and re-order remaining logging so that output only occurs after process executions. Also attempt to sync disks before each process execution (comments explain why I say "attempt").

Example output with a dryrun:

```
$ rm -rf *.bz2 *.log && ../krun.py --dryrun --reboot example.krun               
[2016-02-25 11:45:51: INFO] Wait 1 secs to allow system to cool prior to collecting initial temperature readings
[2016-02-25 11:45:51: INFO] SIMULATED: time.sleep(1)
[2016-02-25 11:45:53: INFO] Reboot prior to first execution
[2016-02-25 11:45:53: INFO] SIMULATED: reboot (restarting Krun in-place)
[2016-02-25 11:46:10: INFO] SIMULATED: time.sleep (would have waited 180 seconds).
[2016-02-25 11:46:21: INFO] SIMULATED: Benchmark process execution
[2016-02-25 11:46:21: INFO] Finished 'dummy(1000)' (default-python variant) under 'CPython'
[2016-02-25 11:46:21: INFO] 3 executions left in scheduler queue
[2016-02-25 11:46:21: INFO] Estimated completion     : ????-??-?? ??:??:?? (?:??:?? from now)
[2016-02-25 11:46:21: INFO] Next execution is 'nbody(1000)' (default-python variant) under 'CPython'
[2016-02-25 11:46:21: INFO] Estimated completion (next execution): ????-??-?? ??:??:?? (?:??:?? from now)
[2016-02-25 11:46:21: INFO] Executions until ETA known: 1
[2016-02-25 11:46:21: INFO] Reboot in preparation for next execution
[2016-02-25 11:46:21: INFO] SIMULATED: reboot (restarting Krun in-place)
[2016-02-25 11:46:23: INFO] SIMULATED: time.sleep (would have waited 180 seconds).
[2016-02-25 11:46:35: INFO] SIMULATED: Benchmark process execution
[2016-02-25 11:46:35: INFO] Finished 'nbody(1000)' (default-python variant) under 'CPython'
[2016-02-25 11:46:35: INFO] 2 executions left in scheduler queue
[2016-02-25 11:46:35: INFO] Estimated completion     : 2016-02-25 11:46:35 (0:00:00 from now)
[2016-02-25 11:46:35: INFO] Next execution is 'dummy(1000)' (default-python variant) under 'CPython'
[2016-02-25 11:46:35: INFO] Estimated completion (next execution): 2016-02-25 11:46:35 (0:00:00 from now)
[2016-02-25 11:46:35: INFO] Reboot in preparation for next execution
[2016-02-25 11:46:35: INFO] SIMULATED: reboot (restarting Krun in-place)
[2016-02-25 11:46:37: INFO] SIMULATED: time.sleep (would have waited 180 seconds).
[2016-02-25 11:46:38: INFO] SIMULATED: Benchmark process execution
[2016-02-25 11:46:38: INFO] Finished 'dummy(1000)' (default-python variant) under 'CPython'
[2016-02-25 11:46:38: INFO] 1 executions left in scheduler queue
[2016-02-25 11:46:38: INFO] Estimated completion     : 2016-02-25 11:46:38 (0:00:00 from now)
[2016-02-25 11:46:38: INFO] Next execution is 'nbody(1000)' (default-python variant) under 'CPython'
[2016-02-25 11:46:38: INFO] Estimated completion (next execution): 2016-02-25 11:46:38 (0:00:00 from now)
[2016-02-25 11:46:38: INFO] Reboot in preparation for next execution
[2016-02-25 11:46:38: INFO] SIMULATED: reboot (restarting Krun in-place)
[2016-02-25 11:46:40: INFO] SIMULATED: time.sleep (would have waited 180 seconds).
[2016-02-25 11:46:41: INFO] SIMULATED: Benchmark process execution
[2016-02-25 11:46:41: INFO] Finished 'nbody(1000)' (default-python variant) under 'CPython'
[2016-02-25 11:46:41: INFO] 0 executions left in scheduler queue
[2016-02-25 11:46:41: INFO] Estimated completion     : 2016-02-25 11:46:41 (0:00:00 from now)
[2016-02-25 11:46:42: INFO] Done: Results dumped to example_results.json.bz2
[2016-02-25 11:46:42: INFO] Session completed. Log file at: 'example_20160225_114551.log'

Don't forget to disable Krun at boot.
```

As you can see there is no output (that we would see on a real run) between reboots and process executions. You can ignore the bogus ETAs. These don't work in dry run mode.

Note that this does not deal with killing Satan's evil daemons. This will be a separate PR.

Fixes #151.

OK?