### PR TITLE
Implement a simple result stripper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,31 @@ been prepared for reliable benchmarking.
 Note that you should not collect results intended for publication with
 `--develop`.
 
+## Re-running Part of your Experiment
+
+Sometimes it is necessary to re-run a subset of your experiment. For example,
+if after completing an experiment, you find that one of your VMs was
+miscompiled, you may want to re-run all benchmarks for the troublesome VM only.
+Of course, under ideal circumstances, you would collect all results in one go.
+
+You can use the `--strip-results` mode to strip results from your result file.
+Once stripped, you can run with `--resume` to re-collect the results you
+stripped.
+
+The switch accepts a "key-spec". All process executions matching the key-spec
+are removed. A key-spec is of the form 'benchmark:vm:variant". Any of the three
+fields can also be a star '*' to indicate a wildcard. E.g. `--strip-results
+'*:CPython:*'` will remove all results for the 'CPython' VM. If ou use a
+wildcard, be sure to quote the argument so the shell does not expand the stars.
+
+Note also that the stars are not true wildcards. E.g. the key-spec '*:CPy*:*'
+will not match 'mybenchmark:CPython:myvariant'. Fields are either a value or
+literally '*'.
+
+Once you have stripped results, if you ran an experiment in reboot mode you
+will need to reboot manually to re-run the stripped results (with rc.local set
+up correctly).
+
 ## Licenses
 
 The *nbody* benchmark comes from the Computer Language Benchmarks Game, which

--- a/krun.py
+++ b/krun.py
@@ -132,7 +132,11 @@ def create_arg_parser():
                         help=("Enable developer mode"))
     parser.add_argument("--info", action="store_true",
                         help=("Print session info for specified "
-                              "config file and exit")),
+                              "config file and exit"))
+    parser.add_argument("--strip-results", action="store",
+                        metavar="KEY-SPEC",
+                        help="Strip result key from results file")
+
     filename_help = ("Krun configuration or results file. FILENAME should" +
                      " be a configuration file when running benchmarks " +
                      "(e.g. experiment.krun) and a results file " +
@@ -183,6 +187,10 @@ def main(parser):
         # Info mode doesn't run the experiment.
         # Just prints some metrics and exits.
         util.print_session_info(config)
+        return
+
+    if args.strip_results:
+        util.strip_results(config, args.strip_results)
         return
 
     attach_log_file(config, args.resume)

--- a/krun/results.py
+++ b/krun/results.py
@@ -1,6 +1,7 @@
 from krun.audit import Audit
 from krun.config import Config
-from logging import debug
+from logging import debug, info
+from krun.util import fatal
 
 import bz2  # decent enough compression with Python 2.7 compatibility.
 import json
@@ -107,3 +108,47 @@ class Results(object):
                 self.starting_temperatures == other.starting_temperatures and
                 self.eta_estimates == other.eta_estimates and
                 self.error_flag == other.error_flag)
+
+    def strip_results(self, key_spec):
+        debug("Strip results: %s" % key_spec)
+
+        spec_elems = key_spec.split(":")
+        if len(spec_elems) != 3:
+            fatal("malformed key spec: %s" % key_spec)
+
+        new_data = self.data.copy()
+        removed_keys = 0
+        removed_execs = 0
+
+        # We have to keep track of how many executions have run successfully so
+        # that we can set self.reboots accordingly. It's not correct to simply
+        # deduct one for each execution we remove, as the reboots value is one
+        # higher due to the initial reboot. Bear in mind the user may strip
+        # several result keys in succession, so counting the completed
+        # executions is the only safe way.
+        completed_execs = 0
+
+        for key in self.data.iterkeys():
+            key_elems = key.split(":")
+            # deal with wildcards
+            for i in xrange(3):
+                if spec_elems[i] == "*":
+                    key_elems[i] = "*"
+
+            # decide whether to remove
+            if key_elems == spec_elems:
+                removed_keys += 1
+                removed_execs += len(new_data[key])
+                new_data[key] = []
+                self.eta_estimates[key] = []
+                info("Removed results for: %s" % key)
+            else:
+                completed_execs += len(new_data[key])
+
+        self.data = new_data
+
+        # If the results were collected with reboot mode, update reboots count
+        if self.reboots != 0:
+            self.reboots = completed_execs
+
+        return removed_keys

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -3,7 +3,7 @@ from krun.util import (format_raw_exec_results,
                        check_and_parse_execution_results,
                        run_shell_cmd, get_git_version,
                        ExecutionFailed, get_session_info,
-                       run_shell_cmd_list, FatalKrunError)
+                       run_shell_cmd_list, FatalKrunError, strip_results)
 from krun.tests.mocks import MockMailer
 from krun.tests import TEST_DIR
 from krun.config import Config
@@ -262,3 +262,52 @@ def test_get_git_version0001():
     vers = get_git_version()
     num = int(vers, 16)
     # should not crash
+
+
+@pytest.fixture
+def to_strip():
+    from krun.platform import detect_platform
+    from krun.results import Results
+
+    path = os.path.join(TEST_DIR, "quick.krun")
+    config = Config(path)
+
+    platform = detect_platform(None)
+    results = Results(config, platform,
+                      results_file=config.results_filename())
+    return results
+
+
+def test_strip_results0001(to_strip):
+    key_spec = "dummy:CPython:default-python"
+    n_removed = to_strip.strip_results(key_spec)
+    assert n_removed == 1
+    assert to_strip.reboots == 3
+
+
+def test_strip_results0002(to_strip):
+    key_spec = "dummy:*:*"
+    n_removed = to_strip.strip_results(key_spec)
+    assert n_removed == 2
+    assert to_strip.reboots == 2
+
+
+def test_strip_results0003(to_strip):
+    key_spec = "*:*:*"
+    n_removed = to_strip.strip_results(key_spec)
+    assert n_removed == 4
+    assert to_strip.reboots == 0
+
+
+def test_strip_results0004(to_strip):
+    key_spec = "j:k:l"  # nonexistent key
+    n_removed = to_strip.strip_results(key_spec)
+    assert n_removed == 0
+    assert to_strip.reboots == 4
+
+
+def test_strip_results0005(to_strip, caplog):
+    key_spec = "jkl"  # malformed key
+    with pytest.raises(FatalKrunError):
+        to_strip.strip_results(key_spec)
+    assert "malformed key" in caplog.text()

--- a/krun/util.py
+++ b/krun/util.py
@@ -1,7 +1,7 @@
 import json
 import os
 from subprocess import Popen, PIPE
-from logging import error, debug
+from logging import error, debug, info
 
 FLOAT_FORMAT = ".6f"
 
@@ -209,3 +209,16 @@ def get_git_version():
         run_shell_cmd("sh -c 'cd %s && git rev-parse --verify HEAD'" % DIR)
 
     return out.strip()  # returns the hash
+
+
+def strip_results(config, key_spec):
+    from krun.platform import detect_platform
+    from krun.results import Results
+
+    platform = detect_platform(None)
+    results = Results(config, platform,
+                      results_file=config.results_filename())
+    n_removed = results.strip_results(key_spec)
+    if n_removed > 0:
+        results.write_to_file()
+    info("Removed %d result keys" % n_removed)


### PR DESCRIPTION
Last week we had the need to re-run the C benchmarks. I ran them as a separate experiment, but realised that the starting temperatures will differ, so this is wrong.

Using this change we could have run `krun.py --strip-results '*:C:*'` and resumed the experiment to re-run only the C experiments with the same starting temperature.

Let's not merge this hastily, as it has the potential to waste benchmarking time (e.g. run a long experiment and halfway through the reboot count is wrong).

Tested with unit tests, and with the example krun scenario. Looks good, but quite a fiddly change.