### PR TITLE
Mention rmsr in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You need to have the following installed:
   * cffi (`python-cffi` package in Debian)
   * cset (for pinning on Linux only. `cpuset` package in Debian)
   * virt-what (Linux only. `virt-what` package in Debian)
+  * rmsr (Linux only. https://github.com/softdevteam/rmsr)
 
 If you want to benchmark Java, you will also need:
   * A Java SDK 7 (`openjdk-7-jdk` package in Debian)


### PR DESCRIPTION
At least mention rmsr in the README.

This is a start on #260, but we need to implement the mechanism to automatically load rmsr and document it.

OK?