### PR TITLE
Debug switches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install linux-libc-dev libc6-dev
     - sudo apt-get install oracle-java8-installer
+    - sudo apt-get install virt-what
     - sudo useradd krun
     - sudo adduser krun sudo
     - sudo passwd -d krun
@@ -23,4 +24,4 @@ script:
     - make
     - make java-bench
     - cd ../
-    - python ../krun.py --develop travis.krun
+    - python ../krun.py --no-pstate-check --no-tickless-check travis.krun

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 
 install:
     - pip install -r requirements.txt
+    - pip install colorlog
 
 script:
     - py.test --cov-report term --cov=krun  krun

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You need to have the following installed:
   * cpufrequtils (Linux only. `cpufrequtils` package in Debian)
   * cffi (`python-cffi` package in Debian)
   * cset (for pinning on Linux only. `cpuset` package in Debian)
+  * virt-what (Linux only. `virt-what` package in Debian)
 
 If you want to benchmark Java, you will also need:
   * A Java SDK 7 (`openjdk-7-jdk` package in Debian)
@@ -270,19 +271,16 @@ how to consume results in Krun format:
 
 It is often useful to test a configuration file, without actually
 running a full benchmark (especially if the benchmark program is
-long).
-Krun supports this with the `--dryrun` command line switch:
+long). The best to test a config is to do something like:
 
 ```bash
-$ ../krun.py --dryrun --debug=INFO example.krun
+$ ../krun.py --dry-run --quick --debug=INFO example.krun
 ```
 
-By passing in `--debug=INFO` you will see a full log of krun actions
-printed to STDOUT.
-Valid debug levels are: `DEBUG`, `INFO`, `WARN`, `DEBUG`,
-`CRITICAL`, `ERROR`.
+See the "Development and Debug Switches" section for a description of these
+switches.
 
-The `--info` switch reports various statistics about the setup described in the
+Another switch, `--info`, reports various statistics about the setup described in the
 specified config file, such as the total number of process executions and which
 benchmark keys will be skipped etc.
 
@@ -320,7 +318,7 @@ This file is compatible with some Linux machines.
 ### Testing a benchmark run with `--reboot`
 
 If you need to test a benchmark configuration with `--reboot`, you can
-still use the `--dryrun` flag.
+still use the `--dry-run` flag.
 In a dry run, Krun will not reboot your machine (it will simulate
 rebooting by restarting Krun automatically) and will not pause to
 wait for your network interface to come up.
@@ -372,21 +370,35 @@ The following platforms are currently supported:
 
 To add a new platform definition, add a new class to `krun/platform.py`.
 
-## Developer Mode
+## Development and Debug Switches
 
 If you are making changes to Krun itself (for example, to add a new platform or
-virtual machine definition), you may find the `--develop` switch useful. This
-will cause Krun to run with the following modifications:
+virtual machine definition), there are a few switches which can make your life
+easier.
 
-  * Krun will not run the system prerequisite checks. Checks relating to CPU
-    governors,  CPU scalers, CPU temperatures, tickless kernel, etc.
-  * Krun will not attempt to switch user to run benchmarks.
+  * `--debug=<level>`: Sets the verbosity of Krun.  Valid debug levels are:
+     `DEBUG`, `INFO`, `WARN`, `DEBUG`, `CRITICAL` and `ERROR`. The default is
+     `WARN`. For real benchmarks you should use the default.
 
-This makes it easier to develop krun on (e.g.) a personal laptop which has not
-been prepared for reliable benchmarking.
+  * `--quick`: There are several places where Krun would normally wait using
+    sleeps or a polling loop. These are essential for real benchmarking, but
+    annoying for development. Use `--quick` to skip these delays.
+
+  * `--no-user-change`: Usually Krun will switch to a user named `krun` to
+    perform benchmarking. This switch disables the user change.
+
+  * `--dry-run`: Fakes actual benchmark processes, making them finish
+    instantaneously.
+
+  * `--no-tickless-check`: Do not crash out if the Linux kernel is not
+    tickless.
+
+  * `--no-pstate-check`: Do not crash out if Intel P-states are not disabled.
+
+  * `--fake-reboots`: Restart Krun in-place (using execv) instead of rebooting.
 
 Note that you should not collect results intended for publication with
-`--develop`.
+development switches turned on.
 
 ## Re-running Part of your Experiment
 

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -652,7 +652,8 @@ class LinuxPlatform(UnixLikePlatform):
     def check_preliminaries(self):
         """Checks the system is in a suitable state for benchmarking"""
 
-        self._check_cset_installed()
+        if self.config.ENABLE_PINNING:
+            self._check_cset_installed()
         self._check_isolcpus()
         self._check_cset_shield()
         self._check_virt_what_installed()

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -283,11 +283,7 @@ class ExecutionScheduler(object):
         if self.reboot and self.started_by_init and jobs_left > 0:
             debug("Waiting %s seconds for the system to come up." %
                  str(STARTUP_WAIT_SECONDS))
-            if self.dry_run:
-                info("SIMULATED: time.sleep (would have waited %s seconds)." %
-                     STARTUP_WAIT_SECONDS)
-            else:
-                time.sleep(STARTUP_WAIT_SECONDS)
+            self.platform.sleep(STARTUP_WAIT_SECONDS)
 
         # Important that the dmesg is collected after the above startup wait.
         # Otherwise we get spurious dmesg changes.
@@ -418,12 +414,12 @@ class ExecutionScheduler(object):
                         "Krun was about to execute reboot number: %g. " +
                         "%g jobs have been completed, %g are left to go.") %
                        (self.results.reboots, self.jobs_done, len(self)))
-        if self.dry_run:
-            info("SIMULATED: reboot (restarting Krun in-place)")
+        if self.platform.fake_reboots:
+            warn("SIMULATED: reboot (--fake-reboots)")
             args =  sys.argv
             if not self.started_by_init:
                 args.extend(["--resume", "--started-by-init"])
-                debug("Simulated reboot with args: " + " ".join(args))
+            debug("Simulated reboot with args: " + " ".join(args))
             os.execv(args[0], args)  # replace myself
             assert False  # unreachable
         else:

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -21,7 +21,6 @@ class MockPlatform(BasePlatform):
         self.mailer = mailer
         self.audit = dict()
         self.num_cpus = 0
-        self.developer_mode = False
 
     def pin_process_args(self):
         return []
@@ -85,3 +84,6 @@ class MockPlatform(BasePlatform):
 
     def find_temperature_sensors(self):
         return []
+
+    def is_virtual(self):
+        return False

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -244,3 +244,9 @@ class TestLinuxPlatform(BaseKrunTest):
 
         find = "isolcpus should not be in the kernel command line"
         assert find in caplog.text()
+
+    def test_is_virtual0001(self, platform):
+        """check that virtualisation check doesn't crash"""
+
+        platform._check_virt_what_installed()  # needed to set the command path
+        platform.is_virtual()

--- a/krun/tests/test_scheduler.py
+++ b/krun/tests/test_scheduler.py
@@ -141,6 +141,9 @@ class TestScheduler(BaseKrunTest):
                                    reboot=True, dry_run=True,
                                    started_by_init=True)
         sched.build_schedule()
+        # We will catch the (normally unreachable) 'assert False' in the
+        # fake reboot code to check reboot is being called.
+        sched.platform.fake_reboots = True
         assert len(sched) == 8
         with pytest.raises(AssertionError):
             sched.run()

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -5,7 +5,7 @@ import fnmatch
 import json
 from abc import ABCMeta, abstractmethod
 
-from logging import info, debug
+from logging import info, debug, warn
 from krun import EntryPoint
 from krun.util import fatal, spawn_sanity_check, VM_SANITY_CHECKS_DIR
 from krun.env import EnvChangeAppend, EnvChangeSet, EnvChange
@@ -171,7 +171,7 @@ class BaseVMDef(object):
             args.append("0")
 
         if self.dry_run:
-            info("SIMULATED: Benchmark process execution")
+            warn("SIMULATED: Benchmark process execution (--dryrun)")
             return ("", "", 0)
 
         # We write out a wrapper script whose job is to enforce ulimits
@@ -205,8 +205,12 @@ class BaseVMDef(object):
         if self.config.ENABLE_PINNING:
                 wrapper_args += self.platform.pin_process_args()
 
-        wrapper_args += self.platform.change_user_args(BENCHMARK_USER) + \
-            [DASH, WRAPPER_SCRIPT]
+        if self.platform.no_user_change:
+            warn("Not changing user (--no-change-user)")
+        else:
+            wrapper_args += self.platform.change_user_args(BENCHMARK_USER)
+
+        wrapper_args += [DASH, WRAPPER_SCRIPT]
 
         return wrapper_args
 

--- a/platform_sanity_checks/Makefile
+++ b/platform_sanity_checks/Makefile
@@ -1,4 +1,4 @@
-OS != uname
+OS = $(shell uname -s)
 
 .PHONY: clean all
 
@@ -8,32 +8,32 @@ all: check_openbsd_malloc_options.so check_nice_priority.so \
 	check_linux_scheduler.so
 
 check_openbsd_malloc_options.so: check_openbsd_malloc_options.c
-	if [ "${OS}" = "OpenBSD" ]; then \
-		${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -shared -Wall -Wextra -o \
-		check_openbsd_malloc_options.so check_openbsd_malloc_options.c \
-		; fi
+ifeq (${OS},OpenBSD)
+	${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -shared -Wall -Wextra -o \
+		check_openbsd_malloc_options.so check_openbsd_malloc_options.c
+endif
 
 check_nice_priority.so: check_nice_priority.c
 	${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
 		check_nice_priority.so check_nice_priority.c
 
 check_linux_cpu_affinity_pinned.so: check_linux_cpu_affinity_pinned.c
-	if [ "${OS}" = "Linux" ]; then \
-		${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
-		check_linux_cpu_affinity_pinned.so check_linux_cpu_affinity_pinned.c \
-		; fi
+ifeq (${OS},Linux)
+	${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
+		check_linux_cpu_affinity_pinned.so check_linux_cpu_affinity_pinned.c
+endif
 
 check_linux_cpu_affinity_not_pinned.so: check_linux_cpu_affinity_not_pinned.c
-	if [ "${OS}" = "Linux" ]; then \
+ifeq (${OS},Linux)
 		${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
-		check_linux_cpu_affinity_not_pinned.so check_linux_cpu_affinity_not_pinned.c \
-		; fi
+		check_linux_cpu_affinity_not_pinned.so check_linux_cpu_affinity_not_pinned.c
+endif
 
 check_linux_scheduler.so: check_linux_scheduler.c
-	if [ "${OS}" = "Linux" ]; then \
+ifeq (${OS},Linux)
 		${CC} ${CFLAGS} ${LDFLAGS} ${CPPFLAGS} -fPIC -shared -Wall -Wextra -o \
-		check_linux_scheduler.so check_linux_scheduler.c \
-		; fi
+		check_linux_scheduler.so check_linux_scheduler.c
+endif
 
 clean:
 	rm -f check_openbsd_malloc_options.so check_nice_priority.so \


### PR DESCRIPTION
Hi,

Don't merge this yet. Opening for discussion.

Here's an attempt at sorting out our debug flags. I've managed to untangle `--develop` and `--dryrun` nicely (i hope).

Removed flags:
 * `--dryrun`
 * `--develop`

New flags:
 * Any feature which causes a delay can be skipped with `--quick`.
 * Platform specific flags:
   * `--no-pstate-check`
   * `--no-tickless-check`
 * Other flags:
   * `--no-user-change` -- Means you don't need to set up a krun user and make sure it has permissions to the benchmarks etc.
   * `--fake-reboots` -- Useful for testing stuff which needs persist across reboots, without actually rebooting. E.g. When we come to fix #181 this will be useful.
   * `--dry-run` (not `--dryrun`) -- Fakes the benchmarks, making the finish instantaneously. Useful when hacking a Krun feature which does not touch benchmarks themselves.

Using any of these switches will cause krun to emit warnings that will also appear in the log file. The warning details which switch caused the warning, e.g.:

```
[2016-05-17 14:20:28 WARNING] Ignoring enabled P-states (--no-pstate-check)
```

I know we were aiming to have only `--quick` and platform specific switches. The "other flags" bits are things which I have untangled from the old `--dryrun` and `--develop`. I thought hard about trying to group these, but I now feel strongly that we shouldn't. If we were to group them, I would only end up having to comment out parts of code all the time, which is what we are trying to avoid.

What do others think?