### PR TITLE
Unify temperature sensors interface across platforms and add checks.

### DIFF
--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -82,3 +82,6 @@ class MockPlatform(BasePlatform):
 
     def sync_disks(self):
         pass
+
+    def find_temperature_sensors(self):
+        return []

--- a/krun/tests/test_genericplatform.py
+++ b/krun/tests/test_genericplatform.py
@@ -1,13 +1,48 @@
 from krun.tests import BaseKrunTest
+import pytest
 
 class TestGenericPlatform(BaseKrunTest):
     """Platform tests that can be run on any platform"""
 
     def test_temperature_thresholds(self, mock_platform):
         temps = {"x": 30.0, "y": 12.34, "z": 666.0}
+        mock_platform.temp_sensors = ["x", "y", "z"]
         mock_platform.starting_temperatures = temps
 
         for k, v in temps.iteritems():
             assert mock_platform.temperature_thresholds[k] == temps[k] + 5
 
+    def test_inconsistent_sensors0001(self, platform, caplog):
+        # The platform has already detected the available sensors. Now we
+        # confuse it, by moving a sensor. This shouldn't happen of course, but
+        # tests are good nevertheless.
 
+        if not platform.temp_sensors:
+            pytest.skip("no temperature sensors")
+
+        platform.temp_sensors[0] += "_moved"
+
+        with pytest.raises(SystemExit):
+            platform.take_temperature_readings()
+
+        expect = "Failed to read sensor"
+        assert expect in caplog.text()
+
+
+    def test_inconsistent_sensors0002(self, platform, caplog):
+        platform.temp_sensors = ["different", "sensors"]
+
+        with pytest.raises(SystemExit):
+            platform.starting_temperatures = {"a": 1000, "b": 2000}
+
+        expect = "Inconsistent sensors. ['a', 'b'] vs ['different', 'sensors']"
+        assert expect in caplog.text()
+
+    def test_inconsistent_sensors0003(self, platform, caplog):
+        platform.temp_sensors = ["a"]
+
+        with pytest.raises(SystemExit):
+            platform.starting_temperatures = {"a": 1000, "b": 2000}
+
+        expect = "Inconsistent sensors. ['a', 'b'] vs ['a']"
+        assert expect in caplog.text()


### PR DESCRIPTION
Finishing off work I started on Frday: This essentially adds sanity checks to the sensors code, however there was some refactoring to allow the checks to be generic between platforms.

 * OpenBSD sensor code was refactored into separate "find sensors" / "read sensors" phases to match linux.
 * The sensors that are detected are now checked against the sensors that we saw prior to reboot.

OK?