### PR TITLE
Add more dmesg skips for Linux.

### DIFF
--- a/krun/platform.py
+++ b/krun/platform.py
@@ -1174,6 +1174,7 @@ class LinuxPlatform(UnixLikePlatform):
                 re.compile("^.*ADDRCONF\(NETDEV_CHANGE\)"),
                 re.compile("^.*NIC Link is (Up|Down)"),
                 re.compile("^.*irq.* for MSI/MSI-X"),
+                re.compile("^.*eth[0-9]: link (down|up)"),
             ]
 
     def _sched_get_priority_max(self):

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -261,6 +261,10 @@ class TestLinuxPlatform(BaseKrunTest):
             "[  115.154048] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready",
             "[  118.714565] e1000e: eth0 NIC Link is Up 1000 Mbps Full Duplex, Flow Control: None",
             "[  118.714594] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready",
+            "[    6.672097] r8169 0000:06:00.0 eth0: link up",
+            "[  190.178748] r8169 0000:06:00.0 eth0: link down",
+            "[  190.178780] r8169 0000:06:00.0 eth0: link down",
+            "[  193.276415] r8169 0000:06:00.0 eth0: link up",
         ]
         assert not platform._check_dmesg_for_changes(
             platform.get_allowed_dmesg_patterns(), old_lines, new_lines, mock_manifest)


### PR DESCRIPTION
Seems each driver has its own up/down dmesgs.

Fixes email spam from the last run.