### PR TITLE
Core cycles support for Krun

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ up correctly).
 ## Security Notes
 
 Krun is not intended to be run on a secure multi-user system, as it uses sudo
-to elevate proveleges.
+to elevate privileges.
 
 Sudo is used to:
 
@@ -447,6 +447,8 @@ Sudo is used to:
  * Set process priorities.
  * Create cgroup shields (Linux only, off by default)
  * Detect virtualised hosts.
+ * Change Linux capabilities(7) for MSR device node access.
+ * Change MSR device node filesystem permissions.
 
 Please make sure you understand the implications of this.
 

--- a/iterations_runners/iterations_runner.c
+++ b/iterations_runners/iterations_runner.c
@@ -53,9 +53,9 @@ main(int argc, char **argv)
     void     *krun_dl_handle = 0;
     int     (*krun_bench_func)(int); /* func ptr to benchmark entry */
     double    krun_wallclock_start = -1, krun_wallclock_stop = -1;
-    double   *krun_iter_times = NULL;
-    u_int64_t krun_tsr_start = 0, krun_tsr_stop = 0;
-    u_int64_t *krun_tsr_iter_times = NULL;
+    double   *krun_wallclock_times = NULL;
+    u_int64_t krun_cycles_start = 0, krun_cycles_stop = 0;
+    u_int64_t *krun_cycle_counts = NULL;
 
     if (argc != 6) {
         printf("usage: iterations_runner_c "
@@ -68,6 +68,8 @@ main(int argc, char **argv)
     krun_total_iters = convert_str_to_int(argv[2]);
     krun_param = convert_str_to_int(argv[3]);
     krun_debug = convert_str_to_int(argv[4]);
+
+    libkruntime_init();
 
     krun_dl_handle = dlopen(krun_benchmark, RTLD_NOW | RTLD_LOCAL);
     if (krun_dl_handle == NULL) {
@@ -82,22 +84,22 @@ main(int argc, char **argv)
         goto clean;
     }
 
-    krun_iter_times = calloc(krun_total_iters, sizeof(double));
-    if (krun_iter_times == NULL) {
+    krun_wallclock_times = calloc(krun_total_iters, sizeof(double));
+    if (krun_wallclock_times == NULL) {
         errx(EXIT_FAILURE, "%s", strerror(errno));
         goto clean;
     }
 
-    krun_tsr_iter_times = calloc(krun_total_iters, sizeof(u_int64_t));
-    if (krun_tsr_iter_times == NULL) {
+    krun_cycle_counts = calloc(krun_total_iters, sizeof(u_int64_t));
+    if (krun_cycle_counts == NULL) {
         errx(EXIT_FAILURE, "%s", strerror(errno));
         goto clean;
     }
 
     for (krun_iter_num = 0; krun_iter_num < krun_total_iters;
         krun_iter_num++) {
-        krun_iter_times[krun_iter_num] = 0;
-        krun_tsr_iter_times[krun_iter_num] = 0;
+        krun_wallclock_times[krun_iter_num] = 0;
+        krun_cycle_counts[krun_iter_num] = 0;
     }
 
     for (krun_iter_num = 0; krun_iter_num < krun_total_iters;
@@ -109,23 +111,37 @@ main(int argc, char **argv)
         }
 
         /* timed section */
+        krun_cycles_start = read_core_cycles();
         krun_wallclock_start = clock_gettime_monotonic();
-        krun_tsr_start = read_ts_reg_start();
         (void) (*krun_bench_func)(krun_param);
-        krun_tsr_stop = read_ts_reg_stop();
         krun_wallclock_stop = clock_gettime_monotonic();
+        krun_cycles_stop = read_core_cycles();
 
-        krun_iter_times[krun_iter_num] =
+        if (krun_cycles_start > krun_cycles_stop) {
+            fprintf(stderr, "cycle count start greater than stop\n");
+            fprintf(stderr, "start=%" PRIu64 ", stop=%" PRIu64 "\n",
+                krun_cycles_start, krun_cycles_stop);
+            exit(EXIT_FAILURE);
+        }
+
+        if (krun_wallclock_start > krun_wallclock_stop) {
+            fprintf(stderr, "wallclock time start greater than stop\n");
+            fprintf(stderr, "start=%f, stop=%f\n",
+                krun_wallclock_start, krun_wallclock_stop);
+            exit(EXIT_FAILURE);
+        }
+
+        krun_wallclock_times[krun_iter_num] =
             krun_wallclock_stop - krun_wallclock_start;
-        krun_tsr_iter_times[krun_iter_num] =
-            krun_tsr_stop - krun_tsr_start;
+        krun_cycle_counts[krun_iter_num] =
+            krun_cycles_stop - krun_cycles_start;
     }
 
     /* Emit results */
     fprintf(stdout, "[[");
     for (krun_iter_num = 0; krun_iter_num < krun_total_iters;
         krun_iter_num++) {
-        fprintf(stdout, "%f", krun_iter_times[krun_iter_num]);
+        fprintf(stdout, "%f", krun_wallclock_times[krun_iter_num]);
 
         if (krun_iter_num < krun_total_iters - 1) {
             fprintf(stdout, ", ");
@@ -134,7 +150,7 @@ main(int argc, char **argv)
     fprintf(stdout, "], \n[");
     for (krun_iter_num = 0; krun_iter_num < krun_total_iters;
         krun_iter_num++) {
-        fprintf(stdout, "%" PRIu64, krun_tsr_iter_times[krun_iter_num]);
+        fprintf(stdout, "%" PRIu64, krun_cycle_counts[krun_iter_num]);
 
         if (krun_iter_num < krun_total_iters - 1) {
             fprintf(stdout, ", ");
@@ -143,11 +159,13 @@ main(int argc, char **argv)
     fprintf(stdout, "]]\n");
 
 clean:
-    free(krun_iter_times);
+    free(krun_wallclock_times);
 
     if (krun_dl_handle != NULL) {
         dlclose(krun_dl_handle);
     }
+
+    libkruntime_done();
 
     return (EXIT_SUCCESS);
 }

--- a/iterations_runners/iterations_runner.lua
+++ b/iterations_runners/iterations_runner.lua
@@ -1,8 +1,9 @@
 local ffi = require("ffi")
 ffi.cdef[[
-    double clock_gettime_monotonic();
-    double read_ts_reg_start_double();
-    double read_ts_reg_stop_double();
+    double libkruntime_init(void);
+    double libkruntime_done(void);
+    double clock_gettime_monotonic(void);
+    double read_core_cycles_double(void);
 ]]
 local kruntime = ffi.load("kruntime")
 
@@ -12,48 +13,64 @@ local BM_param = tonumber(arg[3])
 local BM_debug = tonumber(arg[4]) > 0
 
 if #arg ~= 5 then
-    print("usage: iterations_runner.lua <benchmark> <# of iterations> " ..
-          "<benchmark param> <debug flag> <instrument flag>")
+    io.stderr:write("usage: iterations_runner.lua <benchmark> <# of iterations> " ..
+                    "<benchmark param> <debug flag> <instrument flag>")
     os.exit(1)
 end
 
 dofile(BM_benchmark)
 
-local BM_iter_times = {}
+local BM_wallclock_times = {}
 for BM_i = 1, BM_iters, 1 do
-    BM_iter_times[BM_i] = 0
+    BM_wallclock_times[BM_i] = 0
 end
 
-local BM_tsr_iter_times = {}
+local BM_cycle_counts = {}
 for BM_i = 1, BM_iters, 1 do
-    BM_tsr_iter_times[BM_i] = 0
+    BM_cycle_counts[BM_i] = 0
 end
+
+kruntime.libkruntime_init()
 
 for BM_i = 1, BM_iters, 1 do
     if BM_debug then
         io.stderr:write(string.format("[iterations_runner.lua] iteration %d/%d\n", BM_i, BM_iters))
     end
 
-    local BM_start_time = kruntime.clock_gettime_monotonic()
-    local BM_tsr_start_time = kruntime.read_ts_reg_start_double();
+    local BM_cycles_start = kruntime.read_core_cycles_double();
+    local BM_wallclock_start = kruntime.clock_gettime_monotonic()
     run_iter(BM_param) -- run one iteration of benchmark
-    local BM_tsr_end_time = kruntime.read_ts_reg_stop_double();
-    local BM_end_time = kruntime.clock_gettime_monotonic()
+    local BM_wallclock_stop = kruntime.clock_gettime_monotonic()
+    local BM_cycles_stop = kruntime.read_core_cycles_double()
 
-    BM_iter_times[BM_i] = BM_end_time - BM_start_time
-    BM_tsr_iter_times[BM_i] = BM_tsr_end_time - BM_tsr_start_time
+    if BM_wallclock_start > BM_wallclock_stop then
+        io.stderr:write("wallclock start is greater than stop\n")
+        io.stderr:write(String.format("start=%d stop=%d\n", BM_wallclock_start, BM_wallclock_stop))
+        os.exit(1)
+    end
+
+    if BM_cycles_start > BM_cycles_stop then
+        io.stderr:write("cycles start is greater than stop\n")
+        io.stderr:write(String.format("start=%d stop=%d\n", BM_cycles_start, BM_cycles_stop))
+        os.exit(1)
+    end
+
+    BM_wallclock_times[BM_i] = BM_wallclock_stop - BM_wallclock_start
+    BM_cycle_counts[BM_i] = BM_cycles_stop - BM_cycles_start
 end
+
+kruntime.libkruntime_done()
 
 io.stdout:write("[[")
 for BM_i = 1, BM_iters, 1 do
-    io.stdout:write(BM_iter_times[BM_i])
+    io.stdout:write(BM_wallclock_times[BM_i])
     if BM_i < BM_iters then
         io.stdout:write(", ")
     end
 end
 io.stdout:write("], [")
 for BM_i = 1, BM_iters, 1 do
-    io.stdout:write(BM_tsr_iter_times[BM_i])
+    io.stdout:write(BM_cycle_counts[BM_i])
     if BM_i < BM_iters then
         io.stdout:write(", ")
     end

--- a/krun/results.py
+++ b/krun/results.py
@@ -18,8 +18,8 @@ class Results(object):
 
         # Maps key to results:
         # "bmark:vm:variant" -> [[e0i0, e0i1, ...], [e1i0, e1i1, ...], ...]
-        self.data = dict()      # wall-clock times
-        self.tsr_data = dict()  # timestamp register times
+        self.data = dict()              # wall-clock times
+        self.core_cycles_data = dict()  # core cycles all cores
 
         self.reboots = 0
 
@@ -69,7 +69,7 @@ class Results(object):
                 for variant in vm_info["variants"]:
                     key = ":".join((bmark, vm_name, variant))
                     self.data[key] = []
-                    self.tsr_data[key] = []
+                    self.core_cycles_data[key] = []
                     self.instr_data[key] = defaultdict(list)
                     self.eta_estimates[key] = []
 
@@ -92,7 +92,7 @@ class Results(object):
         to_write = {
             "config": self.config.text,
             "data": self.data,
-            "tsr_data": self.tsr_data,
+            "core_cycles_data": self.core_cycles_data,
             "instr_data": self.instr_data,
             "audit": self.audit.audit,
             "reboots": self.reboots,

--- a/krun/util.py
+++ b/krun/util.py
@@ -101,7 +101,7 @@ def check_and_parse_execution_results(stdout, stderr, rc):
         raise ExecutionFailed(err_s)
 
     assert len(json_data) == 2
-    return json_data  # [wall-clock times, TSR reg times]
+    return json_data  # [wall-clock times, core-cycle counts]
 
 def spawn_sanity_check(platform, entry_point, vm_def,
                        check_name, force_dir=None):

--- a/libkrun/Makefile
+++ b/libkrun/Makefile
@@ -1,6 +1,10 @@
 LIBKRUNTIME_CFLAGS =	-Wall -shared -fPIC
 COMMON_CFLAGS = -Wall -pedantic -std=gnu99
 
+ifeq ("${TRAVIS}", "true")
+	COMMON_CFLAGS += -DTRAVIS
+endif
+
 ifeq ($(shell uname -s),Linux)
 	LIBKRUNTIME_LDFLAGS =	-lrt -ldl
 else

--- a/libkrun/libkruntime.c
+++ b/libkrun/libkruntime.c
@@ -1,5 +1,10 @@
 /*
- * C support functions.
+ * C support functions for timing.
+ *
+ * Note that this library contains explicit calls to exit() upon error
+ * conditions.
+ *
+ * This file assumes you are using an x86 system.
  *
  * Code style is KNF with 4 spaces instead of tabs.
  */
@@ -8,6 +13,9 @@
 #include <errno.h>
 #include <stdio.h>
 #include <inttypes.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdint.h>
 
 #include "libkruntime.h"
 
@@ -20,6 +28,44 @@
 #else
 #define ACTUAL_CLOCK_MONOTONIC    CLOCK_MONOTONIC
 #endif
+
+#if defined(__linux__) && !defined(TRAVIS)
+/*
+ * Rather than open and close the MSR device nodes all the time, we hold them
+ * open over multiple in-process iterations, thus minimising the amount of work
+ * that needs to be done to use them
+ */
+int *msr_w_nodes = NULL;
+int *msr_r_nodes = NULL;
+
+int num_msr_nodes = -1;
+#define MAX_MSR_PATH 32
+
+// Fixed-funtion counter control register
+#define MSR_IA32_FIXED_CTR_CTRL 0x38d
+
+/*
+ * Bitfields of MSR_IA32_FIXED_CTR_CTRL related to fixed counter 1.
+ * AKA, CPU_CLK_UNHLATED.CORE in the Intel manual.
+ */
+// Enable couting in ring 0
+#define EN1_OS      1 << 4
+// Enable counting in higer rings
+#define EN1_USR     1 << 5
+// Enable counting for all core threads (if any)
+#define EN1_ANYTHR  1 << 6
+
+/* MSR address of fixed-function performance counter 1 */
+#define PCTR_IA32_PERF_FIXED_CTR1    0x30a
+uint64_t pctr_val_mask = 0; // configured in initialisation
+
+#elif defined(__linux__) && defined(TRAVIS)
+// Travis has no performance counters.
+#elif defined(__OpenBSD__)
+// We do not yet support performance counters on OpenBSD
+#else
+#error "Unsupported platform"
+#endif // __linux__ && !TRAVIS
 
 double
 clock_gettime_monotonic()
@@ -37,9 +83,18 @@ clock_gettime_monotonic()
 }
 
 /*
- * JNI Implementation -- Optionally compiled in
+ * JNI wrappers -- Optionally compiled in
  */
 #ifdef WITH_JAVA
+JNIEXPORT void JNICALL
+Java_IterationsRunner_JNI_1libkruntime_1init(JNIEnv *e, jclass c) {
+    libkruntime_init();
+}
+
+JNIEXPORT void JNICALL
+Java_IterationsRunner_JNI_1libkruntime_1done(JNIEnv *e, jclass c) {
+    libkruntime_done();
+}
 
 JNIEXPORT jdouble JNICALL
 Java_IterationsRunner_JNI_1clock_1gettime_1monotonic(JNIEnv *e, jclass c) {
@@ -47,76 +102,273 @@ Java_IterationsRunner_JNI_1clock_1gettime_1monotonic(JNIEnv *e, jclass c) {
 }
 
 JNIEXPORT jlong JNICALL
-Java_IterationsRunner_JNI_1read_1ts_1reg_1start(JNIEnv *e, jclass c)
+Java_IterationsRunner_JNI_1read_1core_1cycles(JNIEnv *e, jclass c)
 {
-    return read_ts_reg_start();
-}
-
-JNIEXPORT jlong JNICALL
-Java_IterationsRunner_JNI_1read_1ts_1reg_1stop(JNIEnv *e, jclass c)
-{
-    return read_ts_reg_stop();
+    return read_core_cycles();
 }
 #endif
 
-/*
- * Support for reading the TS (timestamp) register.
- *
- * These functions assume an x86-64 CPU.
- *
- * For more info, see page 16 of:
- *
- * "How to Benchmark Code Execution Times on Intel® IA-32 and IA-64
- * Instruction Set Architectures" by Gabriele Paoloni.
- */
-
-u_int64_t
-read_ts_reg_start()
+#if defined(__linux__) && !defined(TRAVIS)
+int
+open_msr_node(int core, int flags)
 {
-    u_int32_t hi, lo;
+    char path[MAX_MSR_PATH];
+    int msr_node;
 
-    __asm volatile (
-        "cpuid\n\t"             // Barrier (trashes e[abcd]x)
-        "rdtsc\n\t"             // Put TSR in edx:eax, also trashes ecx
-        "mov %%edx, %0\n\t"     // Copy out the high 32-bits of TSR
-        "mov %%eax, %1\n\t"     // Copy out the low 32-bits of TSR
-        // ---
-        : "=r" (hi), "=r" (lo)              // outputs
-        :                                   // inputs
-        : "%rax", "%rbx", "%rcx", "%rdx");  // other clobbers
-    return ((u_int64_t) hi << 32) | (u_int64_t) lo;
+    /*
+     * Note this is not the default msr(4) device node!
+     *
+     * We are using a lightly modified version of that driver we call rmsr,
+     * which disables capabilities on the device node. This allows a normal
+     * user to access the device as per normal filesystem permissions, without
+     * having to tag executables with capabilities, and whilst retaining the
+     * use of LD_LIBRARY_PATH (which Krun uses a lot).
+     *
+     * https://github.com/softdevteam/rmsr
+     */
+    if (snprintf(path, MAX_MSR_PATH, "/dev/cpu/%d/rmsr", core) < 0) {
+        perror("snprintf");
+        exit(EXIT_FAILURE);
+    }
+
+    msr_node = open(path, flags);
+    if (msr_node == -1) {
+        perror(path);
+        exit(EXIT_FAILURE);
+    }
+
+    return msr_node;
 }
 
 u_int64_t
-read_ts_reg_stop()
+read_msr(int core, long addr)
 {
-    u_int32_t hi, lo;
+    u_int64_t msr_val;
+    int msr_node;
 
-    __asm volatile(
-        "rdtscp\n\t"                    // Put TSR in edx:eax, also trashes ecx
-        "mov %%edx, %0\n\t"             // Copy out the high 32-bits of TSR
-        "mov %%eax, %1\n\t"             // Copy out the low 32-bits of TSR
-        "cpuid\n\t"                     // Barrier (trashes e[abcd]x)
-        // ---
-        : "=r" (hi), "=r" (lo)              // outputs
-        :                                   // inputs
-        : "%rax", "%rbx", "%rcx", "%rdx");  // other clobbers
-    return ((u_int64_t) hi << 32) | (u_int64_t) lo;
+    msr_node = msr_r_nodes[core];
+
+    if (lseek(msr_node, addr, SEEK_SET) == -1) {
+        perror("lseek");
+        exit(EXIT_FAILURE);
+    }
+
+    if (read(msr_node, &msr_val, sizeof(msr_val)) != sizeof(msr_val)) {
+        perror("read");
+        exit(EXIT_FAILURE);
+    }
+
+    return msr_val;
+}
+
+void
+write_msr(int core, long addr, uint64_t msr_val)
+{
+    int msr_node;
+
+    msr_node = msr_w_nodes[core];
+
+    if (lseek(msr_node, addr, SEEK_SET) == -1) {
+        perror("lseek");
+        exit(EXIT_FAILURE);
+    }
+
+    if (write(msr_node, &msr_val, sizeof(msr_val)) != sizeof(msr_val)) {
+        perror("write");
+        exit(EXIT_FAILURE);
+    }
+}
+
+/*
+ * Configure fixed-function counter 1 to count all rings and threads
+ */
+void
+config_fixed_ctr1(int core, int enable)
+{
+    u_int64_t msr_val = read_msr(core, MSR_IA32_FIXED_CTR_CTRL);
+    if (enable) {
+        msr_val |= (EN1_OS | EN1_USR | EN1_ANYTHR);
+    } else {
+        msr_val &= ~(EN1_OS | EN1_USR | EN1_ANYTHR);
+    }
+    write_msr(core, MSR_IA32_FIXED_CTR_CTRL, msr_val);
+}
+
+void
+config_fixed_ctr1_all_cores(int enable)
+{
+    int core;
+
+    for (core = 0; core < num_msr_nodes; core++) {
+        config_fixed_ctr1(core, enable);
+        write_msr(core, PCTR_IA32_PERF_FIXED_CTR1, 0); // reset
+    }
+}
+
+void
+close_fd(int fd)
+{
+    int ok = close(fd);
+    if (ok == -1) {
+        perror("close");
+        exit(EXIT_FAILURE);
+    }
+}
+
+int
+get_fixed_pctr1_width()
+{
+    uint32_t eax, edx;
+    int fixed_ctr_width, arch_ctr_vers, num_fixed_ctrs;
+
+    asm volatile(
+        "mov $0xa, %%eax\n\t"       // pctr leaf
+        "cpuid\n\t"
+        : "=a" (eax), "=d" (edx)    // out
+        :                           // in
+        : "ebx", "ecx");            // clobber
+
+    /* eax
+     *   0-4:  number of fixed-func counters
+     *   5-12: width of counters
+     */
+    num_fixed_ctrs = edx & 0x1f;
+    fixed_ctr_width = (edx & 0x1fe0) >> 5;
+
+    /* eax
+     *   0-7:  architectural counter version
+     *   8-31: reserved
+     */
+    arch_ctr_vers = eax & 0xff;
+
+    // fixed function perf ctrs appeared on arch counter version 2
+    if (arch_ctr_vers < 2) {
+        printf("arch pctr version >=2 is required! got %d\n", arch_ctr_vers);
+        exit(EXIT_FAILURE);
+    }
+
+    // We are interested in IA32_FIXED_CTR1, (i.e. the second fixed counter)
+    if (num_fixed_ctrs < 2) {
+        fprintf(stderr, "too few fixed-function counters: %d\n",
+            num_fixed_ctrs);
+        exit(EXIT_FAILURE);
+    }
+
+    return fixed_ctr_width;
+}
+#elif defined(__linux__) && defined(TRAVIS)
+// Travis has no performance counters
+#elif defined(__OpenBSD__)
+// We do not yet support performance counters on OpenBSD
+#else
+#error "Unsupported platform"
+#endif // linux && !TRAVIS
+
+void
+libkruntime_init(void)
+{
+#if defined(__linux__) && !defined(TRAVIS)
+    int core;
+
+    /* See how wide the counter values are and make an appropriate mask */
+    pctr_val_mask = ((uint64_t) 1 << get_fixed_pctr1_width()) - 1;
+
+    /* Set up MSR device node handles */
+    num_msr_nodes = sysconf(_SC_NPROCESSORS_ONLN);
+
+    msr_r_nodes = calloc(num_msr_nodes, sizeof(int));
+    if (msr_r_nodes == NULL) {
+        perror("calloc");
+        exit(EXIT_FAILURE);
+    }
+
+    msr_w_nodes = calloc(num_msr_nodes, sizeof(int));
+    if (msr_w_nodes == NULL) {
+        perror("calloc");
+        exit(EXIT_FAILURE);
+    }
+
+    for (core = 0; core < num_msr_nodes; core++) {
+        msr_r_nodes[core] = open_msr_node(core, O_RDONLY);
+        msr_w_nodes[core] = open_msr_node(core, O_WRONLY);
+    }
+
+    /* Configure and reset CPU_CLK_UNHALTED.CORE on all CPUs */
+    config_fixed_ctr1_all_cores(1);
+#elif defined(__linux__) && defined(TRAVIS)
+    // Travis has no performance counters
+#elif defined(__OpenBSD__)
+    // We do not yet support performance counters on OpenBSD
+#else
+#   error "Unsupported platform"
+#endif  // __linux__ && !TRAVIS
+}
+
+void
+libkruntime_done(void)
+{
+#if defined(__linux__) && !defined(TRAVIS)
+    int core;
+
+    /* Close MSR device nodes */
+    for (core = 0; core < num_msr_nodes; core++) {
+        close_fd(msr_r_nodes[core]);
+        close_fd(msr_w_nodes[core]);
+    }
+#elif defined(__linux__) && defined(TRAVIS)
+    // Travis has no performance counters
+#elif defined(__OpenBSD__)
+    // We do not yet support performance counters on OpenBSD
+#else
+#error "Unsupported platform"
+#endif  // __linux__ && !TRAVIS
+}
+
+u_int64_t
+read_core_cycles(void)
+{
+#if defined(__linux__) && !defined(TRAVIS)
+    int core;
+    uint64_t cycles = 0, val;
+
+    for (core = 0; core < num_msr_nodes; core++) {
+        val = read_msr(core, PCTR_IA32_PERF_FIXED_CTR1) & pctr_val_mask;
+
+        /*
+         * Note that overflow is impossible on most platforms. E.g. on an i7,
+         * the pctr values are 42-bit, and we sum into a 64-bit unsigned. In
+         * such a configuration you would need a huge number of cores in order
+         * to expose the possibility of an overflow.
+         *
+         * Nevertheless, we check.
+         */
+        if (cycles > UINT64_MAX - val) {
+            fprintf(stderr, "Core cycle count overflow!: "
+                    "%" PRIu64 " + %" PRIu64 "\n", cycles, val);
+            exit(EXIT_FAILURE);
+        }
+        cycles += val;
+    }
+
+    return cycles;
+#elif defined(__linux__) && defined(TRAVIS)
+    // Travis has no performance counters
+    return 0;
+#elif defined(__OpenBSD__)
+    // We do not yet support performance counters on OpenBSD
+    return 0;
+#else
+#error "Unsupported platform"
+#endif // __linux__ && !TRAVIS
 }
 
 /*
  * For languages like Lua, where there is suitible integer type
  */
 double
-read_ts_reg_start_double()
+read_core_cycles_double()
 {
-    return u64_to_double(read_ts_reg_start());
-}
-
-double
-read_ts_reg_stop_double()
-{
-    return u64_to_double(read_ts_reg_stop());
+    return u64_to_double(read_core_cycles());
 }
 
 /*

--- a/libkrun/libkruntime.h
+++ b/libkrun/libkruntime.h
@@ -14,14 +14,24 @@
 extern "C" {
 #endif
 
-u_int64_t read_ts_reg_start();
-u_int64_t read_ts_reg_stop();
+void libkruntime_init(void);
+void libkruntime_done(void);
 
-double read_ts_reg_start_double();
-double read_ts_reg_stop_double();
+#ifdef __linux__
+int get_fixed_pctr1_width(void);
+int open_msr_node(int cpu, int flags);
+void config_fixed_ctr1(int cpu, int enable);
+void config_fixed_ctr1_all_cores(int enable);
 
-double read_ts_reg_start_double();
-double clock_gettime_monotonic();
+u_int64_t read_msr(int cpu, long addr);
+void write_msr(int cpu, long addr, uint64_t msr_val);
+void close_fd(int fd);
+#endif // __linux__
+
+u_int64_t read_core_cycles(void);
+double read_core_cycles_double(void);
+
+double clock_gettime_monotonic(void);
 
 double u64_to_double(u_int64_t val);
 
@@ -30,9 +40,10 @@ double u64_to_double(u_int64_t val);
 #endif
 
 #ifdef WITH_JAVA
+JNIEXPORT void JNICALL Java_IterationsRunner_JNI_1libkruntime_1init(JNIEnv *e, jclass c);
+JNIEXPORT void JNICALL Java_IterationsRunner_JNI_1libkruntime_1done(JNIEnv *e, jclass c);
 JNIEXPORT jdouble JNICALL Java_IterationsRunner_JNI_1clock_1gettime_1monotonic(JNIEnv *e, jclass c);
-JNIEXPORT jlong JNICALL Java_IterationsRunner_JNI_1read_1ts_1reg_1start(JNIEnv *e, jclass c);
-JNIEXPORT jlong JNICALL Java_IterationsRunner_JNI_1read_1ts_1reg_1stop(JNIEnv *e, jclass c);
+JNIEXPORT jlong JNICALL Java_IterationsRunner_JNI_1read_1core_1cycles(JNIEnv *e, jclass c);
 #endif  // WITH_JAVA
 
 #endif  // __LIBKRUNTIME_H

--- a/libkrun/test/test_prog.c
+++ b/libkrun/test/test_prog.c
@@ -6,12 +6,13 @@
 
 #include "../libkruntime.h"
 
-void test_tsr_u64(void);
-void test_tsr_double(void);
-void test_tsr_double_prec_ok(void);
-void test_tsr_double_prec_bad(void);
-void test_tsr_u64_double_ratio(void);
+void test_cycles_u64(void);
+void test_cycles_double(void);
+void test_cycles_double_prec_ok(void);
+void test_cycles_double_prec_bad(void);
+void test_cycles_u64_double_ratio(void);
 void test_clock_gettime_monotonic(void);
+void test_msr_time(void);
 
 void usage();
 
@@ -19,103 +20,119 @@ void
 usage()
 {
     printf("usages:\n");
-    printf("  test tsr_u64\n");
-    printf("  test tsr_double\n");
-    printf("  test tsr_double_prec_ok\n");
-    printf("  test tsr_double_prec_bad\n");
-    printf("  test tsr_u64_double_ratio\n");
+    printf("  test cycles_u64\n");
+    printf("  test cycles_double\n");
+    printf("  test cycles_double_prec_ok\n");
+    printf("  test cycles_double_prec_bad\n");
+    printf("  test cycles_u64_double_ratio\n");
     printf("  test clock_gettime_monotonic\n");
-
-    exit(EXIT_FAILURE);
+    printf("  test msr_time\n");
 }
 
 int
 main(int argc, char **argv)
 {
     char *mode;
+    int rv = EXIT_SUCCESS;
 
     if (argc != 2) {
         usage();
+        return (EXIT_FAILURE);
     }
 
     mode = argv[1];
 
-    if (strcmp(mode, "tsr_u64") == 0) {
-        test_tsr_u64();
-    } else if (strcmp(mode, "tsr_double") == 0) {
-        test_tsr_double();
-    } else if (strcmp(mode, "tsr_double_prec_ok") == 0) {
-        test_tsr_double_prec_ok();
-    } else if (strcmp(mode, "tsr_double_prec_bad") == 0) {
-        test_tsr_double_prec_bad();
-    } else if (strcmp(mode, "tsr_u64_double_ratio") == 0) {
-        test_tsr_u64_double_ratio();
+    if (strcmp(mode, "cycles_u64") == 0) {
+        libkruntime_init();
+        test_cycles_u64();
+        libkruntime_done();
+    } else if (strcmp(mode, "cycles_double") == 0) {
+        libkruntime_init();
+        test_cycles_double();
+        libkruntime_done();
+    } else if (strcmp(mode, "cycles_double_prec_ok") == 0) {
+        libkruntime_init();
+        test_cycles_double_prec_ok();
+        libkruntime_done();
+    } else if (strcmp(mode, "cycles_double_prec_bad") == 0) {
+        libkruntime_init();
+        test_cycles_double_prec_bad();
+        libkruntime_done();
+    } else if (strcmp(mode, "cycles_u64_double_ratio") == 0) {
+        libkruntime_init();
+        test_cycles_u64_double_ratio();
+        libkruntime_done();
+    } else if (strcmp(mode, "msr_time") == 0) {
+        libkruntime_init();
+        test_msr_time();
+        libkruntime_done();
     } else if (strcmp(mode, "clock_gettime_monotonic") == 0) {
-        test_clock_gettime_monotonic();
+        test_clock_gettime_monotonic();  // doesn't need init/done
     } else {
         usage();
+        rv = EXIT_FAILURE;
     }
 
-    return (EXIT_SUCCESS);
+    return (rv);
 }
 
 void
-test_tsr_u64(void) {
+test_cycles_u64(void) {
     uint64_t t1, t2, delta;
 
-    t1 = read_ts_reg_start();
-    t2 = read_ts_reg_stop();
+    t1 = read_core_cycles();
+    t2 = read_core_cycles();
     delta = t2 - t1;
 
-    printf("tsr_u64_start= %" PRIu64 "\n", t1);
-    printf("tsr_u64_stop = %" PRIu64 "\n", t2);
-    printf("tsr_u64_delta= %" PRIu64 "\n", delta);
+    printf("cycles_u64_start= %" PRIu64 "\n", t1);
+    printf("cycles_u64_stop = %" PRIu64 "\n", t2);
+    printf("cycles_u64_delta= %" PRIu64 "\n", delta);
 }
 
 void
-test_tsr_double(void)
+test_cycles_double(void)
 {
     double t1, t2, delta;
 
-    t1 = read_ts_reg_start_double();
-    t2 = read_ts_reg_stop_double();
+    t1 = read_core_cycles_double();
+    t2 = read_core_cycles_double();
     delta = t2 - t1;
 
-    printf("tsr_double_start= %f\n", t1);
-    printf("tsr_double_stop = %f\n", t2);
-    printf("tsr_double_delta= %f\n", delta);
+    printf("cycles_double_start= %f\n", t1);
+    printf("cycles_double_stop = %f\n", t2);
+    printf("cycles_double_delta= %f\n", delta);
 }
 
 void
-test_tsr_double_prec_ok(void)
+test_cycles_double_prec_ok(void)
 {
     (void) u64_to_double(666);
     printf("OK\n");
 }
 
 void
-test_tsr_double_prec_bad(void)
+test_cycles_double_prec_bad(void)
 {
     (void) u64_to_double(((u_int64_t) 1 << 62) - 1);
 }
 
 void
-test_tsr_u64_double_ratio(void)
+test_cycles_u64_double_ratio(void)
 {
     u_int64_t i_time1, i_time2, i_delta;
     double d_time1, d_time2, d_delta, ratio;
 
-    i_time1 = read_ts_reg_start();
-    i_time2 = read_ts_reg_stop();
+    i_time1 = read_core_cycles();
+    i_time2 = read_core_cycles();
 
-    d_time1 = read_ts_reg_start_double();
-    d_time2 = read_ts_reg_stop_double();
+    d_time1 = read_core_cycles_double();
+    d_time2 = read_core_cycles_double();
 
     i_delta = i_time2 - i_time1;
     d_delta = d_time2 - d_time1;
     ratio = i_delta / d_delta;
 
-    printf("tsr_u64_double_ratio=%f\n", ratio);
+    printf("cycles_u64_double_ratio=%f\n", ratio);
 }
 
 void
@@ -131,4 +148,33 @@ test_clock_gettime_monotonic()
     printf("monotonic_start= %f\n", t1);
     printf("monotonic_stop = %f\n", t2);
     printf("monotonic_delta= %f\n", delta);
+}
+
+void
+test_msr_time(void)
+{
+    double t1, t2, t3, t4, delta1, delta2;
+    uint64_t c1, c2;
+
+    // time doing "nothing"
+    t1 = clock_gettime_monotonic();
+    t2 = clock_gettime_monotonic();
+    delta1 = t2 - t1;
+
+    // time two msr reads
+    t3 = clock_gettime_monotonic();
+    c1 = read_core_cycles();
+    c2 = read_core_cycles();
+    t4 = clock_gettime_monotonic();
+    delta2 = t4 - t3;
+
+    printf("monotonic_start_nothing= %f\n", t1);
+    printf("monotonic_stop_nothing = %f\n", t2);
+    printf("monotonic_delta_nothing= %f\n", delta1);
+
+    printf("monotonic_start_msrs   = %f\n", t3);
+    printf("monotonic_stop_msrs    = %f\n", t4);
+    printf("cycles_u64_start       = %" PRIu64 "\n", c1);
+    printf("cycles_u64_stop        = %" PRIu64 "\n", c2);
+    printf("monotonic_delta_msrs   = %f\n", delta2);
 }


### PR DESCRIPTION
Hi,

Let's start looking at this, but please don't merge yet.

This change:
 * Adds core_cycles support to libkrun
 * Makes all iterations runners use libkrun.
 * renames variables to be more intuitive.
 * Ensure all iteration runner errors go to stderr.
 * more sanity checking in iterations runners

A typical iteration runner should look like this now (pseudocode):

```
libkruntime_init(); // open msr device nodes and do performance counter setup

loop {
    // timed section
    read_wallclock_time();
    read_core_cycles();
    do_benchmark();
    read_core_cycles();
    read_wallclock_time();
    // end timed section

   check_for_start_readings_greater_than_stop_readings();
}

libkruntime_done(); // close msr device nodes
```

@ltratt is this measurement orderings correct? I think you had some intuition as to which should come first based on clock resolutions etc.

There are some other optimisations and tidy ups, but I would like to do them as separate PRs, as this is already getting large.