### PR TITLE
New Linux pinning strategy using a cset shield. Pin by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,22 @@ You need to have the following installed:
   * GNU make, a C compiler and libc (`build-essential` package in Debian)
   * cpufrequtils (Linux only. `cpufrequtils` package in Debian)
   * cffi (`python-cffi` package in Debian)
-  * taskset (Linux only. `util-linux` package in Debian)
+  * cset (for pinning on Linux only. `cpuset` package in Debian)
+
+Note that to use pinning on Linux, `cset shield` must be in a working state.
+Some Linux distributions have been known to ship with this functionality
+broken. See the `cset` tutorial for information on how to test `cset shield`:
+https://rt.wiki.kernel.org/index.php/Cpuset_Management_Utility/tutorial
 
 ### Kernel arguments
 
-If you are using a Linux system, you will need to set some kernel arguments.
-If your Linux bootloader is Grub, you can follow these steps:
+If you are using a Linux system, you will need to set a kernel arguments to
+disable Intel P-states. If your Linux bootloader is Grub, you can follow these
+steps:
 
   * Edit /etc/default/grub (e.g. `sudo gedit /etc/default/grub`)
   * Add `intel_pstate=disable` to `GRUB_CMDLINE_LINUX_DEFAULT`
-  * If you want to use CPU pinning, add `isolcpus=x,y,z` to
-    `GRUB_CMDLINE_LINUX_DEFAULT`, where 'x,y,z' is a comma separated list of
-    all logical CPUs apart from the boot processor.
-    (i.e. CPU 0). This ensures that the adaptive tick cores are used soley for
-    benchmarks (see 'Tickless Mode Linux Kernel').
   * Run `sudo update-grub`
-
-Note that CPU pinning is off by default due to a bug in the Linux kernel:
-https://bugzilla.kernel.org/show_bug.cgi?id=116701
 
 ### Tickless Mode Linux Kernel
 

--- a/examples/example.krun
+++ b/examples/example.krun
@@ -75,5 +75,5 @@ TEMP_READ_PAUSE = 1
 #PRE_EXECUTION_CMDS = ["sudo service cron stop"]
 #POST_EXECUTION_CMDS = ["sudo service cron start"]
 
-# CPU pinning (off by default)
-#ENABLE_PINNING = False
+# CPU pinning (on by default)
+#ENABLE_PINNING = True

--- a/krun/config.py
+++ b/krun/config.py
@@ -27,7 +27,7 @@ class Config(object):
         self.HEAP_LIMIT = None
         self.STACK_LIMIT = None
         self.TEMP_READ_PAUSE = 60
-        self.ENABLE_PINNING = False
+        self.ENABLE_PINNING = True
 
         self.PRE_EXECUTION_CMDS = []
         self.POST_EXECUTION_CMDS = []

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -225,12 +225,7 @@ class BasePlatform(object):
         changes = self.bench_env_changes()
         EnvChange.apply_all(changes, combine_env)
 
-        new_args = self.adjust_env_cmd(combine_env)
-        if self.config.ENABLE_PINNING:
-            new_args += self.pin_process_args()
-        new_args += args
-
-        return new_args
+        return self.adjust_env_cmd(combine_env) + args
 
     @abstractmethod
     def _change_user_args(self, user="root"):
@@ -278,10 +273,6 @@ class BasePlatform(object):
 
     @abstractmethod
     def pin_process_args(self):
-        pass
-
-    @abstractmethod
-    def change_scheduler_args(self):
         pass
 
 
@@ -506,9 +497,6 @@ class OpenBSDPlatform(UnixLikePlatform):
     def pin_process_args(self):
         return []  # not supported on OpenBSD
 
-    def change_scheduler_args(self):
-        return []  # no control over scheduler
-
 
 class LinuxPlatform(UnixLikePlatform):
     """Deals with aspects generic to all Linux distributions. """
@@ -520,12 +508,8 @@ class LinuxPlatform(UnixLikePlatform):
     CPU_SCALER_FMT = "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_driver"
     KERNEL_ARGS_FILE = "/proc/cmdline"
     ASLR_FILE = "/proc/sys/kernel/randomize_va_space"
-
-    # The best realtime scheduler for our purposes. Also correctly schedules
-    # threads when a process is forced onto isolated cores:
-    # http://stackoverflow.com/questions/36604360/why-does-using-taskset-to-run-a-multi-threaded-linux-program-on-a-set-of-isolate
-    SCHED_ALGO = "fifo"
-    SCHED_RT_RUNTIME_US = "/proc/sys/kernel/sched_rt_runtime_us"
+    CSET_CMD = "/usr/bin/cset"
+    USER_CSET_DIR = "/cpusets/user"
 
     # Expected tickless kernel config
     #
@@ -651,53 +635,46 @@ class LinuxPlatform(UnixLikePlatform):
     def check_preliminaries(self):
         """Checks the system is in a suitable state for benchmarking"""
 
-        self._check_util_linux_installed()
+        self._check_cset_installed()
         self._check_isolcpus()
+        self._check_cset_shield()
         self._check_cpu_governor()
         self._check_cpu_scaler()
         self._check_perf_samplerate()
         self._check_tickless_kernel()
         self._check_aslr_disabled()
-        self._check_realtime_throttle_disabled()
 
-    def _check_realtime_throttle_disabled(self):
-        """Linux kernel gets pretty upset if you run a CPU intensive thread
-        under the real-time thread schedule policy. By default Linux will
-        artificially pre-empt such threads to give other things a chance to run
-        on this core. A switch will flip at runtime leaving a message in dmesg
-        when this comes into effect.
+    # separate for testing
+    def _configure_cset_shield_args(self):
+        """Returns the commands (as a list of list of args)
+        needed to set up/destroy a shield"""
 
-        See the "Limiting the CPU usage of real-time and deadline processes"
-        section in sched(7).
+        if self.config.ENABLE_PINNING:
+            # create shield on all cores but boot core.
+            # OK to create shield when one is already created.
+            cpus = "1-%s" % (self.num_cpus - 1)
+            cmd1 =  self.change_user_args("root") + \
+                [LinuxPlatform.CSET_CMD, "shield", "-c", cpus]
+            # move as many kernel threads as you can, please
+            cmd2 = [LinuxPlatform.CSET_CMD, "shield", "-k", "on"]
+            return [cmd1, cmd2]
+        else:
+            # destroy shield (if existing)
+            if os.path.exists(LinuxPlatform.USER_CSET_DIR):
+                return [self.change_user_args("root") + \
+                    [LinuxPlatform.CSET_CMD, "shield", "-r"]]
+            else:
+                return []  # no commands
 
-        We don't want "throttling" on the benchmarking cores.
+    def _check_cset_shield(self):
+        """Create/reset and check cset sheild status"""
 
-        From sched(7):
-
-        "Specifying [sched_rt_runtime_us] -1 makes the runtime the same as the
-        period; that is, no CPU time is set aside for non-real-time processes."
-        """
-
-        debug("Check real-time thread throttling is off")
-
-        for itr in xrange(2):
-            with open(LinuxPlatform.SCHED_RT_RUNTIME_US) as fh:
-                val = fh.read().strip()
-
-            if val != "-1":
-                if itr == 0:
-                    debug("%s is not -1, adjusting." % LinuxPlatform.SCHED_RT_RUNTIME_US)
-
-                    # Needs to happen as root
-                    args = self.change_user_args() +  \
-                        ["sh", "-c",
-                         "'echo -1 > %s'" % LinuxPlatform.SCHED_RT_RUNTIME_US]
-
-                    cmd = " ".join(args)
-                    run_shell_cmd(cmd)
-                else:
-                    fatal("Could not set %s to -1" %
-                          LinuxPlatform.SCHED_RT_RUNTIME_US)
+        debug("create/check/remove cset shield")
+        cmds = self._configure_cset_shield_args()
+        for args in cmds:
+            cmd = " ".join(args)
+            out, _, _ = run_shell_cmd(cmd)
+            debug(out)  # cset is quite chatty on stdout
 
     @staticmethod
     def _tickless_config_info_str(modes):
@@ -897,35 +874,37 @@ class LinuxPlatform(UnixLikePlatform):
         return cmd
 
     def pin_process_args(self):
-        """Pin to a set of adaptive tick CPUs.
-        We are working the assumption that the kernel is NO_HZ_FULL_ALL meaning
-        that all but the first CPU are in adaptive tick mode."""
+        """Pin to a set of isolated (via cset shield), adaptive tick CPUs."""
 
         if self.num_cpus == 1:
             fatal("not enough CPUs to pin")
 
-        cpus = ",".join([str(x) for x in xrange(1, self.num_cpus)])
-        return ["taskset", "-c", cpus]
+        # cset shielding requires root
+        # double dash signifies end of cset args
+        return self.change_user_args("root") + \
+            [LinuxPlatform.CSET_CMD, "shield", "-e", "--"]
 
-    def _check_util_linux_installed(self):
-        debug("Check util-linux is installed")
+    def _check_cset_installed(self):
+        debug("Check cset is installed")
 
         from distutils.spawn import find_executable
-        if not find_executable("taskset"):
-            fatal("util-linix is not installed "
-                  "(needed for pinning and scheduler tweaking).")
+        if not find_executable("cset"):
+            fatal("cset is not installed (needed for pinning).")
 
     def sanity_checks(self):
         UnixLikePlatform.sanity_checks(self)
-        if self.config.ENABLE_PINNING:
-            self._sanity_check_cpu_affinity()
-            self._sanity_check_scheduler()
+        self._sanity_check_cpu_affinity()
+        self._sanity_check_scheduler()
 
     def _sanity_check_cpu_affinity(self):
         from krun.vm_defs import NativeCodeVMDef
         from krun import EntryPoint
 
-        ep = EntryPoint("check_linux_cpu_affinity.so")
+        if self.config.ENABLE_PINNING:
+            ep = EntryPoint("check_linux_cpu_affinity_pinned.so")
+        else:
+            ep = EntryPoint("check_linux_cpu_affinity_not_pinned.so")
+
         vd = NativeCodeVMDef()
         util.spawn_sanity_check(self, ep, vd, "CPU affinity",
                                 force_dir=PLATFORM_SANITY_CHECK_DIR)
@@ -939,29 +918,19 @@ class LinuxPlatform(UnixLikePlatform):
         util.spawn_sanity_check(self, ep, vd, "Scheduler",
                                 force_dir=PLATFORM_SANITY_CHECK_DIR)
 
-    def _advise_isolcpus_arg(self, got_cpus, expect_cpus):
-        """Error out and guide user in isolating CPUs"""
-
-        arg = "isolcpus=%s" % ",".join(expect_cpus)
-        self._fatal_kernel_arg(
-            arg, "CPUs incorrectly isolated. Got: %s, expect: %s" %
-            (got_cpus, expect_cpus)
-        )
-
     def _check_isolcpus(self):
-        """Checks the correct CPUs have been isolated if pinning is enabled.
-        (All but the boot processor)
+        """Checks that the isolcpus kernel arg is not in use.
 
-        Conversely check cores are *not* isolated if pinning is disabled.
+        We used to use isolcpus to run processes on isolated cores, but this --
+        at the time -- had issues for multi-threaded programs:
+        https://bugzilla.kernel.org/show_bug.cgi?id=116701
+
+        Now we achieve the correct behaviour using a cset shield, which is
+        arguably better anyway, as it moves (some) kernel threads off the
+        benchmarking cores too.
         """
 
-        debug("Check cores are isolated correctly (pinning=%s)" % \
-              self.config.ENABLE_PINNING)
-
-        if self.config.ENABLE_PINNING:
-            expect_cpus = [str(x) for x in xrange(1, self.num_cpus)]
-        else:
-            expect_cpus = []
+        debug("Check isolcpus not in use")
 
         all_args = self._get_kernel_cmdline()
 
@@ -981,18 +950,16 @@ class LinuxPlatform(UnixLikePlatform):
         else:
             got_cpus = []
 
-        if expect_cpus != got_cpus:
-            self._advise_isolcpus_arg(got_cpus, expect_cpus)  # exits
+        if got_cpus != []:
+            self._fatal_kernel_arg(
+                "isolcpus", "isolcpus should not be in the kernel command line"
+            )
 
     def _sched_get_priority_max(self):
         # If we later support other operating systems which too support static
         # thread priorities, then move this method into a super-class and call
         # out to C to sched_get_priority_max(2).
         return 99  # Linux specific maximum
-
-    def change_scheduler_args(self):
-        algo_arg = "--%s" % LinuxPlatform.SCHED_ALGO
-        return ["chrt", algo_arg, str(self._sched_get_priority_max())]
 
 
 class DebianLinuxPlatform(LinuxPlatform):
@@ -1012,7 +979,7 @@ class DebianLinuxPlatform(LinuxPlatform):
             suffix += "\n"
 
         fatal("%s"
-              "Set `%s` in the kernel arguments.\n"
+              "Set/change/remove `%s` in the kernel arguments.\n"
               "To do this on Debian:\n"
               "  * Edit /etc/default/grub\n"
               "  * Amend GRUB_CMDLINE_LINUX_DEFAULT\n"

--- a/krun/tests/test_openbsdplatform.py
+++ b/krun/tests/test_openbsdplatform.py
@@ -3,6 +3,8 @@ import krun.platform
 import sys
 from krun.tests import BaseKrunTest, subst_env_arg
 from krun.util import run_shell_cmd, FatalKrunError
+from krun import EntryPoint
+from krun.vm_defs import PythonVMDef
 
 
 def make_dummy_get_apm_output_fn(output):
@@ -147,3 +149,26 @@ class TestOpenBSDPlatform(BaseKrunTest):
         args = subst_env_arg(platform.bench_cmdline_adjust(
             ["myarg"], {"MYENV": "some_value"}), "LD_LIBRARY_PATH")
         assert args == expect
+
+    def test_wrapper_args0001(self, platform):
+        ep = EntryPoint("test")
+        vm_def = PythonVMDef('/dummy/bin/python')
+        vm_def.set_platform(platform)
+        got = vm_def._wrapper_args()
+        expect = ['/usr/local/bin/sudo', '-u', 'root', '/usr/bin/nice', '-n', '-20',
+                  '/usr/local/bin/sudo', '-u', 'krun', '/usr/local/bin/dash',
+                  '/tmp/krun_wrapper.dash']
+        assert got == expect
+
+    def test_wrapper_args0002(self, platform):
+        # Pinning isn't supported on OpenBSD, so it should make no difference
+        platform.config.ENABLE_PINNING = False
+
+        ep = EntryPoint("test")
+        vm_def = PythonVMDef('/dummy/bin/python')
+        vm_def.set_platform(platform)
+        got = vm_def._wrapper_args()
+        expect = ['/usr/local/bin/sudo', '-u', 'root', '/usr/bin/nice', '-n', '-20',
+                  '/usr/local/bin/sudo', '-u', 'krun', '/usr/local/bin/dash',
+                  '/tmp/krun_wrapper.dash']
+        assert got == expect

--- a/krun/util.py
+++ b/krun/util.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from subprocess import Popen, PIPE
 from logging import error, debug, info
 
@@ -77,6 +78,12 @@ def run_shell_cmd_list(cmds, failure_fatal=True, extra_env=None):
 
 def check_and_parse_execution_results(stdout, stderr, rc):
     json_exn = None
+
+    # cset(1) on Linux prints to stdout information about which cpuset a pinned
+    # process went to. If this line is present, filter it out.
+    stdout = re.sub('^cset: --> last message, executed args into cpuset "/user",'
+           ' new pid is: [0-9]+\n', '', stdout)
+
     try:
         iterations_results = json.loads(stdout)  # expect a list of floats
     except Exception as e:  # docs don't say what can arise, play safe.

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -184,16 +184,7 @@ class BaseVMDef(object):
 
         debug("Wrapper script:\n%s" % ("\n".join(lines)))
 
-        # The arguments used to invoke the wrapper script now
-        wrapper_args = self.platform.change_user_args("root")
-
-        if self.config.ENABLE_PINNING:
-            wrapper_args += self.platform.change_scheduler_args()
-
-        wrapper_args += self.platform.process_priority_args() + \
-            self.platform.change_user_args(BENCHMARK_USER) + \
-            [DASH, WRAPPER_SCRIPT]
-
+        wrapper_args = self._wrapper_args()
         debug("Execute wrapper: %s" % (" ".join(wrapper_args)))
 
         # Do an OS-level sync. Forces pending writes on to the physical disk.
@@ -203,6 +194,21 @@ class BaseVMDef(object):
             self.platform.sync_disks()
 
         return self._run_exec_popen(wrapper_args)
+
+    # separate for testing
+    def _wrapper_args(self):
+        """Build arguments used to run the wrapper script"""
+
+        wrapper_args = self.platform.change_user_args("root") + \
+            self.platform.process_priority_args()
+
+        if self.config.ENABLE_PINNING:
+                wrapper_args += self.platform.pin_process_args()
+
+        wrapper_args += self.platform.change_user_args(BENCHMARK_USER) + \
+            [DASH, WRAPPER_SCRIPT]
+
+        return wrapper_args
 
     # separate for testing purposes
     def _run_exec_popen(self, args):

--- a/platform_sanity_checks/Makefile
+++ b/platform_sanity_checks/Makefile
@@ -3,7 +3,9 @@ OS != uname
 .PHONY: clean all
 
 all: check_openbsd_malloc_options.so check_nice_priority.so \
-	check_linux_cpu_affinity.so check_linux_scheduler.so
+	check_linux_cpu_affinity_pinned.so \
+	check_linux_cpu_affinity_not_pinned.so \
+	check_linux_scheduler.so
 
 check_openbsd_malloc_options.so: check_openbsd_malloc_options.c
 	if [ "${OS}" = "OpenBSD" ]; then \
@@ -15,10 +17,16 @@ check_nice_priority.so: check_nice_priority.c
 	${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
 		check_nice_priority.so check_nice_priority.c
 
-check_linux_cpu_affinity.so: check_linux_cpu_affinity.c
+check_linux_cpu_affinity_pinned.so: check_linux_cpu_affinity_pinned.c
 	if [ "${OS}" = "Linux" ]; then \
 		${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
-		check_linux_cpu_affinity.so check_linux_cpu_affinity.c \
+		check_linux_cpu_affinity_pinned.so check_linux_cpu_affinity_pinned.c \
+		; fi
+
+check_linux_cpu_affinity_not_pinned.so: check_linux_cpu_affinity_not_pinned.c
+	if [ "${OS}" = "Linux" ]; then \
+		${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
+		check_linux_cpu_affinity_not_pinned.so check_linux_cpu_affinity_not_pinned.c \
 		; fi
 
 check_linux_scheduler.so: check_linux_scheduler.c
@@ -29,4 +37,5 @@ check_linux_scheduler.so: check_linux_scheduler.c
 
 clean:
 	rm -f check_openbsd_malloc_options.so check_nice_priority.so \
-		check_linux_cpu_affinity.so check_linux_scheduler.so
+		check_linux_cpu_affinity_pinned.so check_linux_scheduler.so \
+		check_linux_cpu_affinity_not_pinned.so

--- a/platform_sanity_checks/check_linux_cpu_affinity_not_pinned.c
+++ b/platform_sanity_checks/check_linux_cpu_affinity_not_pinned.c
@@ -1,0 +1,52 @@
+/*
+ * Dummy benchmark that checks the CPU affinity mask for a *unpinned* benchmark.
+ *
+ * The mask should contain all CPUs.
+ *
+ * This code is Linux specific.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sched.h>
+#include <unistd.h>
+
+
+void
+run_iter(int param)
+{
+    pid_t pid;
+    cpu_set_t mask;
+    size_t mask_sz;
+    int ret, i;
+    long n_cpus;
+
+    (void) param;
+    pid = getpid();
+    n_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+    mask_sz = sizeof(mask);
+
+    ret = sched_getaffinity(pid, mask_sz, &mask);
+    if (ret != 0) {
+        perror("sched_getaffinity");
+        exit(EXIT_FAILURE);
+    }
+
+    if (CPU_COUNT(&mask) != n_cpus) {
+        fprintf(stderr, "Wrong number of CPUs in affinity mask\n"
+            "got %d, expect %ld\n", CPU_COUNT(&mask), n_cpus - 1);
+        exit(EXIT_FAILURE);
+    }
+
+    for (i = 0; i < n_cpus; i++) {
+        if (!CPU_ISSET(i, &mask)) {
+            fprintf(stderr, "CPU %d not in affinity mask\n", i);
+            exit(EXIT_FAILURE);
+        }
+    }
+}

--- a/platform_sanity_checks/check_linux_cpu_affinity_pinned.c
+++ b/platform_sanity_checks/check_linux_cpu_affinity_pinned.c
@@ -1,9 +1,8 @@
 /*
- * Dummy benchmark that checks the CPU affinity for a benchmark.
+ * Dummy benchmark that checks the CPU affinity mask for a *pinned* benchmark.
  *
- * We are assuming the Linux kernel is NO_HZ_FULL_ALL tickless, so the affinity
- * should be all but the boot processor (all the other CPUs will be in adaptive
- * tick mode)
+ * The mask should contain all CPUs apart from the boot processor (enforced by
+ * a cset shield).
  *
  * This code is Linux specific.
  */
@@ -40,7 +39,8 @@ run_iter(int param)
     }
 
     if (CPU_COUNT(&mask) != n_cpus - 1) {
-        fprintf(stderr, "Wrong number of CPUs in affinity mask\n");
+        fprintf(stderr, "Wrong number of CPUs in affinity mask\n"
+            "got %d, expect %ld\n", CPU_COUNT(&mask), n_cpus - 1);
         exit(EXIT_FAILURE);
     }
 

--- a/platform_sanity_checks/check_linux_scheduler.c
+++ b/platform_sanity_checks/check_linux_scheduler.c
@@ -1,36 +1,21 @@
-/* Fake benchmark that checks the right scheduler and priority is used on Linux */
+/* Fake benchmark that checks the right scheduling policy is used on Linux */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <sched.h>
 #include <err.h>
 
-#define EXPECT_POLICY SCHED_FIFO
+#define EXPECT_POLICY SCHED_OTHER
 
 void
 run_iter(int param) {
-    int policy, rv, max_prio;
-    struct sched_param s_param;
+    int policy;
 
     (void) param;
 
     policy = sched_getscheduler(0);
     if (policy != EXPECT_POLICY) {
         fprintf(stderr, "Incorrect scheduler in use.\n");
-        exit(EXIT_FAILURE);
-    }
-
-    max_prio = sched_get_priority_max(EXPECT_POLICY);
-
-    rv = sched_getparam(0, &s_param);
-    if (rv != 0) {
-        perror("sched_getparam");
-        exit(EXIT_FAILURE);
-    }
-
-    if (s_param.sched_priority != max_prio) {
-        fprintf(stderr, "Wrong scheduler priority: expect %d, got %d.\n",
-            max_prio, s_param.sched_priority);
         exit(EXIT_FAILURE);
     }
 }


### PR DESCRIPTION
Here's a start on the new pinning code. Please do not merge yet. I would like to test it some more and look for non-linux breakage.

Work in progress...

I recommend skimming the cset tutorial to see roughly what this is all about:
https://rt.wiki.kernel.org/index.php/Cpuset_Management_Utility/tutorial

In short, if the system has N cores, we create a N-1 core shield. All user tasks are migrated off the shield (a.k.a. the "user cset") onto the remaining core (the "system cset"). We move many kernel threads as possible too (you can't move them all). The N-1 cores are the same cores that are in adaptive tick mode. The core not in the shield is the boot processor.

Also:
 * We can now use the default scheduling policy `SCHED_OTHER`. A platform sanity check is checking for this.
 * This scheduler uses only nice priorities, so I've removed the static priority code.
 * Turn pinning back on by default.
 * Check `isolcpus` is not used, as this will interfere with the shield.

It's a big change and there's bound to be mistakes. Please check carefully.
