### PR TITLE
Fix a syntax error in Javascript iterations runner.

### DIFF
--- a/iterations_runners/iterations_runner.js
+++ b/iterations_runners/iterations_runner.js
@@ -1,8 +1,8 @@
 // NOTE: you need to provide clock_gettime_monotonic.
 
 if (this.arguments.length != 5) {
-    throw "usage: iterations_runner.js <benchmark> <# of iterations>" + \
-        "<benchmark param> <debug flag> <instrument flag>";
+    throw "usage: iterations_runner.js <benchmark> <# of iterations> " +
+          "<benchmark param> <debug flag> <instrument flag>";
 }
 
 var BM_entry_point = this.arguments[0];


### PR DESCRIPTION
Missed a syntax error introduced into the Javascript iterations runner by the instrumentation flag work (earlier this week).

Simple fix. OK?