### PR TITLE
Do not pin by default.

### DIFF
--- a/examples/example.krun
+++ b/examples/example.krun
@@ -71,5 +71,5 @@ TEMP_READ_PAUSE = 1
 #PRE_EXECUTION_CMDS = ["sudo service cron stop"]
 #POST_EXECUTION_CMDS = ["sudo service cron start"]
 
-# CPU pinning (on by default)
-#ENABLE_PINNING = True
+# CPU pinning (off by default)
+#ENABLE_PINNING = False

--- a/examples/java.krun
+++ b/examples/java.krun
@@ -75,5 +75,5 @@ TEMP_READ_PAUSE = 1
 #PRE_EXECUTION_CMDS = ["sudo service cron stop"]
 #POST_EXECUTION_CMDS = ["sudo service cron start"]
 
-# CPU pinning (on by default)
-#ENABLE_PINNING = True
+# CPU pinning (off by default)
+#ENABLE_PINNING = False

--- a/examples/travis.krun
+++ b/examples/travis.krun
@@ -82,5 +82,5 @@ TEMP_READ_PAUSE = 1
 #PRE_EXECUTION_CMDS = ["sudo service cron stop"]
 #POST_EXECUTION_CMDS = ["sudo service cron start"]
 
-# CPU pinning (on by default)
-ENABLE_PINNING = False
+# CPU pinning (off by default)
+#ENABLE_PINNING = False

--- a/krun/config.py
+++ b/krun/config.py
@@ -27,7 +27,7 @@ class Config(object):
         self.HEAP_LIMIT = None
         self.STACK_LIMIT = None
         self.TEMP_READ_PAUSE = 60
-        self.ENABLE_PINNING = True
+        self.ENABLE_PINNING = False
 
         self.PRE_EXECUTION_CMDS = []
         self.POST_EXECUTION_CMDS = []

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -152,6 +152,7 @@ class TestLinuxPlatform(BaseKrunTest):
 
     def test_configure_cset_shield_args0001(self, platform):
         platform.num_cpus = 4
+        platform.config.ENABLE_PINNING = True
         got = platform._configure_cset_shield_args()
         expect = [['/usr/bin/sudo', '-u', 'root', '/usr/bin/cset',
                    'shield', '-c', '1-3'],
@@ -159,6 +160,7 @@ class TestLinuxPlatform(BaseKrunTest):
         assert got == expect
 
     def test_configure_cset_shield_args0002(self, platform):
+        platform.config.ENABLE_PINNING = True
         platform.num_cpus = 128
         got = platform._configure_cset_shield_args()
         expect = [['/usr/bin/sudo', '-u', 'root', '/usr/bin/cset',
@@ -172,9 +174,8 @@ class TestLinuxPlatform(BaseKrunTest):
         vm_def.set_platform(platform)
         got = vm_def._wrapper_args()
         expect = ['/usr/bin/sudo', '-u', 'root', '/usr/bin/nice', '-n', '-20',
-                  '/usr/bin/sudo', '-u', 'root', '/usr/bin/cset',
-                  'shield', '-e', '--', '/usr/bin/sudo', '-u', 'krun',
-                  '/bin/dash', '/tmp/krun_wrapper.dash']
+                  '/usr/bin/sudo', '-u', 'krun', '/bin/dash',
+                  '/tmp/krun_wrapper.dash']
         assert got == expect
 
     def test_wrapper_args0002(self, platform):


### PR DESCRIPTION
As discussed face to face with @ltratt:

We suspect that the VMs are asking the system how many CPUs the system
has (not the shield) and spawning a number of worker threads
accordingly. By limiting the number of cores, we may be making
artificial thread contention.

Another PR will follow shortly, as I notice krun thinks bencher3 is virtualised(!)