### PR TITLE
Move pre/post execution hooks.

### DIFF
--- a/krun/results.py
+++ b/krun/results.py
@@ -1,5 +1,6 @@
 from krun.audit import Audit
 from krun.config import Config
+from logging import debug
 
 import bz2  # decent enough compression with Python 2.7 compatibility.
 import json
@@ -73,8 +74,10 @@ class Results(object):
             self.audit = results["audit"]
 
     def write_to_file(self):
-        """Serialise object on disk.
-        """
+        """Serialise object on disk."""
+
+        debug("Writing results out to: %s" % self.filename)
+
         to_write = {
             "config": self.config.text,
             "data": self.data,

--- a/krun/tests/__init__.py
+++ b/krun/tests/__init__.py
@@ -8,6 +8,11 @@ import os
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
+
+
 def subst_env_arg(lst, var):
     """Returns a copy of the list with elements starting with 'var=' changed to
     literally 'var='. Used in tests where an environment variable argument to

--- a/krun/tests/test_scheduler.py
+++ b/krun/tests/test_scheduler.py
@@ -4,6 +4,7 @@ from krun.results import Results
 from krun.scheduler import mean, ExecutionJob, ExecutionScheduler, JobMissingError
 from krun.tests import BaseKrunTest
 import krun.util
+from krun.tests import no_sleep
 
 import os, pytest, subprocess
 from krun.tests import TEST_DIR


### PR DESCRIPTION
This moves the pre/post execution hooks up from the Job into the Scheduler so that we can do the post-exec hook after we dump results out.

Also make tests run faster.

OK?