### PR TITLE
Remove tracing events from PYPYLOG.

### DIFF
--- a/krun/tests/test_vmdef.py
+++ b/krun/tests/test_vmdef.py
@@ -13,8 +13,6 @@ from krun.tests import BaseKrunTest
 from krun import EntryPoint
 from krun import util
 
-PYPY_JIT_SUMMARY_EVENT = ["[fffffffffffe] {jit-summary",
-                          "[ffffffffffff] jit-summary}"]
 
 class TestVMDef(BaseKrunTest):
     """Test stuff in VM definitions"""
@@ -172,7 +170,7 @@ class TestVMDef(BaseKrunTest):
             "[41720a9455be] gc-minor}",
             "@@@ END_IN_PROC_ITER: 0",
             "@@@ JIT_TIME: 0.001",
-        ] + PYPY_JIT_SUMMARY_EVENT))
+        ]))
 
         expect = {'raw_vm_events': [
             ['root', None, None, [
@@ -198,7 +196,7 @@ class TestVMDef(BaseKrunTest):
             "[41720a9455be] gc-minor}",
             "@@@ END_IN_PROC_ITER: 1",
             "@@@ JIT_TIME: 0.002",
-        ] + PYPY_JIT_SUMMARY_EVENT))
+        ]))
 
         expect_one_iter = ['root', None, None, [
             ['gc-minor', 71958059544423, 71958059570622, [
@@ -218,7 +216,7 @@ class TestVMDef(BaseKrunTest):
             "[41720a900000] gc-minor}",  # stop time invalid
             "@@@ END_IN_PROC_ITER: 0",
             "@@@ JIT_TIME: 0.001",
-        ] + PYPY_JIT_SUMMARY_EVENT))
+        ]))
 
         vmd = PyPyVMDef("/pretend/pypy")
         with pytest.raises(AssertionError):
@@ -232,7 +230,7 @@ class TestVMDef(BaseKrunTest):
             "[000000000004] gc-step}",
             "@@@ END_IN_PROC_ITER: 0",
             "@@@ JIT_TIME: 0.001",
-        ] + PYPY_JIT_SUMMARY_EVENT))
+        ]))
 
         vmd = PyPyVMDef("/pretend/pypy")
         with pytest.raises(AssertionError):
@@ -243,29 +241,11 @@ class TestVMDef(BaseKrunTest):
             "[000000000001] {gc-minor",  # unfinished event
             "@@@ END_IN_PROC_ITER: 0",
             "@@@ JIT_TIME: 0.001",
-        ] + PYPY_JIT_SUMMARY_EVENT))
+        ]))
 
         vmd = PyPyVMDef("/pretend/pypy")
         with pytest.raises(AssertionError):
             vmd.parse_instr_stderr_file(pypylog_file)
-
-    def test_pypy_instrumentation0006(self):
-        pypylog_file = StringIO("\n".join([
-            "[41720a93ef67] {gc-minor",
-            "[41720a941224] {gc-minor-walkroots",
-            "[41720a942814] gc-minor-walkroots}",
-            "[41720a9455be] gc-minor}",
-            "@@@ END_IN_PROC_ITER: 0",
-            "@@@ JIT_TIME: 0.001",
-        ]))
-
-        vmd = PyPyVMDef("/pretend/pypy")
-        try:
-            vmd.parse_instr_stderr_file(pypylog_file)
-        except AssertionError:
-            pass  # OK!
-        else:
-            assert False
 
     def test_jdk_instrumentation0001(self):
         """Check the json passes through correctly"""


### PR DESCRIPTION
I think this will fix our issues with the PYPYLOG parser.

I will run a reduced experiment on bencher2 overnight.

Until then, looks OK?

Also maybe of interest to @cfbolz