### PR TITLE
Only clean rmsr if on Linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,6 @@ clean:
 	cd libkrun && ${MAKE} clean
 	cd vm_sanity_checks && ${MAKE} clean
 	cd platform_sanity_checks && ${MAKE} clean
+ifeq ($(shell uname -s),Linux)
 	cd rmsr && ${MAKE} clean
+endif


### PR DESCRIPTION
A part of the build cleans rmsr, even on OpenBSD, causing a crash.

OK?