### PR TITLE
Implement a closed temperature interval when waiting for sensors.

### DIFF
--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -282,7 +282,7 @@ class ExecutionScheduler(object):
         self.platform.collect_starting_dmesg()
 
         while True:
-            self.platform.wait_until_cool()
+            self.platform.wait_for_temperature_sensors()
 
             jobs_left = len(self)
             if jobs_left == 0:

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -26,17 +26,11 @@ class MockPlatform(BasePlatform):
     def check_dmesg_for_changes(self):
         pass
 
-    def wait_until_cpu_cool(self):
-        pass
-
     def CHANGE_USER_CMD(self):
         pass
 
     def take_temperature_readings(self):
-        pass
-
-    def has_cooled(self):
-        return True, None  # pretend we cooled down OK
+        return {}
 
     def check_preliminaries(self):
         pass

--- a/krun/tests/test_genericplatform.py
+++ b/krun/tests/test_genericplatform.py
@@ -1,17 +1,40 @@
-from krun.tests import BaseKrunTest
+from krun.tests import BaseKrunTest, no_sleep
 from krun.util import FatalKrunError
 import pytest
 
 class TestGenericPlatform(BaseKrunTest):
     """Platform tests that can be run on any platform"""
 
-    def test_temperature_thresholds(self, mock_platform):
+    def test_temperature_thresholds0001(self, mock_platform, monkeypatch, caplog):
         temps = {"x": 30.0, "y": 12.34, "z": 666.0}
         mock_platform.temp_sensors = ["x", "y", "z"]
         mock_platform.starting_temperatures = temps
 
-        for k, v in temps.iteritems():
-            assert mock_platform.temperature_thresholds[k] == temps[k] + 1
+        def mock_take_temperature_readings():
+            # a little hotter than we started
+            return {name: temp + 1 for name, temp in temps.iteritems()}
+        monkeypatch.setattr(mock_platform,"take_temperature_readings",
+                            mock_take_temperature_readings)
+
+        mock_platform.wait_for_temperature_sensors()
+        # should exit without crashing, no assert.
+
+    def test_temperature_thresholds0002(self, mock_platform, monkeypatch, caplog):
+        temps = {"x": 30.0}
+        mock_platform.temp_sensors = ["x"]
+        mock_platform.starting_temperatures = temps
+
+        def mock_take_temperature_readings():
+            return {"x": 999}  # system on fire
+        monkeypatch.setattr(mock_platform,"take_temperature_readings",
+                            mock_take_temperature_readings)
+
+        with pytest.raises(FatalKrunError):
+            mock_platform.wait_for_temperature_sensors()
+
+        expect = ("Temperature timeout: Temperature reading 'x' not "
+                  "within interval: (27 <= 999 <= 33)")
+        assert expect in caplog.text()
 
     def test_inconsistent_sensors0001(self, platform, caplog):
         # The platform has already detected the available sensors. Now we


### PR DESCRIPTION
This implements a temperature interval 3 degrees either side of the starting temperatures. The sensor must fall within the interval before we continue.

Also wait longer (up to an hour now).

Also improves timeout message: Fix #176.

OK?