### PR TITLE
More info in results

### DIFF
--- a/krun/platform.py
+++ b/krun/platform.py
@@ -206,6 +206,7 @@ class BasePlatform(object):
         self.audit["uname"] = run_shell_cmd("uname -a")[0]
         self.audit["dmesg"] = run_shell_cmd("dmesg")[0]
         self.audit["krun_version"] = util.get_git_version()
+        self.audit["cli_args"] = sys.argv
 
     def bench_cmdline_adjust(self, args, env_dct):
         """Prepends various arguments to benchmark invocation.

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -205,6 +205,7 @@ class BasePlatform(object):
     def collect_audit(self):
         self.audit["uname"] = run_shell_cmd("uname -a")[0]
         self.audit["dmesg"] = run_shell_cmd("dmesg")[0]
+        self.audit["krun_version"] = util.get_git_version()
 
     def bench_cmdline_adjust(self, args, env_dct):
         """Prepends various arguments to benchmark invocation.

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -1,7 +1,7 @@
 from krun.util import (format_raw_exec_results,
                        log_and_mail, fatal,
                        check_and_parse_execution_results,
-                       run_shell_cmd,
+                       run_shell_cmd, get_git_version,
                        ExecutionFailed, get_session_info,
                        run_shell_cmd_list, FatalKrunError)
 from krun.tests.mocks import MockMailer
@@ -256,3 +256,9 @@ def test_run_shell_cmd_list0003(caplog):
 
     expect = "Environment HOME is already defined"
     assert expect in caplog.text()
+
+
+def test_get_git_version0001():
+    vers = get_git_version()
+    num = int(vers, 16)
+    # should not crash

--- a/krun/util.py
+++ b/krun/util.py
@@ -193,3 +193,19 @@ def make_heat():
     for i in xrange(10000000):
         j += 1
     assert j == 10000000
+
+
+def get_git_version():
+    """Ask the krun checkout for its version. This assumes that Krun is run
+    from a git clone. If we decide to package this into (e.g.) PyPI at a later
+    date, then we would have to re-think this.
+    """
+
+    from distutils.spawn import find_executable
+    if not find_executable("git"):
+        fatal("git not found in ${PATH}. Please install git.")
+
+    out, err, code = \
+        run_shell_cmd("sh -c 'cd %s && git rev-parse --verify HEAD'" % DIR)
+
+    return out.strip()  # returns the hash


### PR DESCRIPTION
This change:

 * Adds debug output for the CLI args (does not appear in production mode)
 * Adds CLI args to the audit, which appears in the results file.
 * Inserts Krun git hash into the audit.

The latter two are re-written upon each reboot. I think that is good enough for now.

OK?

Fixes #141 
