### PR TITLE
Allow dmesg entry for gfx card going into powersave.

### DIFF
--- a/krun/platform.py
+++ b/krun/platform.py
@@ -1175,6 +1175,9 @@ class LinuxPlatform(UnixLikePlatform):
                 re.compile("^.*NIC Link is (Up|Down)"),
                 re.compile("^.*irq.* for MSI/MSI-X"),
                 re.compile("^.*eth[0-9]: link (down|up)"),
+
+                # Graphics card goes into powersave
+                re.compile("^.*\[drm\] Enabling RC6 states"),
             ]
 
     def _sched_get_priority_max(self):

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -265,6 +265,8 @@ class TestLinuxPlatform(BaseKrunTest):
             "[  190.178748] r8169 0000:06:00.0 eth0: link down",
             "[  190.178780] r8169 0000:06:00.0 eth0: link down",
             "[  193.276415] r8169 0000:06:00.0 eth0: link up",
+            # the graphics card going into powersave
+            "[    3.793646] [drm] Enabling RC6 states: RC6 on, RC6p off, RC6pp off",
         ]
         assert not platform._check_dmesg_for_changes(
             platform.get_allowed_dmesg_patterns(), old_lines, new_lines, mock_manifest)


### PR DESCRIPTION
This graphics card dmesg entry is still causing issues. My theory is that this message appears in dmesg when a monitor is absent for X seconds, and this happens after krun collects its pre-exec dmesg.

The only potential issue is that the message could happen mid-process execution.

The change below ignores the message, if that is the behaviour we want.

Thoughts?