### PR TITLE
Implement pre-exec, post-exec and post-session shell commands support.

### DIFF
--- a/examples/example.krun
+++ b/examples/example.krun
@@ -64,3 +64,7 @@ N_EXECUTIONS = 2  # Number of fresh processes.
 # You should set this high enough for the system to cool down a bit.
 # The default (if omitted) is 60 seconds.
 TEMP_READ_PAUSE = 1
+
+# Commands to run before and after each process execution
+#PRE_EXECUTION_CMDS = ["sudo service cron stop"]
+#POST_EXECUTION_CMDS = ["sudo service cron start"]

--- a/krun.py
+++ b/krun.py
@@ -285,7 +285,11 @@ def main(parser):
     sched.build_schedule()
 
     # does the benchmarking
-    sched.run()
+    try:
+        sched.run()
+    except FatalKrunError as e:
+        util.run_shell_cmd_list(config.POST_SESSION_CMDS)
+        raise e
 
 
 def setup_logging(parser):
@@ -323,4 +327,8 @@ if __name__ == "__main__":
     debug("arguments: %s"  % " ".join(sys.argv[1:]))
     parser = create_arg_parser()
     setup_logging(parser)
-    main(parser)
+
+    try:
+        main(parser)
+    except FatalKrunError:
+        pass

--- a/krun/config.py
+++ b/krun/config.py
@@ -28,6 +28,9 @@ class Config(object):
         self.STACK_LIMIT = None
         self.TEMP_READ_PAUSE = 60
 
+        self.PRE_EXECUTION_CMDS = []
+        self.POST_EXECUTION_CMDS = []
+
         if config_file is not None:
             self.read_from_file(config_file)
 
@@ -112,4 +115,6 @@ class Config(object):
                 (self.VARIANTS == other.VARIANTS) and
                 (self.BENCHMARKS == other.BENCHMARKS) and
                 (self.SKIP == other.SKIP) and
-                (self.N_EXECUTIONS == other.N_EXECUTIONS))
+                (self.N_EXECUTIONS == other.N_EXECUTIONS) and
+                (self.PRE_EXECUTION_CMDS == other.PRE_EXECUTION_CMDS) and
+                (self.POST_EXECUTION_CMDS == other.POST_EXECUTION_CMDS))

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -75,6 +75,9 @@ class ExecutionJob(object):
         heap_limit_kb = self.sched.config.HEAP_LIMIT
         stack_limit_kb = self.sched.config.STACK_LIMIT
 
+        # run the user's pre-process-execution commands
+        util.run_shell_cmd_list(self.sched.config.PRE_EXECUTION_CMDS)
+
         stdout, stderr, rc = vm_def.run_exec(
             entry_point, self.benchmark, self.vm_info["n_iterations"],
             self.parameter, heap_limit_kb, stack_limit_kb)
@@ -93,6 +96,9 @@ class ExecutionJob(object):
         # before the next execution, so we are grand.
         info("Finished '%s(%d)' (%s variant) under '%s'" %
                     (self.benchmark, self.parameter, self.variant, self.vm_name))
+
+        # run the user's post-process-execution commands
+        util.run_shell_cmd_list(self.sched.config.POST_EXECUTION_CMDS)
 
         return iterations_results
 

--- a/krun/tests/test_env.py
+++ b/krun/tests/test_env.py
@@ -1,4 +1,5 @@
 from krun.env import EnvChangeSet, EnvChangeAppend
+from krun.util import FatalKrunError
 
 import logging, os
 import pytest
@@ -8,7 +9,7 @@ def test_env_change_set(monkeypatch, caplog):
     env = EnvChangeSet("bach", 1685)
     assert env.var == "bach"
     assert env.val == 1685
-    with pytest.raises(SystemExit):
+    with pytest.raises(FatalKrunError):
         env.apply({"bach": 1695})
     assert "Environment bach is already defined" in caplog.text()
 

--- a/krun/tests/test_genericplatform.py
+++ b/krun/tests/test_genericplatform.py
@@ -1,4 +1,5 @@
 from krun.tests import BaseKrunTest
+from krun.util import FatalKrunError
 import pytest
 
 class TestGenericPlatform(BaseKrunTest):
@@ -22,7 +23,7 @@ class TestGenericPlatform(BaseKrunTest):
 
         platform.temp_sensors[0] += "_moved"
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             platform.take_temperature_readings()
 
         expect = "Failed to read sensor"
@@ -32,7 +33,7 @@ class TestGenericPlatform(BaseKrunTest):
     def test_inconsistent_sensors0002(self, platform, caplog):
         platform.temp_sensors = ["different", "sensors"]
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             platform.starting_temperatures = {"a": 1000, "b": 2000}
 
         expect = "Inconsistent sensors. ['a', 'b'] vs ['different', 'sensors']"
@@ -41,7 +42,7 @@ class TestGenericPlatform(BaseKrunTest):
     def test_inconsistent_sensors0003(self, platform, caplog):
         platform.temp_sensors = ["a"]
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             platform.starting_temperatures = {"a": 1000, "b": 2000}
 
         expect = "Inconsistent sensors. ['a', 'b'] vs ['a']"

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -1,6 +1,7 @@
 import pytest
 import krun.platform
 from krun.tests import BaseKrunTest, subst_env_arg
+from krun.util import FatalKrunError
 import sys
 from StringIO import StringIO
 
@@ -52,7 +53,7 @@ class TestLinuxPlatform(BaseKrunTest):
                             "_open_kernel_config_file",
                             mock_open_kernel_config_file)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             krun.platform.LinuxPlatform._check_tickless_kernel(platform)
 
     def test_tickless0003(self, monkeypatch, platform):
@@ -71,7 +72,7 @@ class TestLinuxPlatform(BaseKrunTest):
                             "_open_kernel_config_file",
                             mock_open_kernel_config_file)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             krun.platform.LinuxPlatform._check_tickless_kernel(platform)
 
     def test_tickless0004(self, monkeypatch, platform):
@@ -89,7 +90,7 @@ class TestLinuxPlatform(BaseKrunTest):
                             "_open_kernel_config_file",
                             mock_open_kernel_config_file)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             krun.platform.LinuxPlatform._check_tickless_kernel(platform)
 
     def test_tickless0005(self, monkeypatch, platform, caplog):
@@ -114,7 +115,7 @@ class TestLinuxPlatform(BaseKrunTest):
                             "_get_kernel_cmdline",
                             dummy_get_kernel_cmdline)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             krun.platform.LinuxPlatform._check_tickless_kernel(platform)
 
         assert "Adaptive-ticks CPUs overridden on kernel command line" \

--- a/krun/tests/test_openbsdplatform.py
+++ b/krun/tests/test_openbsdplatform.py
@@ -2,7 +2,7 @@ import pytest
 import krun.platform
 import sys
 from krun.tests import BaseKrunTest, subst_env_arg
-from krun.util import run_shell_cmd
+from krun.util import run_shell_cmd, FatalKrunError
 
 
 def make_dummy_get_apm_output_fn(output):
@@ -60,7 +60,7 @@ class TestOpenBSDPlatform(BaseKrunTest):
         monkeypatch.setattr(krun.platform.OpenBSDPlatform,
                             "_raw_read_temperature_sensor", dummy)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             platform.take_temperature_readings()
 
         assert "Odd non-degC value" in caplog.text()
@@ -75,7 +75,7 @@ class TestOpenBSDPlatform(BaseKrunTest):
         monkeypatch.setattr(krun.platform.OpenBSDPlatform,
                             "_raw_read_temperature_sensor", dummy)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             platform.take_temperature_readings()
 
         assert "Non-numeric value" in caplog.text()
@@ -90,7 +90,7 @@ class TestOpenBSDPlatform(BaseKrunTest):
         monkeypatch.setattr(krun.platform.OpenBSDPlatform,
                             "_raw_read_temperature_sensor", dummy)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             platform.take_temperature_readings()
 
         assert "Odd non-degC value" in caplog.text()
@@ -118,7 +118,7 @@ class TestOpenBSDPlatform(BaseKrunTest):
         monkeypatch.setattr(krun.platform.OpenBSDPlatform,
                             "_get_apm_output", monkey_func)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FatalKrunError):
             platform._check_apm_state()
         assert "Expected 3 lines of output from apm(8)" in caplog.text()
 


### PR DESCRIPTION
Fixes #150 (since we can scp off results with `POST_EXEC_CMDS`and #160 (since we can kill daemons with a `PRE_EXECUTION_CMDS`).

OK?