### PR TITLE
Pre-allocate results arrays and print once after all iterations.

### DIFF
--- a/iterations_runners/iterations_runner.java
+++ b/iterations_runners/iterations_runner.java
@@ -4,6 +4,8 @@
 // This is not quite ideal. We should use CLOCK_MONOTONIC_RAW instead.
 // For this reason we use JNI to make a call to clock_gettime() ourselves.
 
+import java.util.Arrays;
+
 // All entry points must implement this
 interface BaseKrunEntry {
     public abstract void run_iter(int param);
@@ -36,7 +38,9 @@ class IterationsRunner {
         Object instance = constructors[0].newInstance();
         BaseKrunEntry ke = (BaseKrunEntry) instance; // evil
 
-        System.out.print("[");
+        double[] iter_times = new double[iterations];
+        Arrays.fill(iter_times, -1.0);
+
         // Please, no refelction inside the timed code!
         for (int i = 0; i < iterations; i++) {
             if (debug) {
@@ -47,14 +51,17 @@ class IterationsRunner {
             ke.run_iter(param);
             double stopTime = IterationsRunner.JNI_clock_gettime_monotonic();
 
-            double intvl = (stopTime - startTime);
-            System.out.print(intvl);
+            iter_times[i] = stopTime - startTime;
+        }
+
+        System.out.print("[");
+        for (int i = 0; i < iterations; i++) {
+            System.out.print(iter_times[i]);
 
             if (i < iterations - 1) {
                 System.out.print(", ");
             }
         }
-        System.out.print("]");
-
+        System.out.print("]\n");
     }
 }

--- a/iterations_runners/iterations_runner.js
+++ b/iterations_runners/iterations_runner.js
@@ -11,7 +11,9 @@ var BM_debug = parseInt(this.arguments[3]) > 0;
 
 load(BM_entry_point);
 
-print("[");
+var BM_iter_times = new Array(BM_n_iters);
+BM_iter_times.fill(-1.0);
+
 for (BM_i = 0; BM_i < BM_n_iters; BM_i++) {
     if (BM_debug) {
         print_err("[iterations_runner.js] iteration " + (BM_i + 1) + "/" + BM_n_iters);
@@ -21,8 +23,13 @@ for (BM_i = 0; BM_i < BM_n_iters; BM_i++) {
     run_iter(BM_param);
     var BM_stop_time = clock_gettime_monotonic();
 
-    var BM_intvl = BM_stop_time - BM_start_time;
-    print(BM_intvl);
+    BM_iter_times[BM_i] = BM_stop_time - BM_start_time;
+}
+
+print("[");
+for (BM_i = 0; BM_i < BM_n_iters; BM_i++) {
+    print(BM_iter_times[BM_i]);
+
     if (BM_i < BM_n_iters - 1) {
         print(", ")
     }

--- a/iterations_runners/iterations_runner.lua
+++ b/iterations_runners/iterations_runner.lua
@@ -1,9 +1,3 @@
--- XXX os.clock() probably isn't good enough
--- http://www.lua.org/manual/5.3/manual.html#pdf-os.clock
--- http://codea.io/talk/discussion/360/milliseconds-in-codea-answered
-
-
--- Call out to C to get the monotonic time
 local ffi = require("ffi")
 ffi.cdef[[double clock_gettime_monotonic();]]
 local kruntime = ffi.load("kruntime")
@@ -20,9 +14,12 @@ end
 
 dofile(BM_benchmark)
 
-io.stdout:write("[")
-io.stdout:flush()
-for BM_i = 1, BM_iters, 1 do -- inclusive upper bound in lua
+local BM_iter_times = {}
+for BM_i = 1, BM_iters, 1 do
+    BM_iter_times[BM_i] = -1.0
+end
+
+for BM_i = 1, BM_iters, 1 do
     if BM_debug then
         io.stderr:write(string.format("[iterations_runner.lua] iteration %d/%d\n", BM_i, BM_iters))
     end
@@ -31,15 +28,14 @@ for BM_i = 1, BM_iters, 1 do -- inclusive upper bound in lua
     run_iter(BM_param) -- run one iteration of benchmark
     local BM_end_time = kruntime.clock_gettime_monotonic()
 
-    local BM_intvl = BM_end_time - BM_start_time
+    BM_iter_times[BM_i] = BM_end_time - BM_start_time
+end
 
-    io.stdout:write(BM_intvl)
+io.stdout:write("[")
+for BM_i = 1, BM_iters, 1 do
+    io.stdout:write(BM_iter_times[BM_i])
     if BM_i < BM_iters then
         io.stdout:write(", ")
     end
-
-    io.stdout:flush()
 end
-
-io.stdout:write("]")
-io.stdout:flush()
+io.stdout:write("]\n")

--- a/iterations_runners/iterations_runner.php
+++ b/iterations_runners/iterations_runner.php
@@ -37,7 +37,8 @@ if (!function_exists("run_iter")) {
 
 /* OK, all is well, let's run. */
 
-echo "["; // we are going to print a JSON list.
+$BM_iter_times = array_fill(0, $BM_iters, -1.0);
+
 for ($BM_i = 0; $BM_i < $BM_iters; $BM_i++) {
     if ($BM_debug) {
         fprintf(STDERR, "[iterations_runner.php] iteration %d/%d\n", $BM_i + 1, $BM_iters);
@@ -47,7 +48,12 @@ for ($BM_i = 0; $BM_i < $BM_iters; $BM_i++) {
 	run_iter($BM_param);
 	$stop_time = clock_gettime_monotonic();
 
-	echo $stop_time - $start_time;
+	$BM_iter_times[$BM_i] = $stop_time - $start_time;
+}
+
+echo "[";
+for ($BM_i = 0; $BM_i < $BM_iters; $BM_i++) {
+    echo $BM_iter_times[$BM_i];
     if ($BM_i < $BM_iters - 1) {
         echo ", ";
     }

--- a/iterations_runners/iterations_runner.py
+++ b/iterations_runners/iterations_runner.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
     # OK, all is well, let's run.
 
-    sys.stdout.write("[") # we are going to print a JSON list
+    iter_times = [-1.0] * iters
     for i in xrange(iters):
         if debug:
             sys.stderr.write(
@@ -45,10 +45,11 @@ if __name__ == "__main__":
         bench_func(param)
         stop_time = clock_gettime_monotonic()
 
-        sys.stdout.write("%f" % (stop_time - start_time))
+        iter_times[i] = stop_time - start_time
+
+    sys.stdout.write("[")
+    for i in xrange(iters):
+        print("%f" % iter_times[i])
         if i < iters - 1:
             sys.stdout.write(", ")
-
-        sys.stdout.flush()
-
     sys.stdout.write("]\n")

--- a/iterations_runners/iterations_runner.rb
+++ b/iterations_runners/iterations_runner.rb
@@ -42,10 +42,11 @@ if __FILE__ == $0
     assert benchmark.end_with?(".rb")
     require("#{benchmark}")
 
-    STDOUT.write "["
-    for krun_iter_num in 0..iters - 1 do  # inclusive upper bound
+    iter_times = [-1.0] * iters
+
+    for iter_num in 0..iters - 1 do
         if debug then
-            STDERR.write "[iterations_runner.rb] iteration #{krun_iter_num + 1}/#{iters}\n"
+            STDERR.write "[iterations_runner.rb] iteration #{iter_num + 1}/#{iters}\n"
             STDERR.flush  # JRuby doesn't flush on newline.
         end
 
@@ -53,11 +54,15 @@ if __FILE__ == $0
         run_iter(param)
         stop_time = clock_gettime_monotonic()
 
-        intvl = stop_time - start_time
-        STDOUT.write String(intvl)
-        if krun_iter_num < iters - 1 then
+        iter_times[iter_num] = stop_time - start_time
+    end
+
+    STDOUT.write "["
+    for iter_num in 0..iters - 1 do
+        STDOUT.write String(iter_times[iter_num])
+        if iter_num < iters - 1 then
             STDOUT.write ", "
         end
     end
-    STDOUT.write "]"
+    STDOUT.write "]\n"
 end


### PR DESCRIPTION
And some small tidy-ups along the way.

Fixes #162.

OK?