### PR TITLE
Make Krun Work on a Virtualised Linux Host Again

### DIFF
--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -248,7 +248,6 @@ class TestLinuxPlatform(BaseKrunTest):
     def test_is_virtual0001(self, platform):
         """check that virtualisation check doesn't crash"""
 
-        platform._check_virt_what_installed()  # needed to set the command path
         platform.is_virtual()
 
     def test_check_dmesg_filter0001(self, platform, mock_manifest):

--- a/libkrun/Makefile
+++ b/libkrun/Makefile
@@ -1,8 +1,28 @@
 LIBKRUNTIME_CFLAGS =	-Wall -shared -fPIC
 COMMON_CFLAGS = -Wall -pedantic -std=gnu99
+SUDO = sudo
 
-ifeq ("${TRAVIS}", "true")
-	COMMON_CFLAGS += -DTRAVIS
+# Sadly this tool requires root
+VIRT_WHAT = ${SUDO} /usr/sbin/virt-what
+
+# Detect if we are virtualised (Linux only for now XXX)
+ifeq ($(shell uname -s),Linux)
+	VIRTUALISED = 0  # default off
+
+	VIRT_FACTS = $(shell ${VIRT_WHAT})
+	ifneq ("${VIRT_FACTS}","")
+		VIRTUALISED = 1
+	endif
+
+	ifeq ("${TRAVIS}","true")
+		VIRTUALISED = 1
+	endif
+
+	# Under virtualised conditions, we have no performance counters.
+	# MSR-centric code is also guarded on a per-OS basis in libkruntime.c
+	ifeq (${VIRTUALISED},1)
+		COMMON_CFLAGS += -DNO_MSRS
+	endif
 endif
 
 ifeq ($(shell uname -s),Linux)

--- a/libkrun/test/test_libkruntime.py
+++ b/libkrun/test/test_libkruntime.py
@@ -15,10 +15,10 @@ from krun.platform import detect_platform
 PLATFORM = detect_platform(None, None)
 
 CORECYCLES_SUPPORT = sys.platform.startswith("linux") and \
-    not (os.environ.get("TRAVIS", None) == "true")
+    not PLATFORM.is_virtual()
 
 APERF_MPERF_SUPPORT = sys.platform.startswith("linux") and \
-    not (os.environ.get("TRAVIS", None) == "true")
+    not PLATFORM.is_virtual()
 
 def invoke_c_prog(mode):
     assert os.path.exists(TEST_PROG_PATH)


### PR DESCRIPTION
Hi,

These changes ensure that Krun works on a virtualised Linux machine again.

Tested in a VM and on bare metal. On the former, the `aperf`, `mperf` and `core_cycle` JSON keys are now empty lists.

Fixes #310 