### PR TITLE
Use a fresh user account for each process execution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ before_install:
     - sudo apt-get install linux-libc-dev libc6-dev
     - sudo apt-get install oracle-java8-installer
     - sudo apt-get install virt-what
-    - sudo useradd krun
-    - sudo adduser krun sudo
-    - sudo passwd -d krun
 
 install:
     - pip install -r requirements.txt
@@ -25,4 +22,4 @@ script:
     - make
     - make java-bench
     - cd ../
-    - python ../krun.py --no-pstate-check --no-tickless-check travis.krun
+    - python ../krun.py --no-pstate-check --no-tickless-check --no-user-change travis.krun

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Krun is a framework for running software benchmarking experiments.
 
+**Krun uses sudo to elevate priveleges! Please read these instructions in
+full.**
+
 The `examples/` directory contains a simple experiment using Krun.
 This is a good starting point for setting up your own Krun configuration.
 
@@ -384,8 +387,12 @@ easier.
     sleeps or a polling loop. These are essential for real benchmarking, but
     annoying for development. Use `--quick` to skip these delays.
 
-  * `--no-user-change`: Usually Krun will switch to a user named `krun` to
-    perform benchmarking. This switch disables the user change.
+  * `--no-user-change`: Without this flag, For each process execution, Krun
+    will use a fresh user account called 'krun'. This involves deleting any
+    exising user account (with `userdel -r`) and creating a new user account
+    (with `useradd -m`).  This switch disables the use of a fresh user account,
+    meaning that `userdel` and `useradd` are not invoked, nor does Krun switch
+    user; the user Krun was invoked with is used for benchmarking.
 
   * `--dry-run`: Fakes actual benchmark processes, making them finish
     instantaneously.
@@ -424,6 +431,24 @@ literally '*'.
 Once you have stripped results, if you ran an experiment in reboot mode you
 will need to reboot manually to re-run the stripped results (with rc.local set
 up correctly).
+
+## Security Notes
+
+Krun is not intended to be run on a secure multi-user system, as it uses sudo
+to elevate proveleges.
+
+Sudo is used to:
+
+ * Add and remove a fresh benchmarking user for each process execution.
+ * Switch users.
+ * Change the CPU speed.
+ * Set the perf sample rate (Linux only)
+ * Automatically reboot the system.
+ * Set process priorities.
+ * Create cgroup shields (Linux only, off by default)
+ * Detect virtualised hosts.
+
+Please make sure you understand the implications of this.
 
 ## Licenses
 

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -87,3 +87,6 @@ class MockPlatform(BasePlatform):
 
     def is_virtual(self):
         return False
+
+    def make_fresh_krun_user(self):
+        pass

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -202,6 +202,9 @@ class BaseVMDef(object):
         wrapper_args = self._wrapper_args()
         debug("Execute wrapper: %s" % (" ".join(wrapper_args)))
 
+        if not self.platform.no_user_change:
+            self.platform.make_fresh_krun_user()
+
         # Do an OS-level sync. Forces pending writes on to the physical disk.
         # We do this in an attempt to prevent disk commits happening during
         # benchmarking.


### PR DESCRIPTION
Needs to be tested on OpenBSD. Fixes #226.

Debug log snippet on Linux:
```
...
[2016-06-30 15:04:58 DEBUG] Writing out wrapper script to /tmp/krun_wrapper.dash
[2016-06-30 15:04:58 DEBUG] Wrapper script:
#!/bin/dash
ulimit -d 2097152 || exit $?
ulimit -s 8192 || exit $?
env LD_LIBRARY_PATH=/home/vext01/research/warmup_experiment/krun/krun/../libkrun /home/vext01/research/warmup_experiment/
krun/iterations_runners/iterations_runner_c /home/vext01/research/warmup_experiment/krun/examples/benchmarks/dummy/c/benc
h.so 5 1000 1 0
exit $?
[2016-06-30 15:04:58 DEBUG] Execute wrapper: /usr/bin/sudo -u root /usr/bin/nice -n -20 /usr/bin/sudo -u krun /bin/dash /
tmp/krun_wrapper.dash
[2016-06-30 15:04:58 DEBUG] Delete krun user
[2016-06-30 15:04:58 DEBUG] execute shell cmd: /usr/bin/sudo -u root userdel -r -f krun
[2016-06-30 15:04:59 DEBUG] Create krun user
[2016-06-30 15:04:59 DEBUG] execute shell cmd: /usr/bin/sudo -u root useradd -m krun
[2016-06-30 15:04:59 DEBUG] sync disks...
[2016-06-30 15:04:59 WARNING] SIMULATED: `time.sleep(30)` (--quick)
[2016-06-30 15:04:59 INFO] stderr: [iterations_runner.c] iteration 1/5
[2016-06-30 15:05:00 INFO] stderr: [iterations_runner.c] iteration 2/5
...
```