### PR TITLE
Try to send an email when a FatalKrunError is recieved.

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -7,7 +7,7 @@ usage: runner.py <config_file.krun>
 """
 
 import argparse, json, logging, os, sys
-from logging import debug, info, warn
+from logging import debug, info, warn, error
 import locale
 import time
 
@@ -288,7 +288,9 @@ def main(parser):
     try:
         sched.run()
     except util.FatalKrunError as e:
-        util.run_shell_cmd_list(config.POST_SESSION_CMDS)
+        subject = "Fatal Krun Exception"
+        mailer.send(subject, e.args[0], bypass_limiter=True)
+        util.run_shell_cmd_list(config.POST_EXECUTION_CMDS)
         raise e
 
 
@@ -330,5 +332,5 @@ if __name__ == "__main__":
 
     try:
         main(parser)
-    except util.FatalKrunError:
-        pass
+    except util.FatalKrunError as e:
+        sys.exit(1)

--- a/krun/util.py
+++ b/krun/util.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import os
 from subprocess import Popen, PIPE
 from logging import error, debug
@@ -25,8 +24,9 @@ def fatal(msg):
     error(msg)
 
     # We raise, then later this is trapped in an attempt to run the user's
-    # post-session commands.
-    raise FatalKrunError()
+    # post-session commands. The message is stashed inside the exception so
+    # that we can send an email indicating the problem later.
+    raise FatalKrunError(msg)
 
 
 def log_and_mail(mailer, log_fn, subject, msg, exit=False, bypass_limiter=False):


### PR DESCRIPTION
This adds code which tries to send an email when something has gone wrong. This should make it easier to know when something has gone wrong (instead of waiting until the results file seems to have taken too long to appear on bencher2).

Additional tweaks:

 * Fix broken exception handler which referenced the post-session hook we since removed.
 * Exit with non-zero return code if we fail.
 * Include hostname in subject line of emails (useful when we have several hosts running)
 * sendmail(8) on OpenBSD returns exit code 75 if smtpd is not running. The mail is still submitted, and when the post-execution hooks bring smptd back up, the mail is delivered OK. At a loss for a better plan of action, I have downgraded the error message to a warning message. This situation *can* happen; if a benchmark crashes, we will get mailed stdout and stderr, (all *after* the execution, so the I/O is OK).

There is still a section of code in `main()` which can raise a `FatalKrunException` outside of our handler. We would not recieve an email if these exceptions fire. Do you think it's worth trying to refactor `main` to cover these code paths too?

In reading our mailer code I see a bug. See #181.

Fixes #177.

OK? CC @snim2 