### PR TITLE
Fix config filename

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -7,9 +7,8 @@ usage: runner.py <config_file.krun>
 """
 
 import argparse, json, logging, os, sys
-from logging import debug, info, warn, error
+from logging import debug, info, warn
 import locale
-import time
 
 import krun.util as util
 from krun.config import Config

--- a/krun/config.py
+++ b/krun/config.py
@@ -74,7 +74,7 @@ class Config(object):
     def log_filename(self, resume=False):
         assert self.filename.endswith(".krun")
         if resume:
-            config_mtime = time.gmtime(os.path.getmtime(self.filename))
+            config_mtime = time.localtime(os.path.getmtime(self.filename))
             tstamp = time.strftime(LOGFILE_FILENAME_TIME_FORMAT, config_mtime)
         else:
             tstamp = time.strftime(LOGFILE_FILENAME_TIME_FORMAT)

--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -29,18 +29,19 @@ def test_eq():
     assert not example_config == Config("krun/tests/quick.krun")
 
 
-def test_log_filename(monkeypatch):
+def test_log_filename():
     path = os.path.join(TEST_DIR, "example.krun")
     example_config = Config(path)
     tstamp = time.strftime(LOGFILE_FILENAME_TIME_FORMAT)
     expect_path = os.path.join(TEST_DIR, "example_%s.log" % tstamp)
     assert example_config.log_filename(False) == expect_path
-    def mock_mtime(path):
-        return 1445964109.9363003
-    monkeypatch.setattr(os.path, 'getmtime', mock_mtime)
-    tstamp = '20151027_164149'
-    expect_path = os.path.join(TEST_DIR, "example_%s.log" % tstamp)
-    assert example_config.log_filename(True) == expect_path
+    touch(path)
+    tstamp_expected = time.strftime(LOGFILE_FILENAME_TIME_FORMAT,
+                                    time.localtime(os.path.getmtime(path)))
+    path_from_krun = example_config.log_filename(True)
+    path_from_krun = path_from_krun.split('.')[0]
+    tstamp = path_from_krun.split('_')[-2] + '_' + path_from_krun.split('_')[-1]
+    assert tstamp_expected == tstamp
 
 
 def test_read_config_from_file():


### PR DESCRIPTION
This fixes a bug which caused two log files to be created when in reboot mode. The bug was caused by British Summer Time -- we look up the mtime of the config file and use it to create the filename of the log file. However, `os.path.getmtime()` always returns the time in UTC.

Fixes #216 