### PR TITLE
Improve TSR Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
 script:
     - sudo update-java-alternatives -l || true  # returns 1 on success!
     - sudo update-java-alternatives -s `sudo update-java-alternatives -l | grep 8-oracle | awk '{print $1}'`
-    - py.test --cov-report term --cov=krun  krun
     - uname -a
     - make --version
     - ldd --version
@@ -24,5 +23,8 @@ script:
     - cd examples/benchmarks
     - make
     - make java-bench
-    - cd ../
+    - cd ../../
+    - make
+    - py.test --cov-report term --cov=krun krun libkrun
+    - cd examples
     - python ../krun.py --no-pstate-check --no-tickless-check --no-user-change travis.krun

--- a/iterations_runners/Makefile
+++ b/iterations_runners/Makefile
@@ -1,4 +1,4 @@
-C_ITER_RUNNER_CFLAGS = -fPIC -Wall -Wextra -pedantic
+C_ITER_RUNNER_CFLAGS = -fPIC -Wall -Wextra -pedantic -std=gnu99
 
 ifeq ($(shell uname -s),Linux)
 	C_ITER_RUNNER_LDFLAGS = -ldl -lrt

--- a/iterations_runners/iterations_runner.c
+++ b/iterations_runners/iterations_runner.c
@@ -17,11 +17,10 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "../libkrun/libkruntime.h"
+
 #define BENCH_FUNC_NAME "run_iter"
 
-/* from libkruntime */
-double clock_gettime_monotonic();
-u_int64_t read_ts_reg();
 
 int
 convert_str_to_int(char *s)
@@ -111,9 +110,9 @@ main(int argc, char **argv)
 
         /* timed section */
         krun_wallclock_start = clock_gettime_monotonic();
-        krun_tsr_start = read_ts_reg();
+        krun_tsr_start = read_ts_reg_start();
         (void) (*krun_bench_func)(krun_param);
-        krun_tsr_stop = read_ts_reg();
+        krun_tsr_stop = read_ts_reg_stop();
         krun_wallclock_stop = clock_gettime_monotonic();
 
         krun_iter_times[krun_iter_num] =

--- a/iterations_runners/iterations_runner.java
+++ b/iterations_runners/iterations_runner.java
@@ -132,7 +132,8 @@ class IterationsRunner {
     }
 
     public static native double JNI_clock_gettime_monotonic();
-    public static native long JNI_read_ts_reg();
+    public static native long JNI_read_ts_reg_start();
+    public static native long JNI_read_ts_reg_stop();
 
     public static void main(String args[]) throws
         ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, java.lang.reflect.InvocationTargetException {
@@ -190,9 +191,9 @@ class IterationsRunner {
             }
 
             double startTime = IterationsRunner.JNI_clock_gettime_monotonic();
-            long tsrStartTime = IterationsRunner.JNI_read_ts_reg();
+            long tsrStartTime = IterationsRunner.JNI_read_ts_reg_start();
             ke.run_iter(param);
-            long tsrStopTime = IterationsRunner.JNI_read_ts_reg();
+            long tsrStopTime = IterationsRunner.JNI_read_ts_reg_stop();
             double stopTime = IterationsRunner.JNI_clock_gettime_monotonic();
 
             // Instrumentation mode emits a JSON dict onto a marker line.

--- a/iterations_runners/iterations_runner.js
+++ b/iterations_runners/iterations_runner.js
@@ -25,9 +25,9 @@ for (BM_i = 0; BM_i < BM_n_iters; BM_i++) {
     }
 
     var BM_start_time = clock_gettime_monotonic();
-    var BM_tsr_start_time = read_ts_reg();
+    var BM_tsr_start_time = read_ts_reg_start_double();
     run_iter(BM_param);
-    var BM_tsr_stop_time = read_ts_reg();
+    var BM_tsr_stop_time = read_ts_reg_stop_double();
     var BM_stop_time = clock_gettime_monotonic();
 
     BM_iter_times[BM_i] = BM_stop_time - BM_start_time;

--- a/iterations_runners/iterations_runner.lua
+++ b/iterations_runners/iterations_runner.lua
@@ -1,7 +1,8 @@
 local ffi = require("ffi")
 ffi.cdef[[
     double clock_gettime_monotonic();
-    double read_ts_reg_double();
+    double read_ts_reg_start_double();
+    double read_ts_reg_stop_double();
 ]]
 local kruntime = ffi.load("kruntime")
 
@@ -34,9 +35,9 @@ for BM_i = 1, BM_iters, 1 do
     end
 
     local BM_start_time = kruntime.clock_gettime_monotonic()
-    local BM_tsr_start_time = kruntime.read_ts_reg_double();
+    local BM_tsr_start_time = kruntime.read_ts_reg_start_double();
     run_iter(BM_param) -- run one iteration of benchmark
-    local BM_tsr_end_time = kruntime.read_ts_reg_double();
+    local BM_tsr_end_time = kruntime.read_ts_reg_stop_double();
     local BM_end_time = kruntime.clock_gettime_monotonic()
 
     BM_iter_times[BM_i] = BM_end_time - BM_start_time

--- a/iterations_runners/iterations_runner.php
+++ b/iterations_runners/iterations_runner.php
@@ -47,9 +47,9 @@ for ($BM_i = 0; $BM_i < $BM_iters; $BM_i++) {
     }
 
     $BM_start_time = clock_gettime_monotonic();
-    $BM_tsr_start_time = read_ts_reg();
+    $BM_tsr_start_time = read_ts_reg_start_double();
     run_iter($BM_param);
-    $BM_tsr_stop_time = read_ts_reg();
+    $BM_tsr_stop_time = read_ts_reg_stop_double();
     $BM_stop_time = clock_gettime_monotonic();
 
     $BM_iter_times[$BM_i] = $BM_stop_time - $BM_start_time;

--- a/iterations_runners/iterations_runner.py
+++ b/iterations_runners/iterations_runner.py
@@ -9,15 +9,19 @@ In Kalibera terms, this script represents one executions level run.
 
 import cffi, sys, imp, os
 
+
 ffi = cffi.FFI()
+
 ffi.cdef("""
     double clock_gettime_monotonic();
-    uint64_t read_ts_reg();
+    uint64_t read_ts_reg_start();
+    uint64_t read_ts_reg_stop();
 """)
 libkruntime = ffi.dlopen("libkruntime.so")
 
 clock_gettime_monotonic = libkruntime.clock_gettime_monotonic
-read_ts_reg = libkruntime.read_ts_reg
+read_ts_reg_start = libkruntime.read_ts_reg_start
+read_ts_reg_stop = libkruntime.read_ts_reg_stop
 
 # main
 if __name__ == "__main__":
@@ -54,9 +58,9 @@ if __name__ == "__main__":
                 "[iterations_runner.py] iteration %d/%d\n" % (i + 1, iters))
 
         start_time = clock_gettime_monotonic()
-        tsr_start_time = read_ts_reg()
+        tsr_start_time = read_ts_reg_start()
         bench_func(param)
-        tsr_stop_time = read_ts_reg()
+        tsr_stop_time = read_ts_reg_stop()
         stop_time = clock_gettime_monotonic()
 
         # In instrumentation mode, write an iteration separator to stderr.

--- a/iterations_runners/iterations_runner.rb
+++ b/iterations_runners/iterations_runner.rb
@@ -18,15 +18,6 @@ def assert(cond)
     end
 end
 
-# use only on the result of read_tsr_reg() which should only return signed64
-def signed64_to_unsigned(x)
-    if x >= 0 then
-        return x
-    else
-        return x + 2**64  # will make a bigum
-    end
-end
-
 # main
 if __FILE__ == $0
     if ARGV.length != 5
@@ -53,13 +44,13 @@ if __FILE__ == $0
         end
 
         start_time = clock_gettime_monotonic()
-        tsr_start_time = read_ts_reg()
+        tsr_start_time = read_ts_reg_start()
         run_iter(param)
-        tsr_stop_time = read_ts_reg()
+        tsr_stop_time = read_ts_reg_stop()
         stop_time = clock_gettime_monotonic()
 
         iter_times[iter_num] = stop_time - start_time
-        tsr_iter_times[iter_num] = signed64_to_unsigned(tsr_stop_time) - signed64_to_unsigned(tsr_start_time)
+        tsr_iter_times[iter_num] = tsr_stop_time - tsr_start_time
     end
 
     STDOUT.write "[["

--- a/libkrun/.gitignore
+++ b/libkrun/.gitignore
@@ -1,0 +1,1 @@
+test/test_prog

--- a/libkrun/Makefile
+++ b/libkrun/Makefile
@@ -1,4 +1,5 @@
 LIBKRUNTIME_CFLAGS =	-Wall -shared -fPIC
+COMMON_CFLAGS = -Wall -pedantic -std=gnu99
 
 ifeq ($(shell uname -s),Linux)
 	LIBKRUNTIME_LDFLAGS =	-lrt -ldl
@@ -12,12 +13,16 @@ endif
 
 .PHONY: clean
 
-all: libkruntime.so
+all: libkruntime.so test/test_prog
 
-libkruntime.so: libkruntime.c
+libkruntime.so: libkruntime.c libkruntime.h
 	${CC} ${JAVA_CPPFLAGS} ${JAVA_CFLAGS} ${LIBKRUNTIME_CFLAGS} ${CFLAGS} \
-		${CPPFLAGS} libkruntime.c -o libkruntime.so \
-		${JAVA_LDFLAGS} ${LDFLAGS} ${LIBKRUNTIME_LDFLAGS}\
+		${CPPFLAGS} ${COMMON_CFLAGS} libkruntime.c -o libkruntime.so \
+		${JAVA_LDFLAGS} ${LDFLAGS} ${LIBKRUNTIME_LDFLAGS}
+
+test/test_prog: test/test_prog.c libkruntime.so
+	${CC} ${CFLAGS} ${CPPFLAGS} ${COMMON_CFLAGS} test/test_prog.c \
+		-o test/test_prog ${LDFLAGS} -L. -lkruntime -Wl,-rpath=$(shell pwd)
 
 clean:
-	rm -f libkruntime.so
+	rm -f libkruntime.so test/test_prog

--- a/libkrun/libkruntime.c
+++ b/libkrun/libkruntime.c
@@ -1,5 +1,5 @@
 /*
- * C function to get at the monotonic clock.
+ * C support functions.
  *
  * Code style is KNF with 4 spaces instead of tabs.
  */
@@ -7,14 +7,19 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <stdio.h>
+#include <inttypes.h>
+
+#include "libkruntime.h"
+
+#ifdef WITH_JAVA
+#include <jni.h>
+#endif
 
 #if defined(__linux__)
 #define ACTUAL_CLOCK_MONOTONIC    CLOCK_MONOTONIC_RAW
 #else
 #define ACTUAL_CLOCK_MONOTONIC    CLOCK_MONOTONIC
 #endif
-
-u_int64_t read_ts_reg();
 
 double
 clock_gettime_monotonic()
@@ -35,7 +40,6 @@ clock_gettime_monotonic()
  * JNI Implementation -- Optionally compiled in
  */
 #ifdef WITH_JAVA
-#include <jni.h>
 
 JNIEXPORT jdouble JNICALL
 Java_IterationsRunner_JNI_1clock_1gettime_1monotonic(JNIEnv *e, jclass c) {
@@ -43,36 +47,105 @@ Java_IterationsRunner_JNI_1clock_1gettime_1monotonic(JNIEnv *e, jclass c) {
 }
 
 JNIEXPORT jlong JNICALL
-Java_IterationsRunner_JNI_1read_1ts_1reg(JNIEnv *e, jclass c)
+Java_IterationsRunner_JNI_1read_1ts_1reg_1start(JNIEnv *e, jclass c)
 {
-    return read_ts_reg();
+    return read_ts_reg_start();
+}
+
+JNIEXPORT jlong JNICALL
+Java_IterationsRunner_JNI_1read_1ts_1reg_1stop(JNIEnv *e, jclass c)
+{
+    return read_ts_reg_stop();
 }
 #endif
 
 /*
  * Support for reading the TS (timestamp) register.
  *
- * This assumes and x86 CPU.
+ * These functions assume an x86-64 CPU.
  *
- * Derived from:
- * $OpenBSD: pctr.h,v 1.5 2014/03/29 18:09:28 guenther Exp $
+ * For more info, see page 16 of:
+ *
+ * "How to Benchmark Code Execution Times on Intel® IA-32 and IA-64
+ * Instruction Set Architectures" by Gabriele Paoloni.
  */
+
 u_int64_t
-read_ts_reg()
+read_ts_reg_start()
 {
     u_int32_t hi, lo;
 
-    __asm volatile("rdtsc" : "=d" (hi), "=a" (lo));
+    __asm volatile (
+        "cpuid\n\t"             // Barrier (trashes e[abcd]x)
+        "rdtsc\n\t"             // Put TSR in edx:eax, also trashes ecx
+        "mov %%edx, %0\n\t"     // Copy out the high 32-bits of TSR
+        "mov %%eax, %1\n\t"     // Copy out the low 32-bits of TSR
+        // ---
+        : "=r" (hi), "=r" (lo)              // outputs
+        :                                   // inputs
+        : "%rax", "%rbx", "%rcx", "%rdx");  // other clobbers
+    return ((u_int64_t) hi << 32) | (u_int64_t) lo;
+}
+
+u_int64_t
+read_ts_reg_stop()
+{
+    u_int32_t hi, lo;
+
+    __asm volatile(
+        "rdtscp\n\t"                    // Put TSR in edx:eax, also trashes ecx
+        "mov %%edx, %0\n\t"             // Copy out the high 32-bits of TSR
+        "mov %%eax, %1\n\t"             // Copy out the low 32-bits of TSR
+        "cpuid\n\t"                     // Barrier (trashes e[abcd]x)
+        // ---
+        : "=r" (hi), "=r" (lo)              // outputs
+        :                                   // inputs
+        : "%rax", "%rbx", "%rcx", "%rdx");  // other clobbers
     return ((u_int64_t) hi << 32) | (u_int64_t) lo;
 }
 
 /*
- * Return TSR as a double.
- *
  * For languages like Lua, where there is suitible integer type
  */
 double
-read_ts_reg_double()
+read_ts_reg_start_double()
 {
-    return (double) read_ts_reg();
+    return u64_to_double(read_ts_reg_start());
+}
+
+double
+read_ts_reg_stop_double()
+{
+    return u64_to_double(read_ts_reg_stop());
+}
+
+/*
+ * Check for double precision loss.
+ *
+ * Since some languages cannot represent a u_int64_t, we sometimes have to pass
+ * around a double. This is annoying since precision could be silently lost.
+ * This function makes loss of precision explicit, stopping the VM.
+ *
+ * We don't expect to actually see a crash since the TSR is zeroed at reboot,
+ * and our benchmarks are not long enough running to generate a large enough
+ * TSR value to cause precision loss (you would need a integer that would not
+ * fit in a 52-bit unsigned int before precision starts being lost in
+ * lower-order bits). Nevertheless, we check it.
+ *
+ * This routine comes at a small cost (a handful of asm instrs). Note that this
+ * cost is a drop in the ocean compared to benchmark workloads.
+ */
+double
+u64_to_double(u_int64_t u64_val)
+{
+    double d_val = (double) u64_val;
+    u_int64_t u64_val2 = (u_int64_t) d_val;
+
+    if (u64_val != u64_val2) {
+        fprintf(stderr, "Loss of precision detected!\n");
+        fprintf(stderr, "%" PRIu64 " != %" PRIu64 "\n", u64_val, u64_val2);
+        exit(EXIT_FAILURE);
+    }
+    // (otherwise all is well)
+    return d_val;
 }

--- a/libkrun/libkruntime.h
+++ b/libkrun/libkruntime.h
@@ -1,0 +1,38 @@
+#ifndef __LIBKRUNTIME_H
+#define __LIBKRUNTIME_H
+
+#include <time.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+
+#ifdef WITH_JAVA
+#include <jni.h>
+#endif // WITH_JAVA
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+u_int64_t read_ts_reg_start();
+u_int64_t read_ts_reg_stop();
+
+double read_ts_reg_start_double();
+double read_ts_reg_stop_double();
+
+double read_ts_reg_start_double();
+double clock_gettime_monotonic();
+
+double u64_to_double(u_int64_t val);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef WITH_JAVA
+JNIEXPORT jdouble JNICALL Java_IterationsRunner_JNI_1clock_1gettime_1monotonic(JNIEnv *e, jclass c);
+JNIEXPORT jlong JNICALL Java_IterationsRunner_JNI_1read_1ts_1reg_1start(JNIEnv *e, jclass c);
+JNIEXPORT jlong JNICALL Java_IterationsRunner_JNI_1read_1ts_1reg_1stop(JNIEnv *e, jclass c);
+#endif  // WITH_JAVA
+
+#endif  // __LIBKRUNTIME_H

--- a/libkrun/test/test_libkruntime.py
+++ b/libkrun/test/test_libkruntime.py
@@ -1,0 +1,67 @@
+from subprocess import Popen, PIPE
+import os
+
+# Some TSR tests collect two TSR readings as fast as possible, so the delta
+# should be pretty small (but it ultimately depends upon the CPU).
+NOT_MANY_CYCLES = 5000
+
+DIR = os.path.abspath(os.path.dirname(__file__))
+TEST_PROG_PATH = os.path.join(DIR, "test_prog")
+
+
+def invoke_c_prog(mode):
+    assert os.path.exists(TEST_PROG_PATH)
+
+    p = Popen(TEST_PROG_PATH + " " + mode,
+              stderr=PIPE, stdout=PIPE, shell=True)
+    out, err = p.communicate()
+    return p.returncode, out.strip(), err.strip()
+
+
+def parse_keyvals(out, doubles=True):
+    dct = {}
+    for line in out.splitlines():
+        key, val = line.split("=")
+        if doubles:
+            dct[key.strip()] = float(val)
+        else:
+            dct[key.strip()] = int(val)
+    return dct
+
+
+class TestLibKrunTime(object):
+    def test_tsr_u64(self):
+        rv, out, _ = invoke_c_prog("tsr_u64")
+        assert rv == 0
+        dct = parse_keyvals(out)
+        assert 0 <= dct["tsr_u64_delta"] <= NOT_MANY_CYCLES
+
+    def test_tsr_double(self):
+        rv, out, _ = invoke_c_prog("tsr_double")
+        assert rv == 0
+        dct = parse_keyvals(out, True)
+        assert 0 <= dct["tsr_double_delta"] <= NOT_MANY_CYCLES
+
+    def test_tsr_double_prec_ok(self):
+        rv, out, _ = invoke_c_prog("tsr_double_prec_ok")
+        assert rv == 0
+        assert out == "OK"
+
+    def test_tsr_double_prec_bad(self):
+        rv, _, err = invoke_c_prog("tsr_double_prec_bad")
+        assert rv == 1
+        assert "Loss of precision detected!" in err
+
+    def test_tsr_u64_double_ratio(self):
+        rv, out, _ = invoke_c_prog("tsr_u64_double_ratio")
+        assert rv == 0
+        dct = parse_keyvals(out, True)
+        # The integer version should always be faster
+        assert dct["tsr_u64_double_ratio"] <= 1
+
+    def test_clock_gettime_monotonic(self):
+        rv, out, _ = invoke_c_prog("clock_gettime_monotonic")
+        assert rv == 0
+        dct = parse_keyvals(out)
+        # Depends on speed of CPU, but should be very close to 1
+        assert 0.95 <= dct["monotonic_delta"] <= 1.05

--- a/libkrun/test/test_prog.c
+++ b/libkrun/test/test_prog.c
@@ -1,0 +1,134 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../libkruntime.h"
+
+void test_tsr_u64(void);
+void test_tsr_double(void);
+void test_tsr_double_prec_ok(void);
+void test_tsr_double_prec_bad(void);
+void test_tsr_u64_double_ratio(void);
+void test_clock_gettime_monotonic(void);
+
+void usage();
+
+void
+usage()
+{
+    printf("usages:\n");
+    printf("  test tsr_u64\n");
+    printf("  test tsr_double\n");
+    printf("  test tsr_double_prec_ok\n");
+    printf("  test tsr_double_prec_bad\n");
+    printf("  test tsr_u64_double_ratio\n");
+    printf("  test clock_gettime_monotonic\n");
+
+    exit(EXIT_FAILURE);
+}
+
+int
+main(int argc, char **argv)
+{
+    char *mode;
+
+    if (argc != 2) {
+        usage();
+    }
+
+    mode = argv[1];
+
+    if (strcmp(mode, "tsr_u64") == 0) {
+        test_tsr_u64();
+    } else if (strcmp(mode, "tsr_double") == 0) {
+        test_tsr_double();
+    } else if (strcmp(mode, "tsr_double_prec_ok") == 0) {
+        test_tsr_double_prec_ok();
+    } else if (strcmp(mode, "tsr_double_prec_bad") == 0) {
+        test_tsr_double_prec_bad();
+    } else if (strcmp(mode, "tsr_u64_double_ratio") == 0) {
+        test_tsr_u64_double_ratio();
+    } else if (strcmp(mode, "clock_gettime_monotonic") == 0) {
+        test_clock_gettime_monotonic();
+    } else {
+        usage();
+    }
+
+    return (EXIT_SUCCESS);
+}
+
+void
+test_tsr_u64(void) {
+    uint64_t t1, t2, delta;
+
+    t1 = read_ts_reg_start();
+    t2 = read_ts_reg_stop();
+    delta = t2 - t1;
+
+    printf("tsr_u64_start= %" PRIu64 "\n", t1);
+    printf("tsr_u64_stop = %" PRIu64 "\n", t2);
+    printf("tsr_u64_delta= %" PRIu64 "\n", delta);
+}
+
+void
+test_tsr_double(void)
+{
+    double t1, t2, delta;
+
+    t1 = read_ts_reg_start_double();
+    t2 = read_ts_reg_stop_double();
+    delta = t2 - t1;
+
+    printf("tsr_double_start= %f\n", t1);
+    printf("tsr_double_stop = %f\n", t2);
+    printf("tsr_double_delta= %f\n", delta);
+}
+
+void
+test_tsr_double_prec_ok(void)
+{
+    (void) u64_to_double(666);
+    printf("OK\n");
+}
+
+void
+test_tsr_double_prec_bad(void)
+{
+    (void) u64_to_double(((u_int64_t) 1 << 62) - 1);
+}
+
+void
+test_tsr_u64_double_ratio(void)
+{
+    u_int64_t i_time1, i_time2, i_delta;
+    double d_time1, d_time2, d_delta, ratio;
+
+    i_time1 = read_ts_reg_start();
+    i_time2 = read_ts_reg_stop();
+
+    d_time1 = read_ts_reg_start_double();
+    d_time2 = read_ts_reg_stop_double();
+
+    i_delta = i_time2 - i_time1;
+    d_delta = d_time2 - d_time1;
+    ratio = i_delta / d_delta;
+
+    printf("tsr_u64_double_ratio=%f\n", ratio);
+}
+
+void
+test_clock_gettime_monotonic()
+{
+    double t1, t2, delta;
+
+    t1 = clock_gettime_monotonic();
+    sleep(1);
+    t2 = clock_gettime_monotonic();
+    delta = t2 - t1;
+
+    printf("monotonic_start= %f\n", t1);
+    printf("monotonic_stop = %f\n", t2);
+    printf("monotonic_delta= %f\n", delta);
+}


### PR DESCRIPTION
This change:

 * Implements "intel style" TSR benchmarking in libkruntime.
 * Checks for precision loss in VMs using doubles.
 * Introduces a proper header file for libkruntime (some VMs will use this).
 * Introduces a test program (initially used for development, but may as well keep it).
 * Updates all iteration runners to use the new interface.

The change of C standard was to work around some annoyances to do with `timeval` and `u_int`* on linux.

Will post a PR for the warmup experiment too. EDIT: https://github.com/softdevteam/warmup_experiment/pull/147

Looks good? Did I miss anything?