### PR TITLE
When loading a manifest file, check all headers are present.

### DIFF
--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -25,6 +25,8 @@ class ManifestManager(object):
     NUM_REBOOTS_BYTES = 8
     NUM_REBOOTS_FMT = "%%0%dd" % NUM_REBOOTS_BYTES
 
+    HEADER_FIELDS = set(["num_reboots", "eta_avail_idx", "num_mails_sent"])
+
     def __init__(self, config, new_file=False):
         """If new_file is True, write a new manifest file to disk based on the
         contents of the config file, otherwise parse the (existing) manifest
@@ -84,6 +86,7 @@ class ManifestManager(object):
         self._reset()
         fh = self._open()
         offset = 0
+        seen_headers = set()
 
         # Parse manifest header
         for line in fh:
@@ -103,9 +106,13 @@ class ManifestManager(object):
                     self.num_reboots_offset = offset + len(key) + 1
                 else:
                     util.fatal("bad key in the manifest header: %s" % key)
+                seen_headers.add(key)
                 offset += len(line)
         else:
             assert False
+
+        # Check we saw all the necessary header fields
+        assert seen_headers == ManifestManager.HEADER_FIELDS
 
         # Get info from the rest of the file
         exec_idx = 0

--- a/krun/tests/test_manifest_manager.py
+++ b/krun/tests/test_manifest_manager.py
@@ -92,6 +92,19 @@ O dummy:CPython:default-python
 E nbody:CPython:default-python
 """
 
+# num_mails_sent is missing
+MISSING_HEADER_EXAMPLE_MANIFEST = """eta_avail_idx=4
+num_reboots=00000000
+keys
+E dummy:Java:default-java
+C nbody:Java:default-java
+C dummy:CPython:default-python
+S nbody:CPython:default-python
+C dummy:Java:default-java
+S nbody:Java:default-java
+O dummy:CPython:default-python
+E nbody:CPython:default-python
+"""
 
 def _setup(contents):
     class FakeConfig(object):
@@ -481,3 +494,7 @@ def test_update_num_reboots0002():
     with pytest.raises(AssertionError):
         manifest.update_num_reboots()
     _tear_down(manifest.path)
+
+def test_missing_header_manifest0001():
+    with pytest.raises(AssertionError):
+        manifest = _setup(MISSING_HEADER_EXAMPLE_MANIFEST)


### PR DESCRIPTION
A small change to make the manifest parser more robust.

OK?