### PR TITLE
Add environment vars for ETA, and add sleeps to ETA.

### DIFF
--- a/examples/example.krun
+++ b/examples/example.krun
@@ -66,5 +66,11 @@ N_EXECUTIONS = 2  # Number of fresh processes.
 TEMP_READ_PAUSE = 1
 
 # Commands to run before and after each process execution
+#
+# Environment available for these commands:
+#   KRUN_RESULTS_FILE: path to results file.
+#   KRUN_LOG_FILE: path to log file.
+#   KRUN_ETA_DATUM: time the ETA was computed
+#   KRUN_ETA_VALUE: estimated time of completion
 #PRE_EXECUTION_CMDS = ["sudo service cron stop"]
 #POST_EXECUTION_CMDS = ["sudo service cron start"]

--- a/krun.py
+++ b/krun.py
@@ -186,6 +186,7 @@ def main(parser):
         return
 
     attach_log_file(config, args.resume)
+    debug("Krun invoked with arguments: %s" % sys.argv)
 
     mail_recipients = config.MAIL_TO
     if type(mail_recipients) is not list:

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -21,6 +21,7 @@ from krun.env import EnvChangeSet, EnvChange, EnvChangeAppend
 NICE_PRIORITY = -20
 DIR = os.path.abspath(os.path.dirname(__file__))
 LIBKRUNTIME_DIR = os.path.join(DIR, "..", "libkrun")
+SYNC_SLEEP_SECS = 30  # time to wait for sync() to finish
 
 
 class BasePlatform(object):
@@ -355,7 +356,7 @@ class UnixLikePlatform(BasePlatform):
         # the buffers are completely flushed.", and the sync command is merely
         # a thin wrapper around the syscall. We wait a while. We have reports
         # that the sync command itself can take up to 10 seconds.
-        time.sleep(30)
+        time.sleep(SYNC_SLEEP_SECS)
 
 
 class OpenBSDPlatform(UnixLikePlatform):

--- a/krun/time_estimate.py
+++ b/krun/time_estimate.py
@@ -33,3 +33,8 @@ class TimeEstimateFormatter(object):
             return str(self.delta).split(".")[0]
         else:
             return UNKNOWN_TIME_DELTA
+
+def now_str():
+    """Just return the time now (formatted)"""
+
+    return str(datetime.datetime.now().strftime(ABS_TIME_FORMAT))


### PR DESCRIPTION
Opening for discussion.

This adds two environment variables to the pre/post hook environment:

 * `KRUN_ETA_DATUM`
 * `KRUN_ETA_VALUE`

It also attempts to take sleeps for sync() and waiting for the system to come up.

I hacked the sync wait to 5 seconds, and used the following hooks:

```
PRE_EXECUTION_CMDS = [                                                          
    'echo "At ${KRUN_ETA_DATUM} ETA is ${KRUN_ETA_VALUE}" >> eta_pre.log'       
]                                                                               
POST_EXECUTION_CMDS = [                                                         
    'echo "At ${KRUN_ETA_DATUM} ETA is ${KRUN_ETA_VALUE}" >> eta_post.log'      
]                                                                               
```

Then I ran without reboots.

Seems to work at first glance:

```
wilfred:examples] cat eta_post.log 
At 2016-04-18 16:35:13 ETA is Unknown. Known in 1 process executions.
At 2016-04-18 16:35:31 ETA is 2016-04-18 16:36:47
At 2016-04-18 16:35:41 ETA is 2016-04-18 16:36:42
At 2016-04-18 16:35:46 ETA is 2016-04-18 16:36:37
At 2016-04-18 16:35:56 ETA is 2016-04-18 16:36:32
At 2016-04-18 16:36:02 ETA is 2016-04-18 16:36:27
At 2016-04-18 16:36:12 ETA is 2016-04-18 16:36:22
At 2016-04-18 16:36:30 ETA is 2016-04-18 16:36:30
```
But what confuses me is that the estimates are frequently too pessimistic (estimates are frequently longer than in reality), whereas (unless the example benchmark had a variance in the order of seconds) I would expect the estimates to be too optimistic, as there are other delays (e.g. temperature waits, time for the hooks to execute), which are not (and cannot be easily) accounted for in the ETA.

I must be missing something. Will continue to work on this, but shout if you have an idea.