### PR TITLE
Improve examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ script:
     - JAVA_CPPFLAGS='"-I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux"' JAVA_LDFLAGS=-L${JAVA_HOME}/lib ENABLE_JAVA=1 make
     - cd examples/benchmarks
     - make
+    - make java-bench
     - cd ../
-    - PYTHONPATH=.. python ../krun.py --develop example.krun
+    - python ../krun.py --develop travis.krun

--- a/examples/benchmarks/Makefile
+++ b/examples/benchmarks/Makefile
@@ -2,9 +2,25 @@ JAVAC ?=	javac
 
 BENCHMARKS = dummy nbody
 
-.PHONY: all clean
+BENCH_CFLAGS =    -shared -Wall -fPIC -m64
+BENCH_LDFLAGS =
+C_EXTRA_LDFLAGS_dummy =
+C_EXTRA_LDFLAGS_nbody = -lm
 
-all:
+.PHONY: all c-bench java-bench clean clean-c clean-java
+
+all: c-bench
+
+c-bench:
+	$(foreach i, ${BENCHMARKS}, \
+		echo "Building C benchmark ${i}..."; \
+		cd ${i}/c && \
+		${CC} ${CFLAGS} ${CPPFLAGS} ${BENCH_CFLAGS} -o bench.so bench.c \
+		${LDFLAGS} ${BENCH_LDFLAGS} ${C_EXTRA_LDFLAGS_${i}} || exit $?; \
+		cd ../../; \
+	)
+
+java-bench:
 	$(foreach i, ${BENCHMARKS}, \
 		echo "Building java benchmark ${i}..."; \
 		cd ${i}/java && \
@@ -12,9 +28,18 @@ all:
 		cd ../../; \
 	)
 
-clean:
+clean: clean-java clean-c
+
+clean-java:
 	$(foreach i, ${BENCHMARKS}, \
 		cd ${i}/java && \
-		rm *.class; \
-		cd ../../ \
+		rm -f *.class; \
+		cd ../../; \
+	)
+
+clean-c:
+	$(foreach i, ${BENCHMARKS}, \
+		cd  ${i}/c && \
+		rm -f *.so; \
+		cd ../../; \
 	)

--- a/examples/benchmarks/dummy/c/bench.c
+++ b/examples/benchmarks/dummy/c/bench.c
@@ -1,0 +1,18 @@
+/* Dummy benchmark.
+ * Each iteration sleeps for one second.
+ */
+#include <unistd.h>
+
+#define DELAY 1 /* second. */
+
+/* The benchmark itself. */
+void dummy() {
+    sleep(DELAY);
+}
+
+/* Entry point to the benchmark.
+ * This method is called by krun and runs one iteration of the benchmark.
+ */
+void run_iter(int n) {
+    dummy();
+}

--- a/examples/benchmarks/nbody/c/bench.c
+++ b/examples/benchmarks/nbody/c/bench.c
@@ -1,0 +1,174 @@
+/*
+ * The Great Computer Language Shootout
+ * http://shootout.alioth.debian.org/
+ *
+ * contributed by Christoph Bauer
+ *
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <err.h>
+#include <string.h>
+
+#define pi 3.141592653589793
+#define solar_mass (4 * pi * pi)
+#define days_per_year 365.24
+
+static double checksum = 0;
+#define EXPECT_CHECKSUM -0.3381550232201908645635057837353087961673736572265625
+#define N_ADVANCES 100000
+#define EPSILON 0.0000000000001
+
+
+struct planet {
+  double x, y, z;
+  double vx, vy, vz;
+  double mass;
+};
+
+void n_advance(int nbodies, struct planet * bodies, double dt)
+{
+  int i, j;
+
+  for (i = 0; i < nbodies; i++) {
+    struct planet * b = &(bodies[i]);
+    for (j = i + 1; j < nbodies; j++) {
+      struct planet * b2 = &(bodies[j]);
+      double dx = b->x - b2->x;
+      double dy = b->y - b2->y;
+      double dz = b->z - b2->z;
+      double distance = sqrt(dx * dx + dy * dy + dz * dz);
+      double mag = dt / (distance * distance * distance);
+      b->vx -= dx * b2->mass * mag;
+      b->vy -= dy * b2->mass * mag;
+      b->vz -= dz * b2->mass * mag;
+      b2->vx += dx * b->mass * mag;
+      b2->vy += dy * b->mass * mag;
+      b2->vz += dz * b->mass * mag;
+    }
+  }
+  for (i = 0; i < nbodies; i++) {
+    struct planet * b = &(bodies[i]);
+    b->x += dt * b->vx;
+    b->y += dt * b->vy;
+    b->z += dt * b->vz;
+  }
+}
+
+double energy(int nbodies, struct planet * bodies)
+{
+  double e;
+  int i, j;
+
+  e = 0.0;
+  for (i = 0; i < nbodies; i++) {
+    struct planet * b = &(bodies[i]);
+    e += 0.5 * b->mass * (b->vx * b->vx + b->vy * b->vy + b->vz * b->vz);
+    for (j = i + 1; j < nbodies; j++) {
+      struct planet * b2 = &(bodies[j]);
+      double dx = b->x - b2->x;
+      double dy = b->y - b2->y;
+      double dz = b->z - b2->z;
+      double distance = sqrt(dx * dx + dy * dy + dz * dz);
+      e -= (b->mass * b2->mass) / distance;
+    }
+  }
+  return e;
+}
+
+void offset_momentum(int nbodies, struct planet * bodies)
+{
+  double px = 0.0, py = 0.0, pz = 0.0;
+  int i;
+  for (i = 0; i < nbodies; i++) {
+    px += bodies[i].vx * bodies[i].mass;
+    py += bodies[i].vy * bodies[i].mass;
+    pz += bodies[i].vz * bodies[i].mass;
+  }
+  bodies[0].vx = - px / solar_mass;
+  bodies[0].vy = - py / solar_mass;
+  bodies[0].vz = - pz / solar_mass;
+}
+
+#define NBODIES 5
+struct planet *bodies = NULL;
+/*
+ * Benchmark mutates the bodies!
+ * This is the initial state, which is restored after each run.
+ */
+const struct planet initial_bodies[NBODIES] = {
+  {                               /* sun */
+    0, 0, 0, 0, 0, 0, solar_mass
+  },
+  {                               /* jupiter */
+    4.84143144246472090e+00,
+    -1.16032004402742839e+00,
+    -1.03622044471123109e-01,
+    1.66007664274403694e-03 * days_per_year,
+    7.69901118419740425e-03 * days_per_year,
+    -6.90460016972063023e-05 * days_per_year,
+    9.54791938424326609e-04 * solar_mass
+  },
+  {                               /* saturn */
+    8.34336671824457987e+00,
+    4.12479856412430479e+00,
+    -4.03523417114321381e-01,
+    -2.76742510726862411e-03 * days_per_year,
+    4.99852801234917238e-03 * days_per_year,
+    2.30417297573763929e-05 * days_per_year,
+    2.85885980666130812e-04 * solar_mass
+  },
+  {                               /* uranus */
+    1.28943695621391310e+01,
+    -1.51111514016986312e+01,
+    -2.23307578892655734e-01,
+    2.96460137564761618e-03 * days_per_year,
+    2.37847173959480950e-03 * days_per_year,
+    -2.96589568540237556e-05 * days_per_year,
+    4.36624404335156298e-05 * solar_mass
+  },
+  {                               /* neptune */
+    1.53796971148509165e+01,
+    -2.59193146099879641e+01,
+    1.79258772950371181e-01,
+    2.68067772490389322e-03 * days_per_year,
+    1.62824170038242295e-03 * days_per_year,
+    -9.51592254519715870e-05 * days_per_year,
+    5.15138902046611451e-05 * solar_mass
+  }
+};
+
+void inner_iter(int n)
+{
+  int i;
+
+  offset_momentum(NBODIES, bodies);
+  checksum += energy(NBODIES, bodies);
+  for (i = 1; i <= n; i++)
+    n_advance(NBODIES, bodies, 0.01);
+  checksum += energy(NBODIES, bodies);
+
+  if (abs(checksum - EXPECT_CHECKSUM) >= EPSILON) {
+    errx(EXIT_FAILURE, "bad checksum: %.52f vs %.52f",
+        checksum, EXPECT_CHECKSUM);
+  }
+}
+
+void run_iter(int n) {
+   int i;
+
+   if ((bodies = malloc(sizeof(initial_bodies))) == NULL) {
+     errx(EXIT_FAILURE, "malloc failed");
+   }
+
+   for (i = 0; i < n; i++) {
+      /* reset global state */
+      checksum = 0;
+      memcpy(bodies, initial_bodies, sizeof(initial_bodies));
+      inner_iter(N_ADVANCES);
+   }
+
+   free(bodies);
+}

--- a/examples/example.krun
+++ b/examples/example.krun
@@ -1,5 +1,5 @@
 import os
-from krun.vm_defs import (PythonVMDef, JavaVMDef)
+from krun.vm_defs import (PythonVMDef, NativeCodeVMDef)
 from krun import EntryPoint
 from krun.util import fatal
 from distutils.spawn import find_executable
@@ -8,10 +8,6 @@ from distutils.spawn import find_executable
 PYTHON27_BIN = find_executable("python2.7")
 if PYTHON27_BIN is None:
     fatal("Python binary not found in path")
-
-JAVA_BIN = find_executable("java")
-if JAVA_BIN is None:
-    fatal("Java binary not found in path")
 
 # Who to mail
 MAIL_TO = []
@@ -27,16 +23,16 @@ STACK_LIMIT = 8192  # KiB
 
 # Variant name -> EntryPoint
 VARIANTS = {
-    "default-java": EntryPoint("KrunEntry", subdir="java"),
+    "default-c": EntryPoint("bench.so", subdir="c"),
     "default-python": EntryPoint("bench.py", subdir="python"),
 }
 
 ITERATIONS_ALL_VMS = 5  # Small number for testing.
 
 VMS = {
-    'Java': {
-        'vm_def': JavaVMDef(JAVA_BIN),
-        'variants': ['default-java'],
+    'C': {
+        'vm_def': NativeCodeVMDef(),
+        'variants': ['default-c'],
         'n_iterations': ITERATIONS_ALL_VMS,
     },
     'CPython': {
@@ -54,8 +50,8 @@ BENCHMARKS = {
 
 # list of "bench:vm:variant"
 SKIP=[
+    #"*:C:*",
     #"*:CPython:*",
-    #"*:Java:*",
 ]
 
 N_EXECUTIONS = 2  # Number of fresh processes.

--- a/examples/java.krun
+++ b/examples/java.krun
@@ -1,0 +1,79 @@
+import os
+from krun.vm_defs import (PythonVMDef, JavaVMDef)
+from krun import EntryPoint
+from krun.util import fatal
+from distutils.spawn import find_executable
+
+# For a real experiment you would certainly use absolute paths
+PYTHON27_BIN = find_executable("python2.7")
+if PYTHON27_BIN is None:
+    fatal("Python binary not found in path")
+
+JAVA_BIN = find_executable("java")
+if JAVA_BIN is None:
+    fatal("Java binary not found in path")
+
+# Who to mail
+MAIL_TO = []
+
+# Maximum number of error emails to send per-run
+#MAX_MAILS = 2
+
+DIR = os.getcwd()
+JKRUNTIME_DIR = os.path.join(DIR, "krun", "libkruntime", "")
+
+HEAP_LIMIT = 2097152  # KiB
+STACK_LIMIT = 8192  # KiB
+
+# Variant name -> EntryPoint
+VARIANTS = {
+    "default-java": EntryPoint("KrunEntry", subdir="java"),
+    "default-python": EntryPoint("bench.py", subdir="python"),
+}
+
+ITERATIONS_ALL_VMS = 5  # Small number for testing.
+
+VMS = {
+    'Java': {
+        'vm_def': JavaVMDef(JAVA_BIN),
+        'variants': ['default-java'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+    'CPython': {
+        'vm_def': PythonVMDef(PYTHON27_BIN),
+        'variants': ['default-python'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    }
+}
+
+
+BENCHMARKS = {
+    'dummy': 1000,
+    'nbody': 1000,
+}
+
+# list of "bench:vm:variant"
+SKIP=[
+    #"*:CPython:*",
+    #"*:Java:*",
+]
+
+N_EXECUTIONS = 2  # Number of fresh processes.
+
+# No. of seconds to wait before taking the initial temperature reading.
+# You should set this high enough for the system to cool down a bit.
+# The default (if omitted) is 60 seconds.
+TEMP_READ_PAUSE = 1
+
+# Commands to run before and after each process execution
+#
+# Environment available for these commands:
+#   KRUN_RESULTS_FILE: path to results file.
+#   KRUN_LOG_FILE: path to log file.
+#   KRUN_ETA_DATUM: time the ETA was computed
+#   KRUN_ETA_VALUE: estimated time of completion
+#PRE_EXECUTION_CMDS = ["sudo service cron stop"]
+#POST_EXECUTION_CMDS = ["sudo service cron start"]
+
+# CPU pinning (on by default)
+#ENABLE_PINNING = True

--- a/examples/travis.krun
+++ b/examples/travis.krun
@@ -1,0 +1,86 @@
+import os
+from krun.vm_defs import (PythonVMDef, JavaVMDef, NativeCodeVMDef)
+from krun import EntryPoint
+from krun.util import fatal
+from distutils.spawn import find_executable
+
+# For a real experiment you would certainly use absolute paths
+PYTHON27_BIN = find_executable("python2.7")
+if PYTHON27_BIN is None:
+    fatal("Python binary not found in path")
+
+JAVA_BIN = find_executable("java")
+if JAVA_BIN is None:
+    fatal("Java binary not found in path")
+
+# Who to mail
+MAIL_TO = []
+
+# Maximum number of error emails to send per-run
+#MAX_MAILS = 2
+
+DIR = os.getcwd()
+JKRUNTIME_DIR = os.path.join(DIR, "krun", "libkruntime", "")
+
+HEAP_LIMIT = 2097152  # KiB
+STACK_LIMIT = 8192  # KiB
+
+# Variant name -> EntryPoint
+VARIANTS = {
+    "default-c": EntryPoint("bench.so", subdir="c"),
+    "default-java": EntryPoint("KrunEntry", subdir="java"),
+    "default-python": EntryPoint("bench.py", subdir="python"),
+}
+
+ITERATIONS_ALL_VMS = 1  # Keep travis-ci runs short..
+
+VMS = {
+    'C': {
+        'vm_def': NativeCodeVMDef(),
+        'variants': ['default-c'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+    'Java': {
+        'vm_def': JavaVMDef(JAVA_BIN),
+        'variants': ['default-java'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+    'CPython': {
+        'vm_def': PythonVMDef(PYTHON27_BIN),
+        'variants': ['default-python'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    }
+}
+
+
+BENCHMARKS = {
+    'dummy': 1000,
+    'nbody': 1000,
+}
+
+# list of "bench:vm:variant"
+SKIP=[
+    #"*:C:*",
+    #"*:CPython:*",
+    #"*:Java:*",
+]
+
+N_EXECUTIONS = 1  # Number of fresh processes. Keep travis-ci runs short.
+
+# No. of seconds to wait before taking the initial temperature reading.
+# You should set this high enough for the system to cool down a bit.
+# The default (if omitted) is 60 seconds.
+TEMP_READ_PAUSE = 1
+
+# Commands to run before and after each process execution
+#
+# Environment available for these commands:
+#   KRUN_RESULTS_FILE: path to results file.
+#   KRUN_LOG_FILE: path to log file.
+#   KRUN_ETA_DATUM: time the ETA was computed
+#   KRUN_ETA_VALUE: estimated time of completion
+#PRE_EXECUTION_CMDS = ["sudo service cron stop"]
+#POST_EXECUTION_CMDS = ["sudo service cron start"]
+
+# CPU pinning (on by default)
+ENABLE_PINNING = False


### PR DESCRIPTION
  * Default example uses Native and Python VMs
  * Separate example for those who want to use Java
  * New Travis config which tests C, Java and Python examples, but only uses one process execution and iteration
  * Brings documentation up to date

Fixes #191 