### PR TITLE
Log the environment

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -208,6 +208,9 @@ def inner_main(mailer, on_first_invocation, config, args):
     instr_dir = util.get_instr_json_dir(config)
     instr_dir_exists = os.path.exists(instr_dir)
 
+    envlog_dir = util.get_envlog_dir(config)
+    envlog_dir_exists = os.path.exists(envlog_dir)
+
     if out_file_exists and not os.path.isfile(out_file):
         util.fatal(
             "Output file '%s' exists but is not a regular file" % out_file)
@@ -217,8 +220,10 @@ def inner_main(mailer, on_first_invocation, config, args):
                    "Move the file away before running Krun." % out_file)
 
     if instr_dir_exists and on_first_invocation:
-        util.fatal("Instrumentation dir '%s' exists (from an older run?)" %
-                   (instr_dir))
+        util.fatal("Instrumentation dir '%s' exists." % instr_dir)
+
+    if envlog_dir_exists and on_first_invocation:
+        util.fatal("Env log dir '%s' exists." % envlog_dir)
 
     if not out_file_exists and not on_first_invocation:
         util.fatal("No results file to resume. Expected '%s'" % out_file)

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -1,4 +1,6 @@
 from krun.platform import BasePlatform
+from krun.config import Config
+import pytest
 
 
 class MockMailer(object):
@@ -22,6 +24,7 @@ class MockPlatform(BasePlatform):
         self.audit = dict()
         self.num_cpus = 0
         self.num_per_core_measurements = 0
+        self.no_user_change = True
 
     def pin_process_args(self):
         return []
@@ -91,3 +94,8 @@ class MockPlatform(BasePlatform):
 
     def make_fresh_krun_user(self):
         pass
+
+
+@pytest.fixture
+def mock_platform():
+    return MockPlatform(MockMailer(), Config())


### PR DESCRIPTION
Not ready to merge.

Laurie asked last week if we could log the environment of each process execution, so that we could check that each benchmark with the same key (so that's vm + benchmark pairings) ran with the same environment.

This PR makes a start on that. I'm using a line of shell script, as it's the innermost place before the VM itself is invoked.

Questions:
 * Should this only be done when the instrument flag is on?
 * This change introduces I/O just before the benchmark. Should we move the sync wait into the wrapper script (after the new I/O) in the form of  `sync && sleep N`?

If the general approach is OK, then I will need to do some magic with the log file locations. I couldn't write into the experiment dir, as the krun user does not have access. At the moment, I write to /tmp. Likley a good idea is to write first to /tmp, then have krun move it after the execution finishes.

FWIW, I don't see any environment discrepancies using just the example config file. A typical env looks like this:
```
SUDO_GID=0                                                                      
MAIL=/var/mail/krun                                                             
USER=krun                                                                       
HOME=/home/krun                                                                 
SUDO_UID=0                                                                      
LOGNAME=krun                                                                    
TERM=unknown                                                                    
USERNAME=krun                                                                   
PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin                
SUDO_COMMAND=/usr/local/bin/dash /tmp/krun_wrapper.dash                         
SHELL=/bin/ksh                                                                  
SUDO_USER=root                                                                  
PWD=/home/edd/krun/examples                                                     
``` 