### PR TITLE
Ensure collection of start temperatures is guarded by hooks.

### DIFF
--- a/krun/results.py
+++ b/krun/results.py
@@ -40,10 +40,8 @@ class Results(object):
             self.init_from_config()
             self.config_text = self.config.text
         if platform is not None:
-            self.starting_temperatures = platform.starting_temperatures
             self._audit = Audit(platform.audit)
         else:
-            self.starting_temperatures = list()
             self.audit = dict()
 
         # Import data from a Results object serialised on disk.
@@ -159,7 +157,6 @@ class Results(object):
             "aperf_counts": self.aperf_counts,
             "mperf_counts": self.mperf_counts,
             "audit": self.audit.audit,
-            "starting_temperatures": self.starting_temperatures,
             "eta_estimates": self.eta_estimates,
             "error_flag": self.error_flag,
         }
@@ -182,7 +179,6 @@ class Results(object):
                 self.aperf_counts == other.aperf_counts and
                 self.mperf_counts == other.mperf_counts and
                 self.audit == other.audit and
-                self.starting_temperatures == other.starting_temperatures and
                 self.eta_estimates == other.eta_estimates and
                 self.error_flag == other.error_flag)
 

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -311,10 +311,6 @@ class ExecutionJob(object):
                 self.key == other.key and
                 self.parameter == other.parameter)
 
-    def add_exec_time(self, exec_time):
-        """Feed back a rough execution time for ETA usage"""
-        self.sched.add_eta_info(self.key, exec_time)
-
     def run(self, mailer, dry_run=False):
         """Runs this job (execution)"""
 

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -32,6 +32,7 @@ class MockPlatform(BasePlatform):
         self.num_cpus = 0
         self.num_per_core_measurements = 0
         self.no_user_change = True
+        self.temp_sensors = []
 
     def pin_process_args(self):
         return []
@@ -39,7 +40,7 @@ class MockPlatform(BasePlatform):
     def change_scheduler_args(self):
         return []
 
-    def check_dmesg_for_changes(self, mock_platform):
+    def check_dmesg_for_changes(self, manifest):
         pass
 
     def CHANGE_USER_CMD(self):

--- a/krun/tests/test_mailer.py
+++ b/krun/tests/test_mailer.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from krun.tests.mocks import mock_mailer
+from krun.tests.mocks import mock_mailer, mock_platform
 from krun.scheduler import ManifestManager
 from krun.tests import TEST_DIR
 from krun.config import Config
@@ -8,10 +8,10 @@ from contextlib import contextmanager
 
 
 @pytest.yield_fixture
-def example_manifest():
+def example_manifest(mock_platform):
     # setup
     config = Config(os.path.join(TEST_DIR, "example.krun"))
-    manifest = ManifestManager(config, new_file=True)
+    manifest = ManifestManager(config, mock_platform, new_file=True)
 
     yield manifest
 

--- a/krun/tests/test_manifest_manager.py
+++ b/krun/tests/test_manifest_manager.py
@@ -4,6 +4,7 @@ import pytest
 from krun.config import Config
 from krun.scheduler import ManifestManager
 from krun.util import FatalKrunError
+from krun.tests.mocks import MockPlatform, mock_platform
 
 DEFAULT_MANIFEST = "krun.manifest"
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -113,7 +114,7 @@ def _setup(contents):
 
     with open(ManifestManager.get_filename(config), "w") as fh:
         fh.write(contents)
-    return ManifestManager(config)
+    return ManifestManager(config, MockPlatform(None, config))
 
 
 def _tear_down(filename):
@@ -312,20 +313,20 @@ def test_get_total_in_proc_iters():
     _tear_down(manifest.path)
 
 
-def test_write_new_manifest0001():
+def test_write_new_manifest0001(mock_platform):
     _setup(BLANK_EXAMPLE_MANIFEST)
     config = Config(os.path.join(TEST_DIR, "example.krun"))
-    manifest1 = ManifestManager(config, new_file=True)
-    manifest2 = ManifestManager(config)  # reads the file in from the last line
+    manifest1 = ManifestManager(config, mock_platform, new_file=True)
+    manifest2 = ManifestManager(config, mock_platform)  # reads the file in from the last line
     assert manifest1 == manifest2
     _tear_down(manifest2.path)
 
 
-def test_write_new_manifest0002():
+def test_write_new_manifest0002(mock_platform):
     manifest_path = "example_000.manifest"
     config_path = os.path.join(TEST_DIR, "more_complicated.krun")
     config = Config(config_path)
-    manifest = ManifestManager(config, new_file=True)
+    manifest = ManifestManager(config, mock_platform, new_file=True)
     assert manifest.total_num_execs == 90  # taking into account skips
     _tear_down(manifest.path)
 

--- a/krun/tests/test_manifest_manager.py
+++ b/krun/tests/test_manifest_manager.py
@@ -120,6 +120,8 @@ def _setup(contents):
 def _tear_down(filename):
     if os.path.exists(filename):
         os.unlink(filename)
+    else:
+        assert(False)
 
 
 def test_parse_manifest():
@@ -157,7 +159,7 @@ def test_parse_manifest():
 def test_parse_empty_manifest():
     with pytest.raises(AssertionError):
         _setup("")
-    _tear_down("example_000.manifest")
+    _tear_down(os.path.join("krun", "tests", "manifest_tests.manifest"))
 
 
 def test_parse_erroneous_manifest_001():
@@ -165,7 +167,7 @@ def test_parse_erroneous_manifest_001():
         _setup("""eta_avail_idx=4
 keys
 X dummy:Java:default-java""")
-    _tear_down("example_000.manifest")
+    _tear_down(os.path.join("krun", "tests", "manifest_tests.manifest"))
 
 
 def test_parse_erroneous_manifest_002():
@@ -173,7 +175,7 @@ def test_parse_erroneous_manifest_002():
         _setup("""bob=4
 keys
 O dummy:Java:default-java""")
-    _tear_down("example_000.manifest")
+    _tear_down(os.path.join("krun", "tests", "manifest_tests.manifest"))
 
 
 def test_parse_erroneous_manifest_003():
@@ -182,7 +184,7 @@ def test_parse_erroneous_manifest_003():
 num_mails_sent=0000
 keyz
 O dummy:Java:default-java""")
-    _tear_down("example_000.manifest")
+    _tear_down(os.path.join("krun", "tests", "manifest_tests.manifest"))
 
 
 def test_parse_erroneous_manifest_004():
@@ -191,7 +193,7 @@ def test_parse_erroneous_manifest_004():
 num_mails_sent=0000
 keys
 O dummy:Java:default-java""")
-    _tear_down("example_000.manifest")
+    _tear_down(os.path.join("krun", "tests", "manifest_tests.manifest"))
 
 
 def test_parse_with_skips():
@@ -499,3 +501,4 @@ def test_update_num_reboots0002():
 def test_missing_header_manifest0001():
     with pytest.raises(AssertionError):
         manifest = _setup(MISSING_HEADER_EXAMPLE_MANIFEST)
+    _tear_down(os.path.join("krun", "tests", "manifest_tests.manifest"))


### PR DESCRIPTION
This ensures that the temperature collection part of krun is wrapped in pre/post hooks, so as to bring down the network etc.

In doing so, i've untangled the initial reboot from the main benchmarking loop. @snim2 and I discussed this earlier and thought this would make the code more comprehensible.

I also added tests for parts of the code which make me nervous ;)

My next PR will kill the `self.results` in `ExecutionScheduler` so as to make it's scope more explicit, and as laurie suggested, use a flag to ensure results are never loaded in before a benchmark is run.

Testing with reboots on bencher7, tested without reboots on bencher6.