### PR TITLE
refactor careful reading of stdout/err of benchmarking processes

### DIFF
--- a/krun/tests/test_process.py
+++ b/krun/tests/test_process.py
@@ -1,4 +1,4 @@
-from krun.vm_defs import print_stderr_linewise
+from krun.util import print_stderr_linewise
 
 def test_quadratic():
     l = []

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -1,7 +1,8 @@
 from krun.util import (format_raw_exec_results,
                        log_and_mail, fatal,
                        check_and_parse_execution_results,
-                       run_shell_cmd, get_git_version,
+                       run_shell_cmd, run_shell_cmd_bench,
+                       get_git_version,
                        ExecutionFailed, get_session_info,
                        run_shell_cmd_list, FatalKrunError, strip_results)
 from krun.tests.mocks import MockMailer
@@ -48,6 +49,11 @@ def test_run_shell_cmd():
     assert err == ""
     assert rc == 0
 
+    msg2 = "another example"
+    out, err, rc = run_shell_cmd("(>&2 echo %s)  && (echo %s)" % (msg2, msg))
+    assert out == msg
+    assert err == msg2
+    assert rc == 0
 
 def test_run_shell_cmd_fatal():
     cmd = "nonsensecommand"
@@ -56,6 +62,31 @@ def test_run_shell_cmd_fatal():
     assert cmd in err
     assert out == ""
 
+def test_run_shell_cmd_bench():
+    from krun.platform import detect_platform
+    platform = detect_platform(None, None)
+    msg = "example text\n"
+    out, err, rc = run_shell_cmd_bench("echo " + msg, platform)
+    assert out == msg
+    assert err == ""
+    assert rc == 0
+
+    msg2 = "another example\n"
+    out, err, rc = run_shell_cmd_bench(
+        "(>&2 echo %s)  && (echo %s)" % (msg2, msg),
+        platform)
+    assert out == msg
+    assert err == msg2
+    assert rc == 0
+
+def test_run_shell_cmd_bench_fatal():
+    from krun.platform import detect_platform
+    cmd = "nonsensecommand"
+    platform = detect_platform(None, None)
+    out, err, rc = run_shell_cmd_bench(cmd, platform, False)
+    assert rc != 0
+    assert cmd in err
+    assert out == ""
 
 def test_check_and_parse_execution_results():
     # [wallclock, cycles, aperf, mperf]

--- a/krun/util.py
+++ b/krun/util.py
@@ -1,10 +1,23 @@
 import json
 import os
 import re
+import select
 from subprocess import Popen, PIPE
 from logging import error, debug, info
 
 FLOAT_FORMAT = ".6f"
+
+SELECT_TIMEOUT = 1.0
+
+# Pipe buffer sizes vary. I've seen reports on the Internet ranging from a
+# page size (Linux pre-2.6.11) to 64K (Linux in 2015). Ideally we would
+# query the pipe for its capacity using F_GETPIPE_SZ, but this is a) not
+# portable between UNIXs even, and b) not exposed by Python's fcntl(). For
+# now, we use a "reasonable" buffer size. If it is larger than the pipe
+# capacity, then no harm done; if it is smaller, then we may do more reads
+# than are strictly necessary. In either case we are safe and correct.
+PIPE_BUF_SZ = 1024 * 16
+
 
 DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -45,8 +58,7 @@ def format_raw_exec_results(exec_data):
 
     return [float(format(x, FLOAT_FORMAT)) for x in exec_data]
 
-
-def run_shell_cmd(cmd, failure_fatal=True, extra_env=None):
+def _run_shell_cmd_start_process(cmd, extra_env):
     debug("execute shell cmd: %s" % cmd)
 
     env = os.environ.copy()
@@ -58,7 +70,10 @@ def run_shell_cmd(cmd, failure_fatal=True, extra_env=None):
             ec = EnvChangeSet(var, val)
             ec.apply(env)
 
-    p = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE, env=env)
+    return Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE, env=env)
+
+def run_shell_cmd(cmd, failure_fatal=True, extra_env=None):
+    p = _run_shell_cmd_start_process(cmd, extra_env)
     stdout, stderr = p.communicate()
     rc = p.wait()
     if failure_fatal and rc != 0:
@@ -68,6 +83,19 @@ def run_shell_cmd(cmd, failure_fatal=True, extra_env=None):
         fatal(msg)
     return stdout.strip(), stderr.strip(), rc
 
+def run_shell_cmd_bench(cmd, platform, failure_fatal=True, extra_env=None):
+    """ The same as run_shell_cmd, but reads the output of the command more
+    carefully, by setting the pipes to unbuffered and using select.
+    Requires a platform."""
+    process = _run_shell_cmd_start_process(cmd, extra_env)
+    res = read_popen_output_carefully(process, platform, print_stderr=False)
+    stdout, stderr, rc = res
+    if failure_fatal and rc != 0:
+        msg = "Command failed: '%s'\n" % cmd
+        msg += "stdout:\n%s\n" % stdout
+        msg += "stderr:\n%s\n" % stderr
+        fatal(msg)
+    return res
 
 def run_shell_cmd_list(cmds, failure_fatal=True, extra_env=None):
     """Run a list of shell commands, stopping on first failure."""
@@ -75,6 +103,86 @@ def run_shell_cmd_list(cmds, failure_fatal=True, extra_env=None):
     for cmd in cmds:
         _, _, rv = run_shell_cmd(cmd, extra_env=extra_env)
         assert rv == 0
+
+def print_stderr_linewise(info):
+    stderr_partial_line = []
+    while True:
+        d = yield
+        # Take what we just read, and any partial line we had from
+        # a previous read, and see if we can make full lines.
+        # If so, we can print them, otherwise we keep them for
+        # the next time around.
+        startindex = 0
+        while True:
+            try:
+                nl = d.index("\n", startindex)
+            except ValueError:
+                stderr_partial_line.append(d[startindex:])
+                break  # no newlines
+            emit = d[startindex:nl]
+            info("stderr: " + "".join(stderr_partial_line) + emit)
+            stderr_partial_line = []
+            startindex = nl + 1
+
+def read_popen_output_carefully(process, platform, print_stderr=True):
+    """ helper function: given a process, read new data whenever it is
+    available, to make sure that the process is never blocked when trying to
+    write to stdout/stderr. """
+
+    # Get raw OS-level file descriptors and ensure they are unbuffered
+    stdout_fd = process.stdout.fileno()
+    platform.unbuffer_fd(stdout_fd)
+    open_fds = [stdout_fd]
+
+    if process.stderr is None:
+        # stderr was redirected to file, forget it
+        stderr_fd = None
+    else:
+        # Krun is consuming stderr
+        stderr_fd = process.stderr.fileno()
+        open_fds.append(stderr_fd)
+        platform.unbuffer_fd(stderr_fd)
+
+    stderr_data, stdout_data = [], []
+    if print_stderr:
+        stderr_consumer = print_stderr_linewise(info)
+        stderr_consumer.next() # start the generator
+    else:
+        stderr_consumer = None
+
+    while open_fds:
+        ready = select.select(open_fds, [], [], SELECT_TIMEOUT)
+
+        if stdout_fd in ready[0]:
+            d = os.read(stdout_fd, PIPE_BUF_SZ)
+            if d == "":  # EOF
+                open_fds.remove(stdout_fd)
+            else:
+                stdout_data.append(d)
+
+        if stderr_fd in ready[0]:
+            d = os.read(stderr_fd, PIPE_BUF_SZ)
+            if d == "":  # EOF
+                open_fds.remove(stderr_fd)
+            else:
+                stderr_data.append(d)
+                if stderr_consumer is not None:
+                    stderr_consumer.send(d)
+
+    # We know stderr and stdout are closed.
+    # Now we are just waiting for the process to exit, which may have
+    # already happened of course.
+    try:
+        process.wait()
+    except Exception as e:
+        fatal("wait() failed on child pipe: %s" % str(e))
+
+    assert process.returncode is not None
+
+    stderr = "".join(stderr_data)
+    stdout = "".join(stdout_data)
+
+    return stdout, stderr, process.returncode
 
 def check_and_parse_execution_results(stdout, stderr, rc):
     json_exn = None


### PR DESCRIPTION
- move the code from vm_defs.py to a new helper function
read_popen_output_carefully in util.py
- add a new function run_shell_cmd_bench that makes use of that function
(we can't change run_shell_cmd, because for we need a platform object in
read_popen_output_carefully, but run_shell_cmd is used in setting up a
platform).