### PR TITLE
Separate json files for instrumentation data

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -202,6 +202,9 @@ def inner_main(mailer, on_first_invocation, config, args):
     out_file = config.results_filename()
     out_file_exists = os.path.exists(out_file)
 
+    instr_dir = util.get_instr_json_dir(config)
+    instr_dir_exists = os.path.exists(instr_dir)
+
     if out_file_exists and not os.path.isfile(out_file):
         util.fatal(
             "Output file '%s' exists but is not a regular file" % out_file)
@@ -209,6 +212,10 @@ def inner_main(mailer, on_first_invocation, config, args):
     if out_file_exists and on_first_invocation:
         util.fatal("Output results file '%s' already exists. "
                    "Move the file away before running Krun." % out_file)
+
+    if instr_dir_exists and on_first_invocation:
+        util.fatal("Instrumentation dir '%s' exists (from an older run?)" %
+                   (instr_dir))
 
     if not out_file_exists and not on_first_invocation:
         util.fatal("No results file to resume. Expected '%s'" % out_file)

--- a/krun/results.py
+++ b/krun/results.py
@@ -29,10 +29,6 @@ class Results(object):
 
         self.reboots = 0
 
-        # "bmark:vm:variant" ->
-        #     (instrumentation name -> [[e0i0, e0i1, ...], [e1i0, e1i1, ...], ...])
-        self.instr_data = {}
-
         # Record how long execs are taking so we can give the user a rough ETA.
         # Maps "bmark:vm:variant" -> [t_0, t_1, ...]
         self.eta_estimates = dict()
@@ -78,7 +74,6 @@ class Results(object):
                     self.core_cycle_counts[key] = []
                     self.aperf_counts[key] = []
                     self.mperf_counts[key] = []
-                    self.instr_data[key] = defaultdict(list)
                     self.eta_estimates[key] = []
 
     def read_from_file(self, results_file):
@@ -167,7 +162,6 @@ class Results(object):
             "core_cycle_counts": self.core_cycle_counts,
             "aperf_counts": self.aperf_counts,
             "mperf_counts": self.mperf_counts,
-            "instr_data": self.instr_data,
             "audit": self.audit.audit,
             "reboots": self.reboots,
             "starting_temperatures": self.starting_temperatures,
@@ -177,12 +171,6 @@ class Results(object):
         with bz2.BZ2File(self.filename, "w") as f:
             f.write(json.dumps(to_write,
                                indent=1, sort_keys=True, encoding='utf-8'))
-
-    def add_instr_data(self, bench_key, instr_dct):
-        """Record instrumentation data into results object."""
-
-        for instr_key, v in instr_dct.iteritems():
-            self.instr_data[bench_key][instr_key].append(v)
 
     def jobs_completed(self, key):
         """Return number of executions for which we have data for a given

--- a/krun/tests/test_manifest_manager.py
+++ b/krun/tests/test_manifest_manager.py
@@ -67,6 +67,18 @@ E dummy:CPython:default-python
 E nbody:CPython:default-python
 """
 
+IRREGULAR_EXAMPLE_MANIFEST = """eta_avail_idx=4
+keys
+E dummy:Java:default-java
+C nbody:Java:default-java
+C dummy:CPython:default-python
+S nbody:CPython:default-python
+C dummy:Java:default-java
+S nbody:Java:default-java
+O dummy:CPython:default-python
+E nbody:CPython:default-python
+"""
+
 
 def _setup(filename, contents):
     ManifestManager.PATH = os.path.join(TEST_DIR, filename)
@@ -95,6 +107,12 @@ def test_parse_manifest():
         "nbody:Java:default-java": 2,
         "dummy:CPython:default-python": 2,
         "nbody:CPython:default-python": 2,
+    }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 0,
+        "nbody:Java:default-java": 0,
+        "dummy:CPython:default-python": 0,
+        "nbody:CPython:default-python": 0,
     }
     assert manifest.skipped_keys == set()
     assert manifest.non_skipped_keys == set(["dummy:Java:default-java",
@@ -162,6 +180,12 @@ def test_parse_with_skips():
         "dummy:CPython:default-python": 2,
         "nbody:CPython:default-python": 2,
     }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 0,
+        "nbody:Java:default-java": 0,
+        "dummy:CPython:default-python": 0,
+        "nbody:CPython:default-python": 0,
+    }
     assert manifest.skipped_keys == set(["dummy:Java:default-java",
                                         "nbody:Java:default-java"])
     assert manifest.non_skipped_keys == set(["dummy:Java:default-java",
@@ -181,6 +205,12 @@ def test_parse_with_all_skips():
     assert manifest.next_exec_idx == -1
     assert manifest.next_exec_flag_offset == None
     assert manifest.outstanding_exec_counts == {
+        "dummy:Java:default-java": 0,
+        "nbody:Java:default-java": 0,
+        "dummy:CPython:default-python": 0,
+        "nbody:CPython:default-python": 0,
+    }
+    assert manifest.completed_exec_counts == {
         "dummy:Java:default-java": 0,
         "nbody:Java:default-java": 0,
         "dummy:CPython:default-python": 0,
@@ -208,6 +238,12 @@ def test_parse_with_all_errors():
         "dummy:CPython:default-python": 0,
         "nbody:CPython:default-python": 0,
     }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 2,
+        "nbody:Java:default-java": 2,
+        "dummy:CPython:default-python": 2,
+        "nbody:CPython:default-python": 2,
+    }
     assert manifest.skipped_keys == set()
     assert manifest.non_skipped_keys == set(["dummy:Java:default-java",
         "nbody:Java:default-java","dummy:CPython:default-python",
@@ -229,6 +265,12 @@ def test_parse_with_skips_at_end():
         "nbody:Java:default-java": 2,
         "dummy:CPython:default-python": 1,
         "nbody:CPython:default-python": 1,
+    }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 0,
+        "nbody:Java:default-java": 0,
+        "dummy:CPython:default-python": 0,
+        "nbody:CPython:default-python": 0,
     }
     assert manifest.skipped_keys == set(["dummy:CPython:default-python",
                                          "nbody:CPython:default-python",])
@@ -278,6 +320,12 @@ def test_update_blank():
         "dummy:CPython:default-python": 2,
         "nbody:CPython:default-python": 2,
     }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 0,
+        "nbody:Java:default-java": 0,
+        "dummy:CPython:default-python": 0,
+        "nbody:CPython:default-python": 0,
+    }
     # Benchmark completed.
     manifest.update("C")
     assert manifest.num_execs_left == 7
@@ -291,6 +339,12 @@ def test_update_blank():
         "dummy:CPython:default-python": 2,
         "nbody:CPython:default-python": 2,
     }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 1,
+        "nbody:Java:default-java": 0,
+        "dummy:CPython:default-python": 0,
+        "nbody:CPython:default-python": 0,
+    }
     # Benchmark failed.
     manifest.update("E")
     assert manifest.num_execs_left == 6
@@ -303,6 +357,12 @@ def test_update_blank():
         "nbody:Java:default-java": 1,
         "dummy:CPython:default-python": 2,
         "nbody:CPython:default-python": 2,
+    }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 1,
+        "nbody:Java:default-java": 1,
+        "dummy:CPython:default-python": 0,
+        "nbody:CPython:default-python": 0,
     }
     _tear_down()
 
@@ -321,6 +381,12 @@ def test_update_to_completion():
         "dummy:CPython:default-python": 2,
         "nbody:CPython:default-python": 2,
     }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 0,
+        "nbody:Java:default-java": 0,
+        "dummy:CPython:default-python": 0,
+        "nbody:CPython:default-python": 0,
+    }
     # Complete each benchmark.
     for completed in xrange(1, 9):
         manifest.update("C")
@@ -332,5 +398,33 @@ def test_update_to_completion():
         "nbody:Java:default-java": 0,
         "dummy:CPython:default-python": 0,
         "nbody:CPython:default-python": 0,
+    }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 2,
+        "nbody:Java:default-java": 2,
+        "dummy:CPython:default-python": 2,
+        "nbody:CPython:default-python": 2,
+    }
+    _tear_down()
+
+def test_irregular_manifest():
+    _setup("example_blank.manifest", IRREGULAR_EXAMPLE_MANIFEST)
+    manifest = ManifestManager()
+    assert manifest.num_execs_left == 1
+    assert manifest.total_num_execs == 6
+    assert manifest.next_exec_key == "dummy:CPython:default-python"
+    assert manifest.next_exec_idx == 6
+    assert manifest.next_exec_flag_offset == 187
+    assert manifest.outstanding_exec_counts == {
+        "dummy:Java:default-java": 0,
+        "nbody:Java:default-java": 0,
+        "dummy:CPython:default-python": 1,
+        "nbody:CPython:default-python": 0,
+    }
+    assert manifest.completed_exec_counts == {
+        "dummy:Java:default-java": 2,
+        "nbody:Java:default-java": 1,
+        "dummy:CPython:default-python": 1,
+        "nbody:CPython:default-python": 1,
     }
     _tear_down()

--- a/krun/tests/test_scheduler.py
+++ b/krun/tests/test_scheduler.py
@@ -1,7 +1,7 @@
 from krun.audit import Audit
 from krun.config import Config
 from krun.scheduler import (mean, ExecutionJob, ExecutionScheduler,
-                            ManifestManager, EMPTY_MEASUREMENTS)
+                            ManifestManager)
 from krun.tests import BaseKrunTest
 import krun.util
 
@@ -147,7 +147,7 @@ class TestScheduler(BaseKrunTest):
     def test_run_schedule0005(self, mock_platform, monkeypatch):
 
         def dummy_execjob_run(self, mailer, dryrun=False):
-            return EMPTY_MEASUREMENTS, {}, "E"  # pretend jobs fail
+            return self.empty_measurements, {}, "E"  # pretend jobs fail
         monkeypatch.setattr(ExecutionJob, 'run', dummy_execjob_run)
 
         config = Config(os.path.join(TEST_DIR, "example.krun"))


### PR DESCRIPTION
Don't merge yet please.

How about something like this?

If it looks good, I want to add a couple of tests to check I am computing the next exec index correctly from the manifest file.

```
$ python -mpdb ./krun/krun.py test.krun --quick --debug debug
...
[2016-10-17 11:40:58 INFO] Done: Results dumped to test_results.json.bz2
[2016-10-17 11:40:58 INFO] Session completed. Log file at: 'test_20161017_114049.log'
Don't forget to disable Krun at boot.
$ ls test_
test_20161017_114049.log  test_instr_data/          test_results.json.bz2     
vext01@bencher5:~/research/warmup_experiment$ ls test_instr_data/
empty_PyPy_default-python__0.json.bz2  empty_PyPy_default-python__5.json.bz2
empty_PyPy_default-python__1.json.bz2  empty_PyPy_default-python__6.json.bz2
empty_PyPy_default-python__2.json.bz2  empty_PyPy_default-python__7.json.bz2
empty_PyPy_default-python__3.json.bz2  empty_PyPy_default-python__8.json.bz2
empty_PyPy_default-python__4.json.bz2  empty_PyPy_default-python__9.json.bz2
```