### PR TITLE
Dont sync disks for sanity checks

### DIFF
--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -57,7 +57,7 @@ class MockPlatform(BasePlatform):
         return args
 
     def change_user_args(self, user="root"):
-        return "sudo"
+        return ["sudo"]
 
     def process_priority_args(self):
         return []

--- a/krun/util.py
+++ b/krun/util.py
@@ -81,7 +81,7 @@ def spawn_sanity_check(platform, entry_point, vm_def,
     stdout, stderr, rc = \
         vm_def.run_exec(entry_point, check_name, iterations,
                         param, SANITY_CHECK_HEAP_KB, SANITY_CHECK_STACK_KB,
-                        force_dir=force_dir)
+                        force_dir=force_dir, sync_disks=False)
 
     try:
         _ = check_and_parse_execution_results(stdout, stderr, rc)


### PR DESCRIPTION
I noticed that our small run was syncing disks (and waiting 3 mins) multiple times per execution due to sanity checks. This is not necessary. We just need to sync disks before runs we actually hope to take data from.

New tests to confirm this behavior.

OK?