### PR TITLE
Dump results earlier, so that the post-execution hooks see new results.

### DIFF
--- a/krun/results.py
+++ b/krun/results.py
@@ -25,8 +25,6 @@ class Results(object):
         self.aperf_counts = dict()
         self.mperf_counts = dict()
 
-        self.reboots = 0
-
         # Record how long execs are taking so we can give the user a rough ETA.
         # Maps "bmark:vm:variant" -> [t_0, t_1, ...]
         self.eta_estimates = dict()
@@ -161,7 +159,6 @@ class Results(object):
             "aperf_counts": self.aperf_counts,
             "mperf_counts": self.mperf_counts,
             "audit": self.audit.audit,
-            "reboots": self.reboots,
             "starting_temperatures": self.starting_temperatures,
             "eta_estimates": self.eta_estimates,
             "error_flag": self.error_flag,
@@ -185,7 +182,6 @@ class Results(object):
                 self.aperf_counts == other.aperf_counts and
                 self.mperf_counts == other.mperf_counts and
                 self.audit == other.audit and
-                self.reboots == other.reboots and
                 self.starting_temperatures == other.starting_temperatures and
                 self.eta_estimates == other.eta_estimates and
                 self.error_flag == other.error_flag)

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -151,7 +151,7 @@ class ManifestManager(object):
         fh.seek(self.num_mails_sent_offset)
         new_val = self.num_mails_sent + 1
         assert 0 <= new_val <= self.num_mails_maxout
-        fh.write(ManifestManager.NUM_MAILS_FMT % (self.num_mails_sent + 1))
+        fh.write(ManifestManager.NUM_MAILS_FMT % (new_val))
         fh.close()
 
         self._reset()

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -22,13 +22,17 @@ class ManifestManager(object):
     NUM_MAILS_BYTES = 4  # number of bytes used for the (ASCII) field
     NUM_MAILS_FMT = "%%0%dd" % NUM_MAILS_BYTES
 
+    NUM_REBOOTS_BYTES = 8
+    NUM_REBOOTS_FMT = "%%0%dd" % NUM_REBOOTS_BYTES
+
     def __init__(self, config, new_file=False):
         """If new_file is True, write a new manifest file to disk based on the
         contents of the config file, otherwise parse the (existing) manifest
         file corresponding with the config file."""
 
-        # The max number the field can accommodate
+        # Maximum values for mutible header fields
         self.num_mails_maxout = 10 ** ManifestManager.NUM_MAILS_BYTES - 1
+        self.num_reboots_maxout = 10 ** ManifestManager.NUM_REBOOTS_BYTES - 1
 
         self.path = ManifestManager.get_filename(config)
         if new_file:
@@ -59,6 +63,8 @@ class ManifestManager(object):
         self.completed_exec_counts = {}  # including errors
         self.skipped_keys = set()
         self.non_skipped_keys = set()
+        self.num_reboots = -1
+        self.num_reboots_offset = None
 
     def _open(self):
         debug("Reading status cookie from %s" % self.path)
@@ -92,6 +98,9 @@ class ManifestManager(object):
                 elif key == "num_mails_sent":
                     self.num_mails_sent = int(val)
                     self.num_mails_sent_offset = offset + len(key) + 1  # +1 to skip '='
+                elif key == "num_reboots":
+                    self.num_reboots = int(val)
+                    self.num_reboots_offset = offset + len(key) + 1
                 else:
                     util.fatal("bad key in the manifest header: %s" % key)
                 offset += len(line)
@@ -143,6 +152,20 @@ class ManifestManager(object):
         new_val = self.num_mails_sent + 1
         assert 0 <= new_val <= self.num_mails_maxout
         fh.write(ManifestManager.NUM_MAILS_FMT % (self.num_mails_sent + 1))
+        fh.close()
+
+        self._reset()
+        self._parse()  # update stats
+
+    def update_num_reboots(self):
+        """Updates the reboot count header in the manifest file."""
+
+        debug("Increment reboot count in manifest")
+        fh = self._open()
+        fh.seek(self.num_reboots_offset)
+        new_val = self.num_reboots + 1
+        assert 0 <= new_val <= self.num_reboots_maxout
+        fh.write(ManifestManager.NUM_REBOOTS_FMT % (new_val))
         fh.close()
 
         self._reset()
@@ -200,9 +223,11 @@ class ManifestManager(object):
         debug("Writing manifest to %s" % self.path)
 
         num_mails_str = ManifestManager.NUM_MAILS_FMT % 0
+        num_reboots_str = ManifestManager.NUM_REBOOTS_FMT % 0
         with open(self.path, "w") as fh:
             fh.write("eta_avail_idx=%s\n" % eta_avail_idx)
             fh.write("num_mails_sent=%s\n" % num_mails_str)
+            fh.write("num_reboots=%s\n" % num_reboots_str)
             fh.write("keys\n")
             for item in manifest:
                 fh.write("%s\n" % item)
@@ -403,6 +428,7 @@ class ExecutionScheduler(object):
         self.platform.wait_for_temperature_sensors()
 
         if self.on_first_invocation:
+            self.results.write_to_file()
             info("Reboot prior to first execution")
             self._reboot()
 
@@ -478,6 +504,8 @@ class ExecutionScheduler(object):
             if self.results is None:
                 self.results = Results(self.config, self.platform,
                                        results_file=self.config.results_filename())
+
+            self.results.write_to_file()
             util.run_shell_cmd_list(
                 self.config.POST_EXECUTION_CMDS,
                 extra_env=self._make_post_cmd_env()
@@ -524,7 +552,6 @@ class ExecutionScheduler(object):
             info("Reboot in preparation for next execution")
             self._reboot()  # also deals with dumping results file
         elif self.manifest.num_execs_left == 0:
-            self.results.write_to_file()
             self.platform.save_power()
 
             info("Done: Results dumped to %s" % self.config.results_filename())
@@ -546,21 +573,17 @@ class ExecutionScheduler(object):
         """Dump results to disk and reboot"""
 
         expected_reboots = self.manifest.total_num_execs
-        self.results.reboots += 1
+        self.manifest.update_num_reboots()
         debug("About to execute reboot: %g, expecting %g in total." %
-              (self.results.reboots, expected_reboots))
-
-        # Dump the results file.
-        assert self.results is not None
-        self.results.write_to_file()
+              (self.manifest.num_reboots, expected_reboots))
 
         # Check for a boot loop
-        if self.results.reboots > expected_reboots:
+        if self.manifest.num_reboots > expected_reboots:
             util.fatal(("HALTING now to prevent an infinite reboot loop: " +
                         "INVARIANT num_reboots <= num_jobs violated. " +
                         "Krun was about to execute reboot number: %g. " +
                         "%g jobs have been completed, %g are left to go.") %
-                       (self.results.reboots, self.manifest.next_exec_idx,
+                       (self.manifest.num_reboots, self.manifest.next_exec_idx,
                         self.manifest.num_execs_left))
         self._do_reboot()
 

--- a/krun/tests/test_manifest_manager.py
+++ b/krun/tests/test_manifest_manager.py
@@ -452,6 +452,15 @@ def test_update_num_mails_sent0001():
     assert manifest.num_mails_sent == 3
     _tear_down(manifest.path)
 
+def test_update_num_mails_sent0002():
+    """Tests the overflow case"""
+
+    manifest = _setup(BLANK_EXAMPLE_MANIFEST)
+    manifest.num_mails_sent = manifest.num_mails_maxout
+    with pytest.raises(AssertionError):
+        manifest.update_num_mails_sent()
+    _tear_down(manifest.path)
+
 
 def test_update_num_reboots0001():
     manifest = _setup(BLANK_EXAMPLE_MANIFEST)

--- a/krun/tests/test_manifest_manager.py
+++ b/krun/tests/test_manifest_manager.py
@@ -10,6 +10,7 @@ TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 
 BLANK_EXAMPLE_MANIFEST = """eta_avail_idx=4
 num_mails_sent=0000
+num_reboots=00000000
 keys
 O dummy:Java:default-java
 O nbody:Java:default-java
@@ -23,6 +24,7 @@ O nbody:CPython:default-python
 
 SKIPS_EXAMPLE_MANIFEST = """eta_avail_idx=4
 num_mails_sent=0000
+num_reboots=00000000
 keys
 S dummy:Java:default-java
 S nbody:Java:default-java
@@ -36,6 +38,7 @@ O nbody:CPython:default-python
 
 SKIPS_END_EXAMPLE_MANIFEST = """eta_avail_idx=4
 num_mails_sent=0000
+num_reboots=00000000
 keys
 O dummy:Java:default-java
 O nbody:Java:default-java
@@ -49,6 +52,7 @@ S nbody:CPython:default-python
 
 SKIPS_ALL_EXAMPLE_MANIFEST = """eta_avail_idx=4
 num_mails_sent=0000
+num_reboots=00000000
 keys
 S dummy:Java:default-java
 S nbody:Java:default-java
@@ -62,6 +66,7 @@ S nbody:CPython:default-python
 
 ERRORS_ALL_EXAMPLE_MANIFEST = """eta_avail_idx=4
 num_mails_sent=0000
+num_reboots=00000000
 keys
 E dummy:Java:default-java
 E nbody:Java:default-java
@@ -75,6 +80,7 @@ E nbody:CPython:default-python
 
 IRREGULAR_EXAMPLE_MANIFEST = """eta_avail_idx=4
 num_mails_sent=0000
+num_reboots=00000000
 keys
 E dummy:Java:default-java
 C nbody:Java:default-java
@@ -109,7 +115,7 @@ def test_parse_manifest():
     assert manifest.total_num_execs == 8
     assert manifest.next_exec_key == "dummy:Java:default-java"
     assert manifest.next_exec_idx == 0
-    assert manifest.next_exec_flag_offset == 41
+    assert manifest.next_exec_flag_offset == 62
     assert manifest.outstanding_exec_counts == {
         "dummy:Java:default-java": 2,
         "nbody:Java:default-java": 2,
@@ -127,6 +133,10 @@ def test_parse_manifest():
         "nbody:Java:default-java", "dummy:CPython:default-python",
         "nbody:CPython:default-python",]
     )
+    assert manifest.num_reboots == 0
+    assert manifest.num_reboots_offset == 48
+    assert manifest.num_mails_sent == 0
+    assert manifest.num_mails_sent_offset == 31
     _tear_down(manifest.path)
 
 
@@ -177,7 +187,7 @@ def test_parse_with_skips():
     assert manifest.total_num_execs == 6
     assert manifest.next_exec_key == "dummy:CPython:default-python"
     assert manifest.next_exec_idx == 2
-    assert manifest.next_exec_flag_offset == 93
+    assert manifest.next_exec_flag_offset == 114
     assert manifest.outstanding_exec_counts == {
         "dummy:Java:default-java": 1,
         "nbody:Java:default-java": 1,
@@ -260,7 +270,7 @@ def test_parse_with_skips_at_end():
     assert manifest.total_num_execs == 6
     assert manifest.next_exec_key == "dummy:Java:default-java"
     assert manifest.next_exec_idx == 0
-    assert manifest.next_exec_flag_offset == 41
+    assert manifest.next_exec_flag_offset == 62
     assert manifest.outstanding_exec_counts == {
         "dummy:Java:default-java": 2,
         "nbody:Java:default-java": 2,
@@ -313,7 +323,7 @@ def test_update_blank():
     assert manifest.total_num_execs == 8
     assert manifest.next_exec_key == "dummy:Java:default-java"
     assert manifest.next_exec_idx == 0
-    assert manifest.next_exec_flag_offset == 41
+    assert manifest.next_exec_flag_offset == 62
     assert manifest.num_mails_sent_offset == 31
     assert manifest.outstanding_exec_counts == {
         "dummy:Java:default-java": 2,
@@ -333,7 +343,7 @@ def test_update_blank():
     assert manifest.total_num_execs == 8
     assert manifest.next_exec_key == "nbody:Java:default-java"
     assert manifest.next_exec_idx == 1
-    assert manifest.next_exec_flag_offset == 67
+    assert manifest.next_exec_flag_offset == 88
     assert manifest.num_mails_sent_offset == 31
     assert manifest.outstanding_exec_counts == {
         "dummy:Java:default-java": 1,
@@ -353,7 +363,7 @@ def test_update_blank():
     assert manifest.total_num_execs == 8
     assert manifest.next_exec_key == "dummy:CPython:default-python"
     assert manifest.next_exec_idx == 2
-    assert manifest.next_exec_flag_offset == 93
+    assert manifest.next_exec_flag_offset == 114
     assert manifest.num_mails_sent_offset == 31
     assert manifest.outstanding_exec_counts == {
         "dummy:Java:default-java": 1,
@@ -376,7 +386,7 @@ def test_update_to_completion():
     assert manifest.total_num_execs == 8
     assert manifest.next_exec_key == "dummy:Java:default-java"
     assert manifest.next_exec_idx == 0
-    assert manifest.next_exec_flag_offset == 41
+    assert manifest.next_exec_flag_offset == 62
     assert manifest.num_mails_sent_offset == 31
     assert manifest.outstanding_exec_counts == {
         "dummy:Java:default-java": 2,
@@ -416,7 +426,7 @@ def test_irregular_manifest():
     assert manifest.total_num_execs == 6
     assert manifest.next_exec_key == "dummy:CPython:default-python"
     assert manifest.next_exec_idx == 6
-    assert manifest.next_exec_flag_offset == 207
+    assert manifest.next_exec_flag_offset == 228
     assert manifest.num_mails_sent_offset == 31
     assert manifest.outstanding_exec_counts == {
         "dummy:Java:default-java": 0,
@@ -440,4 +450,25 @@ def test_update_num_mails_sent0001():
     manifest.update_num_mails_sent()
     manifest.update_num_mails_sent()
     assert manifest.num_mails_sent == 3
+    _tear_down(manifest.path)
+
+
+def test_update_num_reboots0001():
+    manifest = _setup(BLANK_EXAMPLE_MANIFEST)
+    assert manifest.num_reboots == 0
+    manifest.update_num_reboots()
+    assert manifest.num_reboots == 1
+    manifest.update_num_reboots()
+    manifest.update_num_reboots()
+    assert manifest.num_reboots == 3
+    _tear_down(manifest.path)
+
+
+def test_update_num_reboots0002():
+    """Tests the overflow case"""
+
+    manifest = _setup(BLANK_EXAMPLE_MANIFEST)
+    manifest.num_reboots = manifest.num_reboots_maxout
+    with pytest.raises(AssertionError):
+        manifest.update_num_reboots()
     _tear_down(manifest.path)

--- a/krun/tests/test_scheduler.py
+++ b/krun/tests/test_scheduler.py
@@ -25,7 +25,6 @@ def type_check_results(results):
         assert all([type(x) is float for x in execs])
 
     assert type(results.starting_temperatures) is dict
-    assert type(results.reboots) is int
     assert type(results.audit) is type(Audit(dict()))
     assert type(results.config) is type(Config())
     assert type(results.error_flag) is bool
@@ -286,8 +285,8 @@ class TestScheduler(BaseKrunTest):
             assert False
 
         # Simulate a boot loop
-        sched.results.reboots = 9999  # way too many
-        sched.results.write_to_file()
+        sched.manifest.num_reboots = 9998  # way too many
+        sched.manifest.update_num_reboots() # increments and writes out file
 
         # Run the first process execution
         sched = ExecutionScheduler(config, mock_platform.mailer, mock_platform,


### PR DESCRIPTION
For discussion only at this point.

This is a minimal fix to ensure that the results file is up to date at the time of the post-execution commands running.

There was talk of the log being confusing since the last entry in an mid-run log file is not: "reboot in preparation for next exec". That would entail having the "i'm rebooting" message being logged before the post-execution commands have run, which I find a bit confusing, and would require some more involved changes which we would need to consider carefully.

I think we would be wise to play it safe, and just be aware that the log file you see on bencher2 is at the time of the post-execution hook.

If anyone really feels strongly against, we can reconsider.

Thoughts?