### PR TITLE
Ensure sampling of cold temperature is enclosed in pre/post hooks and put temperatures into manifest.

### DIFF
--- a/krun.py
+++ b/krun.py
@@ -265,7 +265,6 @@ def inner_main(mailer, on_first_invocation, config, args):
             util.fatal(error_msg)
 
         debug("Using pre-recorded initial temperature readings")
-        platform.starting_temperatures = current.starting_temperatures
     else:
         # Touch the config file to update its mtime. This is required
         # by when resuming a partially complete benchmark session, in which
@@ -273,14 +272,6 @@ def inner_main(mailer, on_first_invocation, config, args):
         _, _, rc = util.run_shell_cmd("touch " + args.filename)
         if rc != 0:
             util.fatal("Could not touch config file: " + args.filename)
-
-        info(("Wait %s secs to allow system to cool prior to "
-             "collecting initial temperature readings") %
-             config.TEMP_READ_PAUSE)
-        platform.sleep(config.TEMP_READ_PAUSE)
-
-        debug("Taking fresh initial temperature readings")
-        platform.starting_temperatures = platform.take_temperature_readings()
 
     # Assign platform to VM defs -- needs to happen early for sanity checks
     util.assign_platform(config, platform)

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -499,6 +499,12 @@ class ExecutionScheduler(object):
                 results = Results(self.config, self.platform)
                 results.write_to_file()
 
+                # We still need to run the post-execution commands
+                util.run_shell_cmd_list(
+                    self.config.POST_EXECUTION_CMDS,
+                    extra_env=self._make_post_cmd_env(results)
+                )
+
                 info("Reboot prior to first execution")
                 self._reboot()
             else:

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -25,12 +25,19 @@ class ManifestManager(object):
     NUM_REBOOTS_BYTES = 8
     NUM_REBOOTS_FMT = "%%0%dd" % NUM_REBOOTS_BYTES
 
+    # Start temperature stored in-manifest as YYYYY.ZZ
+    START_TEMPERATURE_BYTES = 8
+    START_TEMPERATURE_FMT = "%08.2f"
+
+    # Mandatory manifest header fields (others exist, e.g. start temperatures)
     HEADER_FIELDS = set(["num_reboots", "eta_avail_idx", "num_mails_sent"])
 
-    def __init__(self, config, new_file=False):
+    def __init__(self, config, platform, new_file=False):
         """If new_file is True, write a new manifest file to disk based on the
         contents of the config file, otherwise parse the (existing) manifest
         file corresponding with the config file."""
+
+        self.platform = platform
 
         # Maximum values for mutible header fields
         self.num_mails_maxout = 10 ** ManifestManager.NUM_MAILS_BYTES - 1
@@ -67,6 +74,7 @@ class ManifestManager(object):
         self.non_skipped_keys = set()
         self.num_reboots = -1
         self.num_reboots_offset = None
+        self.starting_temperatures = {} # name -> (offset, degrees C floats)
 
     def _open(self):
         debug("Reading status cookie from %s" % self.path)
@@ -104,6 +112,11 @@ class ManifestManager(object):
                 elif key == "num_reboots":
                     self.num_reboots = int(val)
                     self.num_reboots_offset = offset + len(key) + 1
+                elif key.startswith("start_temp_"):
+                    sensor_name = key[len("start_temp_"):]
+                    assert sensor_name in self.platform.temp_sensors
+                    self.starting_temperatures[sensor_name] = \
+                        offset + len(key) + 1, float(val)
                 else:
                     util.fatal("bad key in the manifest header: %s" % key)
                 seen_headers.add(key)
@@ -112,7 +125,7 @@ class ManifestManager(object):
             assert False
 
         # Check we saw all the necessary header fields
-        assert seen_headers == ManifestManager.HEADER_FIELDS
+        assert ManifestManager.HEADER_FIELDS.issubset(seen_headers)
 
         # Get info from the rest of the file
         exec_idx = 0
@@ -193,6 +206,17 @@ class ManifestManager(object):
         self._reset()
         self._parse()  # update stats
 
+    def set_starting_temperatures(self, dct):
+        """Set starting temperatures in manifest header"""
+
+        fh = self._open()
+        for sensor, val in dct.iteritems():
+            offset, cur_tmp = self.starting_temperatures[sensor]
+            assert cur_tmp == 0.0  # shouldn't have been written yet
+            fh.seek(offset)
+            fh.write(ManifestManager.START_TEMPERATURE_FMT % val)
+        fh.close()
+
     def __eq__(self, other):
         return (self.next_exec_key == other.next_exec_key and
                 self.next_exec_idx == other.next_exec_idx and
@@ -202,7 +226,8 @@ class ManifestManager(object):
                 self.eta_avail_idx == other.eta_avail_idx and
                 self.outstanding_exec_counts == other.outstanding_exec_counts and
                 self.skipped_keys == other.skipped_keys and
-                self.non_skipped_keys == other.non_skipped_keys)
+                self.non_skipped_keys == other.non_skipped_keys and
+                self.starting_temperatures == other.starting_temperatures)
 
     def _write_new_manifest(self, config):
         """Makes the initial manifest file from the config"""
@@ -229,12 +254,17 @@ class ManifestManager(object):
             one_exec_scheduled = True
         debug("Writing manifest to %s" % self.path)
 
+        # These fields are strictly fixed size, as they are mutated in-place
         num_mails_str = ManifestManager.NUM_MAILS_FMT % 0
         num_reboots_str = ManifestManager.NUM_REBOOTS_FMT % 0
+        start_temperature_str = ManifestManager.START_TEMPERATURE_FMT % 0
+
         with open(self.path, "w") as fh:
             fh.write("eta_avail_idx=%s\n" % eta_avail_idx)
             fh.write("num_mails_sent=%s\n" % num_mails_str)
             fh.write("num_reboots=%s\n" % num_reboots_str)
+            for sensor in self.platform.temp_sensors:
+                fh.write("start_temp_%s=%s\n" % (sensor, start_temperature_str))
             fh.write("keys\n")
             for item in manifest:
                 fh.write("%s\n" % item)
@@ -360,41 +390,39 @@ class ExecutionScheduler(object):
         self.log_path = self.config.log_filename(not self.on_first_invocation)
 
         if on_first_invocation:
-            self.manifest = ManifestManager(config, new_file=True)
-            self.results = Results(self.config, self.platform)
+            self.manifest = ManifestManager(config, platform, new_file=True)
         else:
-            self.manifest = ManifestManager(self.config)
-            self.results = None
+            self.manifest = ManifestManager(self.config, platform)
 
-    def get_estimated_exec_duration(self, key):
-        previous_exec_times = self.results.eta_estimates.get(key)
+    def get_estimated_exec_duration(self, results, key):
+        previous_exec_times = results.eta_estimates.get(key)
         if previous_exec_times:
             return mean(previous_exec_times)
         else:
             return None # we don't know
 
-    def get_estimated_overall_duration(self):
+    def get_estimated_overall_duration(self, results):
         secs = 0
         for key, num_execs in self.manifest.outstanding_exec_counts.iteritems():
-            per_exec = self.get_estimated_exec_duration(key)
+            per_exec = self.get_estimated_exec_duration(results, key)
             if per_exec is not None:
-                secs += self.get_estimated_exec_duration(key) * num_execs
+                secs += self.get_estimated_exec_duration(results, key) * num_execs
             elif key in self.manifest.skipped_keys:
                 continue
             else:
                 return None  # Unknown time for a key which is not skipped.
         return secs
 
-    def get_exec_estimate_time_formatter(self, key):
-        return TimeEstimateFormatter(self.get_estimated_exec_duration(key))
+    def get_exec_estimate_time_formatter(self, results, key):
+        return TimeEstimateFormatter(self.get_estimated_exec_duration(results, key))
 
-    def get_overall_time_estimate_formatter(self):
-        return TimeEstimateFormatter(self.get_estimated_overall_duration())
+    def get_overall_time_estimate_formatter(self, results):
+        return TimeEstimateFormatter(self.get_estimated_overall_duration(results))
 
-    def add_eta_info(self, key, exec_time):
-        self.results.eta_estimates[key].append(exec_time)
+    def add_eta_info(self, results, key, exec_time):
+        results.eta_estimates[key].append(exec_time)
 
-    def _make_post_cmd_env(self):
+    def _make_post_cmd_env(self, results):
         """Prepare an environment dict for post execution hooks"""
 
         jobs_until_eta_known = self.manifest.eta_avail_idx - \
@@ -403,7 +431,7 @@ class ExecutionScheduler(object):
             eta_val = "Unknown. Known in %d process executions." % \
                 jobs_until_eta_known
         else:
-            eta_val = self.get_overall_time_estimate_formatter().finish_str
+            eta_val = self.get_overall_time_estimate_formatter(results).finish_str
 
         return {
             "KRUN_RESULTS_FILE": self.config.results_filename(),
@@ -432,22 +460,10 @@ class ExecutionScheduler(object):
             info("Empty schedule!")
             return
 
-        self.platform.wait_for_temperature_sensors()
-
-        if self.on_first_invocation:
-            self.results.write_to_file()
-            info("Reboot prior to first execution")
-            self._reboot()
-
-        # If we get here, this is a real run, with a benchmark about to
-        # run. Results should never be in memory at this point (as they
-        # grow over time, and can get very large, thus potentially
-        # influencing the benchmark)
-        assert self.results is None
-
         bench, vm, variant = self.manifest.next_exec_key.split(":")
         job = ExecutionJob(self, vm, self.config.VMS[vm], bench, variant,
                            self.config.BENCHMARKS[bench])
+        results = None  # loaded later
 
         # Run the pre-exec commands, the benchmark and the post-exec commands.
         # These are wrapped in a try/except, so that the post-exec commands
@@ -468,7 +484,34 @@ class ExecutionScheduler(object):
             # their size (which gets large) increases over the course of the
             # benchmark session. If results were loaded, then each benchmark
             # would be subject to a different memory layout, which is not fair.
-            assert self.results is None
+            #assert self.results is None
+
+            # Deal with temperature sensors
+            if self.on_first_invocation:
+                info(("Wait %s secs to allow system to cool prior to "
+                     "collecting initial temperature readings") %
+                     self.config.TEMP_READ_PAUSE)
+                self.platform.sleep(self.config.TEMP_READ_PAUSE)
+
+                debug("Taking fresh initial temperature readings")
+                self.platform.starting_temperatures = \
+                    self.platform.take_temperature_readings()
+                self.manifest.set_starting_temperatures(
+                    self.platform.starting_temperatures)
+
+                # Scaffold the results file
+                results = Results(self.config, self.platform)
+                results.write_to_file()
+
+                info("Reboot prior to first execution")
+                self._reboot()
+            else:
+                self.platform.starting_temperatures = \
+                    {sensor: tup[1] for sensor, tup in
+                     self.manifest.starting_temperatures.iteritems()}
+                self.platform.wait_for_temperature_sensors()
+
+            assert results is None
 
             # We collect rough execution times separate from real results. The
             # reason for this is that, even if a benchmark crashes it takes
@@ -481,9 +524,9 @@ class ExecutionScheduler(object):
 
             # Store new measurements in memory. They will be written to disk
             # later at reboot time.
-            self.results = Results(self.config, self.platform,
+            results = Results(self.config, self.platform,
                                    results_file=self.config.results_filename())
-            self.results.append_exec_measurements(job.key, measurements)
+            results.append_exec_measurements(job.key, measurements)
 
             # Store instrumentation data in a separate file
             if job.vm_info["vm_def"].instrument:
@@ -495,7 +538,7 @@ class ExecutionScheduler(object):
                 # Add time taken to wait for system to come up if we are in
                 # hardware-reboot mode.
                 eta_info += STARTUP_WAIT_SECONDS
-            self.add_eta_info(job.key, eta_info)
+            self.add_eta_info(results, job.key, eta_info)
             self.manifest.update(flag)
         except Exception:
             raise
@@ -508,17 +551,18 @@ class ExecutionScheduler(object):
             # _make_post_cmd_env() needs the results to make an ETA. If an
             # exception occurred in the above try block, there's a chance that
             # they have not have been loaded.
-            if self.results is None:
-                self.results = Results(self.config, self.platform,
+            if results is None:
+                results = Results(self.config, self.platform,
                                        results_file=self.config.results_filename())
 
-            self.results.write_to_file()
+            results.write_to_file()
             util.run_shell_cmd_list(
                 self.config.POST_EXECUTION_CMDS,
-                extra_env=self._make_post_cmd_env()
+                extra_env=self._make_post_cmd_env(results)
             )
 
-        tfmt = self.get_overall_time_estimate_formatter()
+        assert results is not None
+        tfmt = self.get_overall_time_estimate_formatter(results)
 
         if self.manifest.eta_avail_idx == self.manifest.next_exec_idx:
             # We just found out roughly how long the session has left, mail out.
@@ -540,7 +584,7 @@ class ExecutionScheduler(object):
                   self.manifest.next_exec_idx))
 
         if self.platform.check_dmesg_for_changes(self.manifest):
-            self.results.error_flag = True
+            results.error_flag = True
 
         assert self.manifest.num_execs_left >= 0
         if self.manifest.num_execs_left > 0:
@@ -550,7 +594,7 @@ class ExecutionScheduler(object):
             info("Next execution is '%s(%d)' (%s variant) under '%s'" %
                  (benchmark, self.config.BENCHMARKS[benchmark], variant, vm_name))
 
-            tfmt = self.get_exec_estimate_time_formatter(job.key)
+            tfmt = self.get_exec_estimate_time_formatter(results, job.key)
             info("{:<35s}: {} ({} from now)".format(
                 "Estimated completion (next execution)",
                 tfmt.finish_str,
@@ -563,12 +607,12 @@ class ExecutionScheduler(object):
 
             info("Done: Results dumped to %s" % self.config.results_filename())
             err_msg = "Errors/warnings occurred -- read the log!"
-            if self.results.error_flag:
+            if results.error_flag:
                 warn(err_msg)
 
             msg = "Session completed. Log file at: '%s'" % (self.log_path)
 
-            if self.results.error_flag:
+            if results.error_flag:
                 msg += "\n\n%s" % err_msg
 
             msg += "\n\nDon't forget to disable Krun at boot."

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -309,10 +309,6 @@ class ExecutionJob(object):
                 self.key == other.key and
                 self.parameter == other.parameter)
 
-    def add_exec_time(self, exec_time):
-        """Feed back a rough execution time for ETA usage"""
-        self.sched.add_eta_info(self.key, exec_time)
-
     def run(self, mailer, dry_run=False):
         """Runs this job (execution)"""
 

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -32,6 +32,7 @@ class MockPlatform(BasePlatform):
         self.num_cpus = 0
         self.num_per_core_measurements = 0
         self.no_user_change = True
+        self.temp_sensors = []
 
     def pin_process_args(self):
         return []

--- a/krun/tests/test_mailer.py
+++ b/krun/tests/test_mailer.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from krun.tests.mocks import mock_mailer
+from krun.tests.mocks import mock_mailer, mock_platform
 from krun.scheduler import ManifestManager
 from krun.tests import TEST_DIR
 from krun.config import Config
@@ -8,10 +8,10 @@ from contextlib import contextmanager
 
 
 @pytest.yield_fixture
-def example_manifest():
+def example_manifest(mock_platform):
     # setup
     config = Config(os.path.join(TEST_DIR, "example.krun"))
-    manifest = ManifestManager(config, new_file=True)
+    manifest = ManifestManager(config, mock_platform, new_file=True)
 
     yield manifest
 

--- a/krun/tests/test_manifest_manager.py
+++ b/krun/tests/test_manifest_manager.py
@@ -4,6 +4,7 @@ import pytest
 from krun.config import Config
 from krun.scheduler import ManifestManager
 from krun.util import FatalKrunError
+from krun.tests.mocks import MockPlatform
 
 DEFAULT_MANIFEST = "krun.manifest"
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -113,7 +114,7 @@ def _setup(contents):
 
     with open(ManifestManager.get_filename(config), "w") as fh:
         fh.write(contents)
-    return ManifestManager(config)
+    return ManifestManager(config, MockPlatform(None, config))
 
 
 def _tear_down(filename):
@@ -313,10 +314,11 @@ def test_get_total_in_proc_iters():
 
 
 def test_write_new_manifest0001():
-    _setup(BLANK_EXAMPLE_MANIFEST)
+    tmp_manifest = _setup(BLANK_EXAMPLE_MANIFEST)
     config = Config(os.path.join(TEST_DIR, "example.krun"))
-    manifest1 = ManifestManager(config, new_file=True)
-    manifest2 = ManifestManager(config)  # reads the file in from the last line
+    manifest1 = ManifestManager(config, tmp_manifest.platform, new_file=True)
+    # reads the file in from the last line
+    manifest2 = ManifestManager(config, tmp_manifest.platform)
     assert manifest1 == manifest2
     _tear_down(manifest2.path)
 
@@ -325,7 +327,8 @@ def test_write_new_manifest0002():
     manifest_path = "example_000.manifest"
     config_path = os.path.join(TEST_DIR, "more_complicated.krun")
     config = Config(config_path)
-    manifest = ManifestManager(config, new_file=True)
+    platform = MockPlatform(None, config)
+    manifest = ManifestManager(config, platform, new_file=True)
     assert manifest.total_num_execs == 90  # taking into account skips
     _tear_down(manifest.path)
 

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -3,7 +3,7 @@ from krun.util import (format_raw_exec_results, log_and_mail, fatal,
                        run_shell_cmd_bench, get_git_version, ExecutionFailed,
                        get_session_info, run_shell_cmd_list, FatalKrunError,
                        stash_envlog, dump_instr_json)
-from krun.tests.mocks import MockMailer
+from krun.tests.mocks import MockMailer, mock_platform
 from krun.tests import TEST_DIR
 from krun.config import Config
 from krun.scheduler import ManifestManager
@@ -148,10 +148,10 @@ stderr:
     assert excinfo.value.message == expected
 
 
-def test_get_session_info0001():
+def test_get_session_info0001(mock_platform):
     path = os.path.join(TEST_DIR, "example.krun")
     config = Config(path)
-    info = get_session_info(config)
+    info = get_session_info(config, mock_platform)
 
     assert info["n_proc_execs"] == 8
     assert info["n_in_proc_iters"] == 40
@@ -167,10 +167,10 @@ def test_get_session_info0001():
     os.unlink(ManifestManager.get_filename(config))
 
 
-def test_get_session_info0002():
+def test_get_session_info0002(mock_platform):
     path = os.path.join(TEST_DIR, "more_complicated.krun")
     config = Config(path)
-    info = get_session_info(config)
+    info = get_session_info(config, mock_platform)
 
     # 6 benchmarks, 9 VMs, skipped 3 exact keys, and all 6 CPython keys
     # Then two repetitions (process executions) of all of the above.

--- a/krun/util.py
+++ b/krun/util.py
@@ -261,7 +261,7 @@ def assign_platform(config, platform):
         vm_info["vm_def"].set_platform(platform)
 
 
-def get_session_info(config):
+def get_session_info(config, platform):
     """Gets information about the session (for --info)
 
     Overwrites any existing manifest file.
@@ -269,7 +269,7 @@ def get_session_info(config):
     Separated from print_session_info for ease of testing"""
 
     from krun.scheduler import ManifestManager
-    manifest = ManifestManager(config, new_file=True)
+    manifest = ManifestManager(config, platform, new_file=True)
 
     return {
         "n_proc_execs": manifest.total_num_execs,


### PR DESCRIPTION
This moves the sampling of the cold sensors into the exception handler so that it is subject to pre/post hooks. The starting temperatures have also been moved into the manifest.

I'm not really happy with this. The change is huge.

Does anyone have any suggestions? I wonder if instead of moving the sampling inside the execution handler, we should add another "critical section" (wrapped in hooks) which deals only with reading the sensors.