### PR TITLE
Use CPU pinning on a set of CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ using, e.g. on Linux you should be able to run `sudo`.
 
 You need to have the following installed:
 
-  * Python2.7 (other versions of Python are not supported)
-  * a Java SDK (version 7)
-  * GNU make, a C compiler and libc (e.g. `sudo apt-get install build-essential`)
-  * cpufrequtils (e.g. `sudo apt-get install cpufrequtils`)
-  * cffi (e.g. `sudo apt-get install python-cffi`)
+  * Python2.7 (pre-installed in Debian)
+  * A Java SDK 7 (`openjdk-7-jdk` package in Debian)
+  * GNU make, a C compiler and libc (`build-essential` package in Debian)
+  * cpufrequtils (Linux only. `cpufrequtils` package in Debian)
+  * cffi (`python-cffi` package in Debian)
+  * taskset (Linux only. `util-linux` package in Debian)
 
 ### Kernel arguments
 
@@ -37,14 +38,24 @@ If your Linux bootloader is Grub, you can follow these steps:
 
   * Edit /etc/default/grub (e.g. `sudo gedit /etc/default/grub`)
   * Add `intel_pstate=disable` to `GRUB_CMDLINE_LINUX_DEFAULT`
+  * Add `isolcpus=x,y,z` to `GRUB_CMDLINE_LINUX_DEFAULT`, where 'x,y,z' is a
+    comma separated list of all logical CPUs apart from the boot processor
+    (i.e. CPU 0). This ensures that the adaptive tick cores are used soley for
+    benchmarks (see 'Tickless Mode Linux Kernel').
   * Run `sudo update-grub`
 
 ### Tickless Mode Linux Kernel
 
+The Linux kernel can run in ``tickless'' configurations, where under certain
+conditions regular tick interrupts can be avoided for a subset of logical CPUs.
+More info here:
+https://www.kernel.org/doc/Documentation/timers/NO_HZ.txt
+
 On a Linux system, Krun will insist that the kernel is running in
-"full tickless" mode. Tickless mode is a compile time kernel parameter, so if it is
-not enabled, you will need to build a custom kernel.  You can verify the
-tickless mode of the current kernel with:
+"full tickless" mode with the NO_HZ_FULL_ALL compile time flag. This will place
+all logical CPUs apart from the boot processor (i.e. CPU 0) into adaptive ticks
+mode. If this is not enabled, you will need to build a custom kernel. You can
+verify the tickless mode of the current kernel with:
 
 ```
 cat /boot/config-`uname -r` | grep HZ

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -531,7 +531,7 @@ class LinuxPlatform(UnixLikePlatform):
         "CONFIG_NO_HZ_IDLE": False,
 
         # Omit scheduler ticks when an adaptive tick CPU has only one
-        # runnable process. This enbles the tickless functionality, but the
+        # runnable process. This enables the tickless functionality, but the
         # system admin must manually specify on adaptive-tick CPUs via
         # the kernel command line. By default, no CPUs are adaptive tick,
         # so we insist also upon CONFIG_NO_HZ_FULL_ALL.

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -211,7 +211,7 @@ class BasePlatform(object):
 
         Currently deals with:
           * CPU pinning (if available)
-          * Adding libkruntime to linker path
+          * Adding libkruntime.so to linker path
 
         It does not deal with changing user, as this is done one
         level up in the wrapper script."""

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -23,6 +23,9 @@ class MockPlatform(BasePlatform):
         self.num_cpus = 0
         self.developer_mode = False
 
+    def pin_process_args(self):
+        return []
+
     def check_dmesg_for_changes(self):
         pass
 

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -26,6 +26,9 @@ class MockPlatform(BasePlatform):
     def pin_process_args(self):
         return []
 
+    def change_scheduler_args(self):
+        return []
+
     def check_dmesg_for_changes(self):
         pass
 

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -122,13 +122,16 @@ class TestLinuxPlatform(BaseKrunTest):
             in caplog.text()
 
     def test_bench_cmdline_adjust0001(self, platform):
-        expect = ['env', 'LD_LIBRARY_PATH=']
+        platform.num_cpus = 8
+        expect = ['env', 'LD_LIBRARY_PATH=', 'taskset', '-c', '1,2,3,4,5,6,7']
 
         args = subst_env_arg(platform.bench_cmdline_adjust([], {}), "LD_LIBRARY_PATH")
         assert args == expect
 
     def test_bench_cmdline_adjust0002(self, platform):
-        expect = ['env', 'MYENV=some_value', 'LD_LIBRARY_PATH=', 'myarg']
+        platform.num_cpus = 2
+        expect = ['env', 'MYENV=some_value', 'LD_LIBRARY_PATH=',
+                  'taskset', '-c', '1', 'myarg']
 
         args = subst_env_arg(platform.bench_cmdline_adjust(
             ["myarg"], {"MYENV": "some_value"}), "LD_LIBRARY_PATH")

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -179,3 +179,51 @@ class TestLinuxPlatform(BaseKrunTest):
         got = platform.take_temperature_readings()
 
         assert expect == got
+
+    def test_isolcpus0001(self, platform, monkeypatch, caplog):
+        platform.num_cpus = 8
+
+        def dummy_get_kernel_cmdline():
+            return "quiet"  # isolcpus missing
+        monkeypatch.setattr(platform, "_get_kernel_cmdline",
+                            dummy_get_kernel_cmdline)
+
+        with pytest.raises(FatalKrunError):
+            platform._check_isolcpus()
+
+        find = "CPUs incorrectly isolated. Got: [], expect: ['1', '2', '3', '4', '5', '6', '7']"
+        assert find in caplog.text()
+
+    def test_isolcpus0002(self, platform, monkeypatch, caplog):
+        platform.num_cpus = 4
+
+        def dummy_get_kernel_cmdline():
+            return "quiet isolcpus=1"  # not enough
+        monkeypatch.setattr(platform, "_get_kernel_cmdline",
+                            dummy_get_kernel_cmdline)
+
+        with pytest.raises(FatalKrunError):
+            platform._check_isolcpus()
+
+        find = "CPUs incorrectly isolated. Got: ['1'], expect: ['1', '2', '3']"
+        assert find in caplog.text()
+
+    def test_isolcpus0003(self, platform, monkeypatch):
+        platform.num_cpus = 8
+
+        def dummy_get_kernel_cmdline():
+            return "quiet isolcpus=1,2,3,4,5,6,7"  # good
+        monkeypatch.setattr(platform, "_get_kernel_cmdline",
+                            dummy_get_kernel_cmdline)
+
+        platform._check_isolcpus()  # should not raise
+
+    def test_isolcpus0004(self, platform, monkeypatch):
+        platform.num_cpus = 8
+
+        def dummy_get_kernel_cmdline():
+            return "quiet isolcpus=7,2,3,4,5,6,1"  # good but odd order
+        monkeypatch.setattr(platform, "_get_kernel_cmdline",
+                            dummy_get_kernel_cmdline)
+
+        platform._check_isolcpus()  # should not raise

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -184,6 +184,7 @@ class BaseVMDef(object):
         # The arguments used to invoke the wrapper script now
         wrapper_args = \
             self.platform.change_user_args("root") + \
+            self.platform.change_scheduler_args() + \
             self.platform.process_priority_args() + \
             self.platform.change_user_args(BENCHMARK_USER) + \
             [DASH, WRAPPER_SCRIPT]

--- a/platform_sanity_checks/Makefile
+++ b/platform_sanity_checks/Makefile
@@ -1,6 +1,7 @@
 OS != uname
 
-all: check_openbsd_malloc_options.so check_nice_priority.so check_linux_cpu_affinity.so
+all: check_openbsd_malloc_options.so check_nice_priority.so \
+	check_linux_cpu_affinity.so check_linux_scheduler.so
 
 .PHONY: clean
 
@@ -20,6 +21,12 @@ check_linux_cpu_affinity.so: check_linux_cpu_affinity.c
 		check_linux_cpu_affinity.so check_linux_cpu_affinity.c \
 		; fi
 
+check_linux_scheduler.so: check_linux_scheduler.c
+	if [ "${OS}" = "Linux" ]; then \
+		${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
+		check_linux_scheduler.so check_linux_scheduler.c \
+		; fi
+
 clean:
 	rm -f check_openbsd_malloc_options.so check_nice_priority.so \
-		check_linux_cpu_affinity.so
+		check_linux_cpu_affinity.so check_linux_scheduler.so

--- a/platform_sanity_checks/Makefile
+++ b/platform_sanity_checks/Makefile
@@ -1,9 +1,9 @@
 OS != uname
 
+.PHONY: clean all
+
 all: check_openbsd_malloc_options.so check_nice_priority.so \
 	check_linux_cpu_affinity.so check_linux_scheduler.so
-
-.PHONY: clean
 
 check_openbsd_malloc_options.so: check_openbsd_malloc_options.c
 	if [ "${OS}" = "OpenBSD" ]; then \

--- a/platform_sanity_checks/Makefile
+++ b/platform_sanity_checks/Makefile
@@ -1,6 +1,6 @@
 OS != uname
 
-all: check_openbsd_malloc_options.so check_nice_priority.so
+all: check_openbsd_malloc_options.so check_nice_priority.so check_linux_cpu_affinity.so
 
 .PHONY: clean
 
@@ -14,5 +14,12 @@ check_nice_priority.so: check_nice_priority.c
 	${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -shared -Wall -Wextra -o \
 		check_nice_priority.so check_nice_priority.c
 
+check_linux_cpu_affinity.so: check_linux_cpu_affinity.c
+	if [ "${OS}" = "Linux" ]; then \
+		${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
+		check_linux_cpu_affinity.so check_linux_cpu_affinity.c \
+		; fi
+
 clean:
-	rm -f check_openbsd_malloc_options.so check_nice_priority.so
+	rm -f check_openbsd_malloc_options.so check_nice_priority.so \
+		check_linux_cpu_affinity.so

--- a/platform_sanity_checks/Makefile
+++ b/platform_sanity_checks/Makefile
@@ -11,7 +11,7 @@ check_openbsd_malloc_options.so: check_openbsd_malloc_options.c
 		; fi
 
 check_nice_priority.so: check_nice_priority.c
-	${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -shared -Wall -Wextra -o \
+	${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
 		check_nice_priority.so check_nice_priority.c
 
 check_linux_cpu_affinity.so: check_linux_cpu_affinity.c

--- a/platform_sanity_checks/check_linux_cpu_affinity.c
+++ b/platform_sanity_checks/check_linux_cpu_affinity.c
@@ -1,0 +1,58 @@
+/*
+ * Dummy benchmark that checks the CPU affinity for a benchmark.
+ *
+ * We are assuming the Linux kernel is NO_HZ_FULL_ALL tickless, so the affinity
+ * should be all but the boot processor (all the other CPUs will be in adaptive
+ * tick mode)
+ *
+ * This code is Linux specific.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sched.h>
+#include <unistd.h>
+
+
+void
+run_iter(int param)
+{
+    pid_t pid;
+    cpu_set_t mask;
+    size_t mask_sz;
+    int ret, i;
+    long n_cpus;
+
+    (void) param;
+    pid = getpid();
+    n_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+    mask_sz = sizeof(mask);
+
+    ret = sched_getaffinity(pid, mask_sz, &mask);
+    if (ret != 0) {
+        perror("sched_getaffinity");
+        exit(EXIT_FAILURE);
+    }
+
+    if (CPU_COUNT(&mask) != n_cpus - 1) {
+        fprintf(stderr, "Wrong number of CPUs in affinity mask\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if (CPU_ISSET(0, &mask)) {
+        fprintf(stderr, "CPU 0 should not be in affinity mask\n");
+        exit(EXIT_FAILURE);
+    }
+
+    for (i = 1; i < n_cpus; i++) {
+        if (!CPU_ISSET(i, &mask)) {
+            fprintf(stderr, "CPU %d not in affinity mask\n", i);
+            exit(EXIT_FAILURE);
+        }
+    }
+}

--- a/platform_sanity_checks/check_linux_scheduler.c
+++ b/platform_sanity_checks/check_linux_scheduler.c
@@ -1,0 +1,36 @@
+/* Fake benchmark that checks the right scheduler and priority is used on Linux */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+#include <err.h>
+
+#define EXPECT_POLICY SCHED_FIFO
+
+void
+run_iter(int param) {
+    int policy, rv, max_prio;
+    struct sched_param s_param;
+
+    (void) param;
+
+    policy = sched_getscheduler(0);
+    if (policy != EXPECT_POLICY) {
+        fprintf(stderr, "Incorrect scheduler in use.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    max_prio = sched_get_priority_max(EXPECT_POLICY);
+
+    rv = sched_getparam(0, &s_param);
+    if (rv != 0) {
+        perror("sched_getparam");
+        exit(EXIT_FAILURE);
+    }
+
+    if (s_param.sched_priority != max_prio) {
+        fprintf(stderr, "Wrong scheduler priority: expect %d, got %d.\n",
+            max_prio, s_param.sched_priority);
+        exit(EXIT_FAILURE);
+    }
+}


### PR DESCRIPTION
Talks with Intel suggest that we should pin our benchmarks to a *set* of isolated cores. For us it makes a great deal of sense to isolate and pin to our adaptive ticks CPUs (all but the boot CPU due to `NO_HZ_FULL_ALL`).

This set of commits:

 * Ensures the adaptive ticks CPUs are isolated and guides the user if not.
 * Uses taskset to pin benchmarks with the correct affinity mask.
 * Tests all of this.
 * Sanity checks the affinity of benchmarks with a C program.
 * Updates related documentation.

The code was loosely based upon the previously reverted pinning code, where we pinned to one CPU only.

After all of this I ran a jruby benchmark and used top to check how the threads are being scheduled. Here is how it looks:

![affin2](https://cloud.githubusercontent.com/assets/604955/14497170/d20d5496-018d-11e6-88c4-ce90cd5a89f1.png)


The benchmark threads have the correct affinity, and are on an adaptive ticks CPU, but all threads run on the same CPU. I think we were expecting the threads to be spread out over the CPUs in the affinity mask (all CPUs apart from CPU 0). The left hand pane in the screen shot is showing that the affinity mask is correctly set.

Having seen this, I wondered if taskset has caused all threads to all go on one core. I commented out the use of taskset and the accompanying sanity check and re-ran. This time all threads are scheduled on the boot processor.

What this means is that JRuby does not and has never utilised >1 CPU despite having loads of threads. Further, I can't say why removing pinning with a single CPU in the affinity mask (as we did a little while back) gave a speed-up.

Raising the PR for code review and discussion. Please don't merge yet.

Next port of call: write a small C program which spawns a load of threads. I want to know if threads simply default to being scheduled on the same CPU as their parent, or if the JVM is forcing all the threads on one core somehow.

Thanks

cc @ltratt for discussion