### PR TITLE
Revise MALLOC_FLAGS for OpenBSD-6.0.

### DIFF
--- a/platform_sanity_checks/check_openbsd_malloc_options.c
+++ b/platform_sanity_checks/check_openbsd_malloc_options.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define EXPECT_OPTS     "sfghjpru"
+#define EXPECT_OPTS     "cfgrux"
 
 void
 run_iter(int param)


### PR DESCRIPTION
On OpenBSD>=6.0:

```
$ MALLOC_OPTIONS=sfghjpru date
malloc() warning: unknown char in MALLOC_OPTIONS
malloc() warning: unknown char in MALLOC_OPTIONS
Wed Dec 14 14:46:24 GMT 2016
```

The offending flags are `h` and `p`, which have been removed. From a 5.8 machine:

```
     H       ``Hint''.  Pass a hint to the kernel about pages we don't use.
             If the machine is paging a lot this may help a bit.
...
     P       ``Move allocations within a page.'' Allocations larger than half
             a page but smaller than a page are aligned to the end of a page
             to catch buffer overruns in more cases.  This is the default.
```

While I was here, I reviewed (and sorted) the remaining flags. Our choice of `f` is awkward:

```
     F       “Freeguard”.  Enable use after free detection.  Unused pages on
             the freelist are read and write protected to cause a segmentation
             fault upon access.  This will also switch off the delayed freeing
             of chunks, reducing random behaviour but detecting double free(3)
             calls as early as possible.  This option is intended for
             debugging rather than improved security (use the U option for
             security).
```

On the one hand, turning this on reduces nondeterminism at the cost of computation (extra `mprotect()`s to protect the freelist pages (?)). What do you think?

Now we have:

```
$ MALLOC_OPTIONS=fgjrsu date
Wed Dec 14 15:08:03 GMT 2016
```

(No warnings).