### PR TITLE
Mail tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 examples/*.log
 examples/*.json
 examples/*.bz2
+examples/*.manifest
 **/*.pyc
 **/*.swp
 **/__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ script:
     - make
     - py.test --cov-report term --cov=krun krun libkrun
     - cd examples
-    - python ../krun.py --no-pstate-check --no-tickless-check --no-user-change travis.krun
+    - python ../krun.py --quick --no-pstate-check --no-tickless-check --no-user-change travis.krun

--- a/krun.py
+++ b/krun.py
@@ -331,8 +331,7 @@ if __name__ == "__main__":
     debug("arguments: %s"  % " ".join(sys.argv[1:]))
     parser = create_arg_parser()
     setup_logging(parser)
-
-    try:
-        main(parser)
-    except:
-        sys.exit(1)
+    main(parser)
+    # All fatal exceptions (FatalKrunError, AssertionError, ...) end up here.
+    # Although Some do get caught deeper in the stack, (to try to recover from
+    # various failures) but they are always re-raised.

--- a/krun.py
+++ b/krun.py
@@ -176,8 +176,9 @@ def main(parser):
         util.print_session_info(config)
         return
 
-    on_first_invocation = not (os.path.isfile(ManifestManager.PATH) and
-                               os.stat(ManifestManager.PATH).st_size > 0)
+    manifest_filename = ManifestManager.get_filename(config)
+    on_first_invocation = not (os.path.isfile(manifest_filename) and
+                               os.stat(manifest_filename).st_size > 0)
 
     attach_log_file(config, not on_first_invocation)
     debug("Krun invoked with arguments: %s" % sys.argv)
@@ -197,7 +198,7 @@ def main(parser):
         for frame in traceback.format_tb(error_info[2]):
             lines.append(frame)
         msg = "".join(lines)
-        util.log_and_mail(mailer, debug, subject, msg, bypass_limiter=False)
+        util.log_and_mail(mailer, debug, subject, msg, bypass_limiter=True)
         raise exn
 
 

--- a/krun/mail.py
+++ b/krun/mail.py
@@ -18,16 +18,18 @@ SENDMAIL = "/usr/sbin/sendmail"
 
 
 class Mailer(object):
-    def __init__(self, recipients, max_mails):
-        self.recipients = recipients
+    def __init__(self, recipients=None, max_mails=5):
+        if recipients is not None:
+            self.recipients = recipients
+        else:
+            self.recipients = []
         self.hostname = socket.gethostname()
         self.short_hostname = self.hostname.split(".")[0]
 
-        # After sending max_mails emails, we stop sending more so as
-        # not to spam. Some emails however, you will always want to send.
+        # After sending the maximum number of emails, we stop sending more so
+        # as not to spam. Some emails however, you will always want to send.
         # For these use send(..., bypass_limiter=True).
         self.max_mails = max_mails
-        self.n_mails_sent = 0
 
     def set_recipients(self, recipients):
         self.recipients = recipients
@@ -35,16 +37,28 @@ class Mailer(object):
     def _wrap_para(self, txt):
         return "\n".join(textwrap.wrap(txt, WRAP_THRESHOLD))
 
-    def send(self, append_subject, inner_body, bypass_limiter=False):
+    def send(self, append_subject, inner_body, bypass_limiter=False,
+             manifest=None):
+        if manifest is not None:
+            num_mails_sent = manifest.num_mails_sent
+        else:
+            # It's OK to call this without a manifest (e.g. outside the
+            # scheduler loop, where there is no manifest to speak of), but
+            # without a manifest we can't know how many emails have been sent.
+            # So, the only time this is OK is if we are skipping the limiter
+            # anyway.
+            assert bypass_limiter  # Krun can't know how many mails were sent
+            num_mails_sent = 0
+
         if not self.recipients:
             # Don't bother mailing if there are no recipients
             return
 
-        if self.n_mails_sent < self.max_mails or bypass_limiter:
+        if bypass_limiter or num_mails_sent < self.max_mails:
             body = "Message from krun running on %s:\n\n" % self.hostname
             body += inner_body + "\n"
 
-            if self.n_mails_sent == self.max_mails - 1 and not bypass_limiter:
+            if not bypass_limiter and num_mails_sent == self.max_mails - 1:
                 body += "\n\n%s" % self._wrap_para(
                     QUOTA_THRESHOLD_TEMPLATE % self.max_mails)
                 logging.warn("Mail quota reached.")
@@ -54,18 +68,20 @@ class Mailer(object):
                 (self.short_hostname, append_subject)
             msg['From'] = "%s@%s" % (FROM_USER, self.hostname)
             msg['To'] = ", ".join(self.recipients)
-
-            logging.debug("Sending email to '%s' subject line '%s'" %
-                  (msg['To'], msg['Subject']))
-
-            pipe = Popen([SENDMAIL, "-t", "-oi"], stdin=PIPE)
-            pipe.communicate(msg.as_string())
-
-            rc = pipe.returncode
-            if rc != 0:
-                logging.warning("Sendmail process returned %d" % rc)
+            self._sendmail(msg)
 
             if not bypass_limiter:
-                self.n_mails_sent += 1
+                manifest.update_num_mails_sent()
         else:
             pass  # as we have already sent our quota of mails
+
+    def _sendmail(self, msg):
+        logging.debug("Sending email to '%s' subject line '%s'" %
+                      (msg['To'], msg['Subject']))
+
+        pipe = Popen([SENDMAIL, "-t", "-oi"], stdin=PIPE)
+        pipe.communicate(msg.as_string())
+
+        rc = pipe.returncode
+        if rc != 0:
+            logging.warning("Sendmail process returned %d" % rc)

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -142,16 +142,18 @@ class BasePlatform(object):
                 return True  # allowed change of dmesg
         return False
 
-    def check_dmesg_for_changes(self):
+    def check_dmesg_for_changes(self, manifest):
         new_dmesg = self._collect_dmesg_lines()
         patterns = self.get_allowed_dmesg_patterns()
 
-        rv = self._check_dmesg_for_changes(patterns, self.last_dmesg, new_dmesg)
+        rv = self._check_dmesg_for_changes(patterns, self.last_dmesg,
+                                           new_dmesg, manifest)
         self.last_dmesg = new_dmesg
 
         return rv
 
-    def _check_dmesg_for_changes(self, patterns, last_dmesg, new_dmesg):
+    def _check_dmesg_for_changes(self, patterns, last_dmesg, new_dmesg,
+                                 manifest):
         differ = difflib.Differ()
         delta = list(differ.compare(last_dmesg, new_dmesg))
         delta_len = len(delta)
@@ -203,7 +205,8 @@ class BasePlatform(object):
         if new_lines:
             # dmesg changed!
             warn_s = ("New dmesg lines:\n%s" % "\n  ".join(new_lines))
-            log_and_mail(self.mailer, warn, "dmesg changed", warn_s)
+            log_and_mail(self.mailer, warn, "dmesg changed", warn_s,
+                         manifest=manifest)
             rv = True  # i.e. a (potential) error occurred
 
         return rv

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -343,7 +343,7 @@ class ExecutionScheduler(object):
     def run(self):
         """Benchmark execution starts here"""
 
-        if not self.on_first_invocation:
+        if self.on_first_invocation:
             util.log_and_mail(self.mailer, debug,
                               "Benchmarking started",
                               "Benchmarking started.\nLogging to %s" %

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -19,30 +19,50 @@ def mean(seq):
 class ManifestManager(object):
     """Data structure for working with the manifest file"""
 
-    PATH = "krun.manifest"
+    NUM_MAILS_BYTES = 4  # number of bytes used for the (ASCII) field
+    NUM_MAILS_FMT = "%%0%dd" % NUM_MAILS_BYTES
 
-    def __init__(self):
-        """Constructor reads an existing manifest file"""
+    def __init__(self, config, new_file=False):
+        """If new_file is True, write a new manifest file to disk based on the
+        contents of the config file, otherwise parse the (existing) manifest
+        file corresponding with the config file."""
 
+        # The max number the field can accommodate
+        self.num_mails_maxout = 10 ** ManifestManager.NUM_MAILS_BYTES - 1
+
+        self.path = ManifestManager.get_filename(config)
+        if new_file:
+            self._write_new_manifest(config)
         self._parse()
+
+    @staticmethod
+    def get_filename(config):
+        assert config.filename.endswith(".krun")
+        config_base = config.filename[:-5]
+        return os.path.abspath(config_base + ".manifest")
 
     def _reset(self):
         # All populated in _parse()
+        #
+        # Do not directly mutate these fields. Use the mutator methods below to
+        # ensure the on-disk manifest file is in sync with the in-memory
+        # instance.
         self.next_exec_key = None
         self.next_exec_idx = -1
         self.next_exec_flag_offset = None
         self.num_execs_left = 0
         self.total_num_execs = 0
         self.eta_avail_idx = 0
+        self.num_mails_sent = 0
+        self.num_mails_sent_offset = None
         self.outstanding_exec_counts = {}
         self.completed_exec_counts = {}  # including errors
         self.skipped_keys = set()
         self.non_skipped_keys = set()
 
     def _open(self):
-        path = os.path.abspath(ManifestManager.PATH)
-        debug("Reading status cookie from %s" % path)
-        return open(path, "r+")
+        debug("Reading status cookie from %s" % self.path)
+        return open(self.path, "r+")
 
     # In its own method, as it needs a config instance
     def get_total_in_proc_iters(self, config):
@@ -61,14 +81,20 @@ class ManifestManager(object):
 
         # Parse manifest header
         for line in fh:
-            offset += len(line)
-            line = line.strip()
-            if line == "keys":
+            strip_line = line.strip()
+            if strip_line == "keys":
+                offset += len(line)
                 break
             else:
-                key, val = line.split("=")
-                assert key == "eta_avail_idx"
-                self.eta_avail_idx = int(val)
+                key, val = strip_line.split("=")
+                if key == "eta_avail_idx":
+                    self.eta_avail_idx = int(val)
+                elif key == "num_mails_sent":
+                    self.num_mails_sent = int(val)
+                    self.num_mails_sent_offset = offset + len(key) + 1  # +1 to skip '='
+                else:
+                    util.fatal("bad key in the manifest header: %s" % key)
+                offset += len(line)
         else:
             assert False
 
@@ -107,6 +133,21 @@ class ManifestManager(object):
             offset += len(line)
         fh.close()
 
+    def update_num_mails_sent(self):
+        """Increments the num_mails_sent_counter in the manifest file"""
+
+        debug("Update num_mails_sent in manifest: %s -> %s" %
+              (self.num_mails_sent, self.num_mails_sent + 1))
+        fh = self._open()
+        fh.seek(self.num_mails_sent_offset)
+        new_val = self.num_mails_sent + 1
+        assert 0 <= new_val <= self.num_mails_maxout
+        fh.write(ManifestManager.NUM_MAILS_FMT % (self.num_mails_sent + 1))
+        fh.close()
+
+        self._reset()
+        self._parse()  # update stats
+
     def update(self, flag):
         """Updates the manifest flag for the just-ran execution
 
@@ -133,8 +174,7 @@ class ManifestManager(object):
                 self.skipped_keys == other.skipped_keys and
                 self.non_skipped_keys == other.non_skipped_keys)
 
-    @classmethod
-    def from_config(cls, config):
+    def _write_new_manifest(self, config):
         """Makes the initial manifest file from the config"""
 
         manifest = []
@@ -157,17 +197,15 @@ class ManifestManager(object):
                                 debug("%s is in skip list. Not scheduling." %
                                       key)
             one_exec_scheduled = True
+        debug("Writing manifest to %s" % self.path)
 
-        path = os.path.abspath(ManifestManager.PATH)
-        debug("Writing manifest to %s" % path)
-
-        with open(path, "w") as fh:
+        num_mails_str = ManifestManager.NUM_MAILS_FMT % 0
+        with open(self.path, "w") as fh:
             fh.write("eta_avail_idx=%s\n" % eta_avail_idx)
+            fh.write("num_mails_sent=%s\n" % num_mails_str)
             fh.write("keys\n")
             for item in manifest:
                 fh.write("%s\n" % item)
-
-        return cls()
 
 
 class ExecutionJob(object):
@@ -237,7 +275,9 @@ class ExecutionJob(object):
                     stdout, stderr, rc)
                 flag = "C"
             except util.ExecutionFailed as e:
-                util.log_and_mail(mailer, error, "Benchmark failure: %s" % self.key, e.message)
+                util.log_and_mail(mailer, error, "Benchmark failure: %s" %
+                                  self.key, e.message,
+                                  manifest=self.sched.manifest)
                 measurements = self.empty_measurements
                 flag = "E"
 
@@ -288,10 +328,10 @@ class ExecutionScheduler(object):
         self.log_path = self.config.log_filename(not self.on_first_invocation)
 
         if on_first_invocation:
-            self.manifest = ManifestManager.from_config(config)
+            self.manifest = ManifestManager(config, new_file=True)
             self.results = Results(self.config, self.platform)
         else:
-            self.manifest = ManifestManager()
+            self.manifest = ManifestManager(self.config)
             self.results = None
 
     def get_estimated_exec_duration(self, key):
@@ -462,7 +502,7 @@ class ExecutionScheduler(object):
                  (self.manifest.eta_avail_idx -
                   self.manifest.next_exec_idx))
 
-        if self.platform.check_dmesg_for_changes():
+        if self.platform.check_dmesg_for_changes(self.manifest):
             self.results.error_flag = True
 
         assert self.manifest.num_execs_left >= 0

--- a/krun/tests/test_genericplatform.py
+++ b/krun/tests/test_genericplatform.py
@@ -1,6 +1,7 @@
 from krun.tests import BaseKrunTest
 from krun.util import FatalKrunError
 from krun.platform import BasePlatform
+from krun.tests.mocks import mock_manifest
 import pytest
 import re
 
@@ -129,49 +130,50 @@ class TestGenericPlatform(BaseKrunTest):
         expect = "Inconsistent sensors. ['a', 'b'] vs ['a']"
         assert expect in caplog.text()
 
-    def test_dmesg_filter0001(self, mock_platform, caplog):
+    def test_dmesg_filter0001(self, mock_platform, caplog, mock_manifest):
         last_dmesg = ["line1", "line2"]
         new_dmesg = ["line1", "line2", "line3"]
 
         # this should indicate change
-        assert mock_platform._check_dmesg_for_changes([], last_dmesg, new_dmesg)
+        assert mock_platform._check_dmesg_for_changes(
+            [], last_dmesg, new_dmesg, mock_manifest)
 
         # and the log will indicate this also
         assert "New dmesg lines" in caplog.text()
         assert "\nline3" in caplog.text()
 
-    def test_dmesg_filter0002(self, mock_platform, caplog):
+    def test_dmesg_filter0002(self, mock_platform, caplog, mock_manifest):
         last_dmesg = ["line1", "line2"]
         new_dmesg = ["line1", "line2", "sliced_bread"]
 
         # this should indicate no change because we allowed the change
         patterns = [re.compile("red.*herring"), re.compile("sl[ixd]c.*bread$")]
-        assert not mock_platform._check_dmesg_for_changes(patterns, last_dmesg,
-                                                          new_dmesg)
+        assert not mock_platform._check_dmesg_for_changes(
+            patterns, last_dmesg, new_dmesg, mock_manifest)
 
-    def test_dmesg_filter0003(self, mock_platform, caplog):
+    def test_dmesg_filter0003(self, mock_platform, caplog, mock_manifest):
         # simulate 2 lines falling off the top of the dmesg buffer
         last_dmesg = ["line1", "line2", "line3", "line4"]
         new_dmesg = ["line3", "line4"]
 
         # despite lines dropping off, this should still indicate no change
-        assert not mock_platform._check_dmesg_for_changes([], last_dmesg,
-                                                          new_dmesg)
+        assert not mock_platform._check_dmesg_for_changes(
+            [], last_dmesg, new_dmesg, mock_manifest)
 
-    def test_dmesg_filter0004(self, mock_platform, caplog):
+    def test_dmesg_filter0004(self, mock_platform, caplog, mock_manifest):
         # simulate 2 lines falling off the top of the dmesg buffer, *and* a
         # new line coming on the bottom of the buffer.
         last_dmesg = ["line1", "line2", "line3", "line4"]
         new_dmesg = ["line3", "line4", "line5"]
 
         # line5 is a problem
-        assert mock_platform._check_dmesg_for_changes([], last_dmesg,
-                                                      new_dmesg)
+        assert mock_platform._check_dmesg_for_changes(
+            [], last_dmesg, new_dmesg, mock_manifest)
         assert "\nline5\n" in caplog.text()
         for num in xrange(1, 5):
             assert not ("\nline%s\n" % num) in caplog.text()
 
-    def test_dmesg_filter0005(self, mock_platform, caplog):
+    def test_dmesg_filter0005(self, mock_platform, caplog, mock_manifest):
         # simulate 2 lines falling off the top of the dmesg buffer, *and* a
         # new line coming on the bottom of the buffer, but the filter accepts
         # the new line.
@@ -179,10 +181,10 @@ class TestGenericPlatform(BaseKrunTest):
         new_dmesg = ["line3", "line4", "line5"]
 
         patterns = [re.compile(".*5$")]
-        assert not mock_platform._check_dmesg_for_changes(patterns, last_dmesg,
-                                                          new_dmesg)
+        assert not mock_platform._check_dmesg_for_changes(
+            patterns, last_dmesg, new_dmesg, mock_manifest)
 
-    def test_dmesg_filter0006(self, mock_platform, caplog):
+    def test_dmesg_filter0006(self, mock_platform, caplog, mock_manifest):
         # Simulate partial line falling off the dmesg buffer due to a new line.
         # The change incurred by the partial line should not trigger our "dmesg
         # changed" flagging code.
@@ -190,14 +192,15 @@ class TestGenericPlatform(BaseKrunTest):
         new_dmesg = ["e1", "line2", "line3", "xx"]  # 3 chars 'xx\n'
 
         patterns = [re.compile("^xx$")]
-        assert not mock_platform._check_dmesg_for_changes(patterns, last_dmesg,
-                                                          new_dmesg)
+        assert not mock_platform._check_dmesg_for_changes(
+            patterns, last_dmesg, new_dmesg, mock_manifest)
 
-    def test_dmesg_filter0007(self, mock_platform, caplog):
+    def test_dmesg_filter0007(self, mock_platform, caplog, mock_manifest):
         # Simulate partial dmesg buffer completely replaced!
         # This should be an error as we have potentially missed other
         # important messages that flew off the top of the buffer too!
         last_dmesg = ["x", "x", "x"]
         new_dmesg = ["y", "y", "y"]
 
-        assert mock_platform._check_dmesg_for_changes([], last_dmesg, new_dmesg)
+        assert mock_platform._check_dmesg_for_changes(
+            [], last_dmesg, new_dmesg, mock_manifest)

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -3,6 +3,7 @@ import krun.platform
 from krun.tests import BaseKrunTest, subst_env_arg
 from krun.util import FatalKrunError
 from krun.vm_defs import  PythonVMDef
+from krun.tests.mocks import mock_manifest
 import sys
 from StringIO import StringIO
 
@@ -249,7 +250,7 @@ class TestLinuxPlatform(BaseKrunTest):
         platform._check_virt_what_installed()  # needed to set the command path
         platform.is_virtual()
 
-    def test_check_dmesg_filter0001(self, platform):
+    def test_check_dmesg_filter0001(self, platform, mock_manifest):
         old_lines = ["START"]  # anchor so krun knows where the changes start
         new_lines = [
             "START",
@@ -262,4 +263,4 @@ class TestLinuxPlatform(BaseKrunTest):
             "[  118.714594] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready",
         ]
         assert not platform._check_dmesg_for_changes(
-            platform.get_allowed_dmesg_patterns(), old_lines, new_lines)
+            platform.get_allowed_dmesg_patterns(), old_lines, new_lines, mock_manifest)

--- a/krun/tests/test_mailer.py
+++ b/krun/tests/test_mailer.py
@@ -1,0 +1,96 @@
+import os
+import pytest
+from krun.tests.mocks import mock_mailer
+from krun.scheduler import ManifestManager
+from krun.tests import TEST_DIR
+from krun.config import Config
+from contextlib import contextmanager
+
+
+@pytest.yield_fixture
+def example_manifest():
+    # setup
+    config = Config(os.path.join(TEST_DIR, "example.krun"))
+    manifest = ManifestManager(config, new_file=True)
+
+    yield manifest
+
+    # teardown
+    if os.path.exists(manifest.path):
+        os.unlink(manifest.path)
+
+
+def test_mailer0001(mock_mailer, example_manifest):
+    mock_mailer.max_mails = 5
+    mock_mailer.set_recipients(["noone@localhost"])
+
+    assert example_manifest.num_mails_sent == 0
+    mock_mailer.send("subject1", "body1", manifest=example_manifest)
+    assert example_manifest.num_mails_sent == 1
+
+    example_manifest._parse()
+    assert example_manifest.num_mails_sent == 1
+
+    assert len(mock_mailer.sent) == 1
+    msg = mock_mailer.sent[0]
+    assert msg["subject"] == "[krun:tests] subject1"
+    assert msg["to"] == "noone@localhost"
+    expect_body = "Message from krun running on tests.suite:\n\nbody1\n"
+    assert msg.get_payload() == expect_body
+
+
+def test_mailer0002(mock_mailer, example_manifest):
+    mock_mailer.max_mails = 5
+    mock_mailer.set_recipients(["noone@localhost", "ghandi@localhost",
+                                "rasputin@localhost"])
+
+    assert example_manifest.num_mails_sent == 0
+    subject = "subject longer, much longer, blah, wibble, noodles"
+    mock_mailer.send(subject, "body1\nbody2\nbody3", manifest=example_manifest)
+    assert example_manifest.num_mails_sent == 1
+
+    example_manifest._parse()
+    assert example_manifest.num_mails_sent == 1
+
+    assert len(mock_mailer.sent) == 1
+    msg = mock_mailer.sent[0]
+    assert msg["subject"] == "[krun:tests] %s" % subject
+
+    assert msg["to"] == "noone@localhost, ghandi@localhost, rasputin@localhost"
+    expect_body = "Message from krun running on tests.suite:\n" \
+        "\nbody1\nbody2\nbody3\n"
+    assert msg.get_payload() == expect_body
+
+
+def test_mailer0003(mock_mailer, example_manifest):
+    """Check message limit works"""
+    mock_mailer.max_mails = 3
+    mock_mailer.set_recipients(["noone@localhost"])
+
+    assert example_manifest.num_mails_sent == 0
+    for i in xrange(10):  # too many emails
+        mock_mailer.send("subject%s" % i, "body%s" % i, manifest=example_manifest)
+
+    assert example_manifest.num_mails_sent == 3
+    msgs = mock_mailer.sent
+    assert len(msgs) == 3
+    for i in xrange(3):
+        assert msgs[i]["subject"].endswith("subject%s" % i)
+
+    # It should however, be possible to send more mail by bypassing the limit
+    mock_mailer.send("subject", "body", bypass_limiter=True)
+    assert len(msgs) == 4
+
+
+def test_mailer0004(mock_mailer):
+    """Check mailing with no manifest works as expected"""
+
+    mock_mailer.max_mails = 3
+    mock_mailer.set_recipients(["noone@localhost"])
+
+    with pytest.raises(AssertionError):
+        mock_mailer.send("subject", "body") # No manifest
+
+    assert len(mock_mailer.sent) == 0
+    mock_mailer.send("subject", "body", bypass_limiter=True)  # no raise
+    assert len(mock_mailer.sent) == 1

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -7,7 +7,7 @@ from krun.tests.mocks import MockMailer
 from krun.tests import TEST_DIR
 from krun.config import Config
 from krun.scheduler import ManifestManager
-from krun.tests.mocks import mock_platform
+from krun.tests.mocks import mock_platform, mock_manifest, mock_mailer
 from bz2 import BZ2File
 
 import json
@@ -27,13 +27,13 @@ def test_fatal(capsys, caplog):
     assert msg in caplog.text()
 
 
-def test_log_and_mail():
+def test_log_and_mail(mock_manifest, mock_mailer):
     log_fn = lambda s: None
-    log_and_mail(MockMailer(), log_fn, "subject", "msg", exit=False,
-                 bypass_limiter=False)
+    log_and_mail(mock_mailer, log_fn, "subject", "msg", exit=False,
+                 bypass_limiter=False, manifest=mock_manifest)
     with pytest.raises(FatalKrunError):
         log_and_mail(MockMailer(), log_fn, "", "", exit=True,
-                     bypass_limiter=False)
+                     bypass_limiter=False, manifest=mock_manifest)
     assert True
 
 
@@ -164,7 +164,7 @@ def test_get_session_info0001():
         "nbody:CPython:default-python",
     ])
     assert info["non_skipped_keys"] == expect_non_skipped_keys
-    os.unlink(ManifestManager.PATH)
+    os.unlink(ManifestManager.get_filename(config))
 
 
 def test_get_session_info0002():
@@ -244,8 +244,7 @@ def test_get_session_info0002():
 
     # There should be no overlap in the used and skipped keys
     assert info["skipped_keys"].intersection(info["non_skipped_keys"]) == set()
-
-    os.unlink(ManifestManager.PATH)
+    os.unlink(ManifestManager.get_filename(config))
 
 
 def test_run_shell_cmd_list0001():

--- a/krun/util.py
+++ b/krun/util.py
@@ -50,9 +50,10 @@ def fatal(msg):
     raise FatalKrunError(msg)
 
 
-def log_and_mail(mailer, log_fn, subject, msg, exit=False, bypass_limiter=False):
+def log_and_mail(mailer, log_fn, subject, msg, exit=False,
+                 bypass_limiter=False, manifest=None):
     log_fn(msg)
-    mailer.send(subject, msg, bypass_limiter)
+    mailer.send(subject, msg, bypass_limiter=bypass_limiter, manifest=manifest)
     if exit:
         raise FatalKrunError()  # causes post-session commands to run
 
@@ -268,7 +269,7 @@ def get_session_info(config):
     Separated from print_session_info for ease of testing"""
 
     from krun.scheduler import ManifestManager
-    manifest = ManifestManager.from_config(config)
+    manifest = ManifestManager(config, new_file=True)
 
     return {
         "n_proc_execs": manifest.total_num_execs,


### PR DESCRIPTION
This fixes a couple of issues with the mailer. See individual commits.

It turned out to be quite a bit more involved that I thought.

Sarah, is there any reason for the tests you wrote for the manifest manager to write it's manifests in a non-default place? I think I could simplify the tests a lot without the need to do that. I suppose it means running the tests would mean any existing krun.manifest would not be touched... I suppose that's a good thing, but it's hard to ensure no test ever writes a manifest in the default place. Any thoughts?