### PR TITLE
Online amperf ratio checks

### DIFF
--- a/examples/benchmarks/nbody/python/bench.py
+++ b/examples/benchmarks/nbody/python/bench.py
@@ -5,6 +5,13 @@
 # modified by Tupteq, Fredrik Johansson, and Daniel Nanz
 # modified by Maciej Fijalkowski
 
+import sys 
+
+EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625
+N_ADVANCES = 100000
+EPSILON = 0.0000000000001
+
+
 def combinations(l):
     result = []
     for x in xrange(len(l) - 1):
@@ -13,51 +20,55 @@ def combinations(l):
             result.append((l[x],y))
     return result
 
-PI = 3.14159265358979323
+PI = 3.141592653589793
 SOLAR_MASS = 4 * PI * PI
 DAYS_PER_YEAR = 365.24
 
-BODIES = {
-    'sun': ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0], SOLAR_MASS),
+def setup_state():
 
-    'jupiter': ([4.84143144246472090e+00,
-                 -1.16032004402742839e+00,
-                 -1.03622044471123109e-01],
-                [1.66007664274403694e-03 * DAYS_PER_YEAR,
-                 7.69901118419740425e-03 * DAYS_PER_YEAR,
-                 -6.90460016972063023e-05 * DAYS_PER_YEAR],
-                9.54791938424326609e-04 * SOLAR_MASS),
+    bodies = {
+        'sun': ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0], SOLAR_MASS),
 
-    'saturn': ([8.34336671824457987e+00,
-                4.12479856412430479e+00,
-                -4.03523417114321381e-01],
-               [-2.76742510726862411e-03 * DAYS_PER_YEAR,
-                4.99852801234917238e-03 * DAYS_PER_YEAR,
-                2.30417297573763929e-05 * DAYS_PER_YEAR],
-               2.85885980666130812e-04 * SOLAR_MASS),
+        'jupiter': ([4.84143144246472090e+00,
+                     -1.16032004402742839e+00,
+                     -1.03622044471123109e-01],
+                    [1.66007664274403694e-03 * DAYS_PER_YEAR,
+                     7.69901118419740425e-03 * DAYS_PER_YEAR,
+                     -6.90460016972063023e-05 * DAYS_PER_YEAR],
+                    9.54791938424326609e-04 * SOLAR_MASS),
 
-    'uranus': ([1.28943695621391310e+01,
-                -1.51111514016986312e+01,
-                -2.23307578892655734e-01],
-               [2.96460137564761618e-03 * DAYS_PER_YEAR,
-                2.37847173959480950e-03 * DAYS_PER_YEAR,
-                -2.96589568540237556e-05 * DAYS_PER_YEAR],
-               4.36624404335156298e-05 * SOLAR_MASS),
+        'saturn': ([8.34336671824457987e+00,
+                    4.12479856412430479e+00,
+                    -4.03523417114321381e-01],
+                   [-2.76742510726862411e-03 * DAYS_PER_YEAR,
+                    4.99852801234917238e-03 * DAYS_PER_YEAR,
+                    2.30417297573763929e-05 * DAYS_PER_YEAR],
+                   2.85885980666130812e-04 * SOLAR_MASS),
 
-    'neptune': ([1.53796971148509165e+01,
-                 -2.59193146099879641e+01,
-                 1.79258772950371181e-01],
-                [2.68067772490389322e-03 * DAYS_PER_YEAR,
-                 1.62824170038242295e-03 * DAYS_PER_YEAR,
-                 -9.51592254519715870e-05 * DAYS_PER_YEAR],
-                5.15138902046611451e-05 * SOLAR_MASS) }
+        'uranus': ([1.28943695621391310e+01,
+                    -1.51111514016986312e+01,
+                    -2.23307578892655734e-01],
+                   [2.96460137564761618e-03 * DAYS_PER_YEAR,
+                    2.37847173959480950e-03 * DAYS_PER_YEAR,
+                    -2.96589568540237556e-05 * DAYS_PER_YEAR],
+                   4.36624404335156298e-05 * SOLAR_MASS),
 
-
-SYSTEM = BODIES.values()
-PAIRS = combinations(SYSTEM)
+        'neptune': ([1.53796971148509165e+01,
+                     -2.59193146099879641e+01,
+                     1.79258772950371181e-01],
+                    [2.68067772490389322e-03 * DAYS_PER_YEAR,
+                     1.62824170038242295e-03 * DAYS_PER_YEAR,
+                     -9.51592254519715870e-05 * DAYS_PER_YEAR],
+                    5.15138902046611451e-05 * SOLAR_MASS) }
 
 
-def advance(dt, n, bodies=SYSTEM, pairs=PAIRS):
+    system = bodies.values()
+    pairs = combinations(system)
+
+    return system, bodies, pairs
+
+
+def advance(dt, n, bodies, pairs):
 
     for i in xrange(n):
         for (([x1, y1, z1], v1, m1),
@@ -80,7 +91,7 @@ def advance(dt, n, bodies=SYSTEM, pairs=PAIRS):
             r[2] += dt * vz
 
 
-def report_energy(bodies=SYSTEM, pairs=PAIRS, e=0.0):
+def report_energy(bodies, pairs, e=0.0):
 
     for (((x1, y1, z1), v1, m1),
          ((x2, y2, z2), v2, m2)) in pairs:
@@ -90,10 +101,9 @@ def report_energy(bodies=SYSTEM, pairs=PAIRS, e=0.0):
         e -= (m1 * m2) / ((dx * dx + dy * dy + dz * dz) ** 0.5)
     for (r, [vx, vy, vz], m) in bodies:
         e += m * (vx * vx + vy * vy + vz * vz) / 2.
-    #print "%.9f" % e
-    "%.9f" % e
+    return e
 
-def offset_momentum(ref, bodies=SYSTEM, px=0.0, py=0.0, pz=0.0):
+def offset_momentum(ref, bodies, px=0.0, py=0.0, pz=0.0):
 
     for (r, [vx, vy, vz], m) in bodies:
         px -= vx * m
@@ -104,8 +114,19 @@ def offset_momentum(ref, bodies=SYSTEM, px=0.0, py=0.0, pz=0.0):
     v[1] = py / m
     v[2] = pz / m
 
-def run_iter(n, ref='sun'):
-    offset_momentum(BODIES[ref])
-    report_energy()
-    advance(0.01, n)
-    report_energy()
+def inner_iter(n, ref='sun'):
+    checksum = 0
+    system, bodies, pairs = setup_state()
+
+    offset_momentum(bodies[ref], system)
+    checksum += report_energy(system, pairs)
+    advance(0.01, n, system, pairs)
+    checksum += report_energy(system, pairs)
+
+    if abs(checksum - EXPECT_CHECKSUM) >= EPSILON:
+        print("bad checksum: %f vs %f" % (checksum, EXPECT_CHECKSUM))
+        sys.exit(1)
+
+def run_iter(n):
+    for i in xrange(n):
+        inner_iter(N_ADVANCES)

--- a/examples/example.krun
+++ b/examples/example.krun
@@ -1,12 +1,12 @@
 import os
-from krun.vm_defs import (PythonVMDef, NativeCodeVMDef)
+from krun.vm_defs import (PyPyVMDef, NativeCodeVMDef)
 from krun import EntryPoint
 from krun.util import fatal
 from distutils.spawn import find_executable
 
 # For a real experiment you would certainly use absolute paths
-PYTHON27_BIN = find_executable("python2.7")
-if PYTHON27_BIN is None:
+PYPY_BIN = find_executable("pypy")
+if PYPY_BIN is None:
     fatal("Python binary not found in path")
 
 # Who to mail
@@ -35,8 +35,8 @@ VMS = {
         'variants': ['default-c'],
         'n_iterations': ITERATIONS_ALL_VMS,
     },
-    'CPython': {
-        'vm_def': PythonVMDef(PYTHON27_BIN),
+    'PyPy': {
+        'vm_def': PyPyVMDef(PYPY_BIN),
         'variants': ['default-python'],
         'n_iterations': ITERATIONS_ALL_VMS,
     }
@@ -45,13 +45,13 @@ VMS = {
 
 BENCHMARKS = {
     'dummy': 1000,
-    'nbody': 1000,
+    'nbody': 15,
 }
 
 # list of "bench:vm:variant"
 SKIP=[
     #"*:C:*",
-    #"*:CPython:*",
+    #"*:PyPy:*",
 ]
 
 N_EXECUTIONS = 2  # Number of fresh processes.

--- a/examples/example.krun
+++ b/examples/example.krun
@@ -73,3 +73,11 @@ TEMP_READ_PAUSE = 1
 
 # CPU pinning (off by default)
 #ENABLE_PINNING = False
+
+# Lower and upper bound for acceptable APERF/MPERF ratios
+AMPERF_RATIO_BOUNDS = 0.995, 1.005
+
+# Rough rate of change in APERF per second above which a core is considered busy.
+# For many machines this is simply the base clock frequency, but generally
+# speaking, is undefined, so you need to check on a per-machine basis.
+AMPERF_BUSY_THRESHOLD = 3.4 * 1000 * 1000 * 1000 / 1000  # 3.4 GHz / 1000

--- a/examples/travis.krun
+++ b/examples/travis.krun
@@ -55,7 +55,7 @@ VMS = {
 
 BENCHMARKS = {
     'dummy': 1000,
-    'nbody': 1000,
+    'nbody': 5,
 }
 
 # list of "bench:vm:variant"

--- a/krun/amperf.py
+++ b/krun/amperf.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python2.7
+#
+# Copyright (c) 2017 King's College London
+# created by the Software Development Team <http://soft-dev.org/>
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition: The above copyright
+# notice and either this complete permission notice or at a minimum a reference
+# to the UPL must be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+import os
+from logging import debug
+
+
+class AMPerfRatios(object):
+    """Per-core {A,M}PERF analysis results"""
+
+    def __init__(self, vals, violations, busy_iters):
+        self.vals = vals  # list of ratios
+        self.violations = violations  # dict: type_string -> [iter_idxs]
+        self.busy_iters = busy_iters  # list of bool
+
+    def ok(self):
+        for iters in self.violations.itervalues():
+            if len(iters) > 0:
+                return False
+        return True
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+
+
+def check_amperf_ratios(aperfs, mperfs, wc_times, busy_threshold, ratio_bounds):
+    results = []  # one AMPerfRatios instance for each core
+
+    for core_idx in xrange(len(aperfs)):
+        core_res = check_core_amperf_ratios(core_idx, aperfs[core_idx],
+                                            mperfs[core_idx], wc_times,
+                                            busy_threshold, ratio_bounds)
+        results.append(core_res)
+    return results
+
+
+def check_core_amperf_ratios(core_idx, aperfs, mperfs, wc_times, busy_threshold,
+                             ratio_bounds):
+    assert len(aperfs) == len(mperfs) == len(wc_times)
+    ratios = []
+    busy_iters = []
+    violations = {
+        "throttle": [],
+        "turbo": [],
+    }
+
+    itr = zip(xrange(len(aperfs)), aperfs, mperfs, wc_times)
+    for iter_idx, aval, mval, wctval in itr:
+        # normalise the counts to per-second readings
+        norm_aval = float(aval) / wctval
+        norm_mval = float(mval) / wctval
+        ratio = norm_aval / norm_mval
+        ratios.append(ratio)
+
+        if norm_aval > busy_threshold:
+            # Busy core
+            busy_iters.append(True)
+            if ratio < ratio_bounds[0]:
+                violations["throttle"].append(iter_idx)
+            elif ratio > ratio_bounds[1]:
+                violations["turbo"].append(iter_idx)
+        else:
+            busy_iters.append(False)
+    return AMPerfRatios(ratios, violations, busy_iters)

--- a/krun/config.py
+++ b/krun/config.py
@@ -65,6 +65,8 @@ class Config(object):
         self.STACK_LIMIT = None
         self.TEMP_READ_PAUSE = 60
         self.ENABLE_PINNING = False
+        self.AMPERF_BUSY_THRESHOLD = None
+        self.AMPERF_RATIO_BOUNDS = None
 
         self.PRE_EXECUTION_CMDS = []
         self.POST_EXECUTION_CMDS = []
@@ -105,6 +107,11 @@ class Config(object):
         self.filename = config_file
         with open(config_file, "r") as fp:
             self.text = fp.read()
+
+        if self.AMPERF_RATIO_BOUNDS and not self.AMPERF_BUSY_THRESHOLD or \
+                not self.AMPERF_RATIO_BOUNDS and self.AMPERF_BUSY_THRESHOLD:
+                fatal("AMPERF_RATIO_BOUNDS and AMPERF_BUSY_THRESHOLD must either "
+                      "both be defined in the config file, or neither")
 
     def log_filename(self, resume=False):
         assert self.filename.endswith(".krun")

--- a/krun/tests/test_amperf.py
+++ b/krun/tests/test_amperf.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2017 King's College London
+# created by the Software Development Team <http://soft-dev.org/>
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition: The above copyright
+# notice and either this complete permission notice or at a minimum a reference
+# to the UPL must be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from krun.amperf import check_core_amperf_ratios
+
+
+GHZ_3_6 = 3.6 * 1024 * 1024 * 1024  # 3.6 GHz
+
+
+def test_ok_ratios0001():
+    """Check ratios which are all 1.0 are OK"""
+
+    busy_threshold = GHZ_3_6 / 1000
+    ratio_bounds = 0.999, 1.001
+
+    aperfs = mperfs = [GHZ_3_6 for x in xrange(2000)]
+    wcts = [1.0 for x in xrange(2000)]
+
+    ratios = check_core_amperf_ratios(
+        0, aperfs, mperfs, wcts, busy_threshold, ratio_bounds)
+
+    assert all([r == 1.0 for r in ratios.vals])
+    assert ratios.ok()
+
+
+def test_ok_ratios0002():
+    """Check normalisation by time is working"""
+
+    busy_threshold = GHZ_3_6 / 1000
+    ratio_bounds = 0.999, 1.001
+
+    aperfs = mperfs = [GHZ_3_6 / 2.0 for x in xrange(2000)]
+    wcts = [0.5 for x in xrange(2000)]
+
+    ratios = check_core_amperf_ratios(
+        0, aperfs, mperfs, wcts, busy_threshold, ratio_bounds)
+
+    assert all([r == 1.0 for r in ratios.vals])
+    assert ratios.ok()
+
+
+def test_bad_ratios0001():
+    """Check throttle problems are detected"""
+
+    busy_threshold = GHZ_3_6 / 1000
+    ratio_bounds = 0.9, 1.1
+
+    aperfs = [GHZ_3_6 for x in xrange(2000)]
+    mperfs = aperfs[:]
+    wcts = [1.0 for x in xrange(2000)]
+    aperfs[501] = GHZ_3_6 / 4
+
+    ratios = check_core_amperf_ratios(
+        0, aperfs, mperfs, wcts, busy_threshold, ratio_bounds)
+
+    assert not all([r == 1.0 for r in ratios.vals])
+    assert not ratios.ok()
+    assert ratios.violations["throttle"] == [501]
+
+
+def test_bad_ratios0002():
+    """Check turbo problems are detected"""
+
+    busy_threshold = GHZ_3_6 / 1000
+    ratio_bounds = 0.9, 1.1
+
+    aperfs = [GHZ_3_6 for x in xrange(2000)]
+    mperfs = aperfs[:]
+    wcts = [1.0 for x in xrange(2000)]
+    aperfs[666] = GHZ_3_6 * 1.25
+
+    ratios= check_core_amperf_ratios(
+        0, aperfs, mperfs, wcts, busy_threshold, ratio_bounds)
+
+    assert not all([r == 1.0 for r in ratios.vals])
+    assert not ratios.ok()
+    assert ratios.violations["turbo"] == [666]
+
+
+def test_bad_ratios0003():
+    """Check a mix of problems are detected"""
+
+    busy_threshold = GHZ_3_6 / 1000
+    ratio_bounds = 0.9, 1.1
+
+    aperfs = [GHZ_3_6 for x in xrange(2000)]
+    mperfs = aperfs[:]
+    wcts = [1.0 for x in xrange(2000)]
+
+    # Mixed bag of problems here
+    aperfs[14] = GHZ_3_6 * 0.77    # throttle
+    mperfs[307] = GHZ_3_6 * 0.8    # turbo
+    aperfs[788] = GHZ_3_6 * 1.15   # turbo
+    aperfs[1027] = GHZ_3_6 * 0.62  # throttle
+    mperfs[1027] = GHZ_3_6 * 0.84  # ^^^^^^^^
+
+    ratios = check_core_amperf_ratios(
+        0, aperfs, mperfs, wcts, busy_threshold, ratio_bounds)
+
+    assert not all([r == 1.0 for r in ratios.vals])
+    assert not ratios.ok()
+    assert ratios.violations["turbo"] == [307, 788]
+    assert ratios.violations["throttle"] == [14, 1027]

--- a/scripts/calibrate_amperf_tolerance.py
+++ b/scripts/calibrate_amperf_tolerance.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python2.7
+#
+# Copyright (c) 2017 King's College London
+# created by the Software Development Team <http://soft-dev.org/>
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition: The above copyright
+# notice and either this complete permission notice or at a minimum a reference
+# to the UPL must be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Draw plots to help you decide a suitable APERF/MPERF tolerance.
+
+usages:
+   calibrate_amperf_tolerance.py analyse <result-file> <aperf-estimate>")
+   calibrate_amperf_tolerance.py plot-hist <amstat-file>")
+   calibrate_amperf_tolerance.py plot-dropoff <amstat-file>")
+
+First use "analyse" mode to analyse the results, then use one of the "plot-*"
+modes to generate plots from the analysed data.
+"""
+
+import json
+import sys
+import os
+import bz2
+from collections import OrderedDict
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from krun.amperf import check_amperf_ratios
+
+
+TOLERANCES = [(i + 1) * 0.0005 for i in xrange(80)]
+
+
+def analyse_amperf(jsn, busy_thresh, output_filename):
+    # Each of these maps a tolerance to a count
+    bad_pexecs = OrderedDict()
+    bad_iters = OrderedDict()
+    for tol in TOLERANCES:
+        # The totals are the same on eacch iteration, so it's OK to use the
+        # value from the final iteration
+        total_pexecs, total_iters, bad_pexecs[tol], bad_iters[tol] = \
+            _analyse_amperf(jsn, busy_thresh, tol)
+
+    bad_pexecs_xs, bad_pexecs_ys = zip(*bad_pexecs.iteritems())
+    bad_iters_xs, bad_iters_ys = zip(*bad_iters.iteritems())
+
+    # JSON can't deal with tuples
+    bad_pexecs_xs, bad_pexecs_ys = list(bad_pexecs_xs), list(bad_pexecs_ys)
+    bad_iters_xs, bad_iters_ys = list(bad_iters_xs), list(bad_iters_ys)
+
+    ratios = _collect_busy_ratios(jsn, busy_thresh)
+
+    dct = {
+        "bad_pexecs": [bad_pexecs_xs, bad_pexecs_ys],
+        "bad_iters": [bad_iters_xs, bad_iters_ys],
+        "total_pexecs": total_pexecs,
+        "total_iters": total_iters,
+        "ratios": ratios,
+    }
+    print("\ndumping to %s" % output_filename)
+    with open(output_filename, "w") as fh:
+        json.dump(dct, fh, indent=2)
+
+
+def _analyse_amperf(jsn, busy_thresh, tol):
+    """Returns the number of bad process executions and in-process
+    iterations"""
+
+    num_bad_pexecs = 0
+    num_bad_iters = 0
+    total_pexecs = 0
+    total_iters = 0
+
+    sys.stdout.write("\ntolerance: %8.5f: " % tol)
+    bounds = 1.0 - tol, 1.0 + tol
+    for bench in jsn["wallclock_times"]:
+        sys.stdout.write(".")
+        sys.stdout.flush()
+        for pexec_idx in xrange(len(jsn["wallclock_times"][bench])):
+            total_pexecs += 1
+            aperfs = jsn["aperf_counts"][bench][pexec_idx]
+            mperfs = jsn["mperf_counts"][bench][pexec_idx]
+            wc_times = jsn["wallclock_times"][bench][pexec_idx]
+            total_iters += len(wc_times)
+            res = check_amperf_ratios(aperfs, mperfs, wc_times, busy_thresh,
+                                      bounds)
+            bad_iters = set()
+            for core in res:
+                # iterate different types of badness
+                for idxs in core.violations.itervalues():
+                    bad_iters.update(idxs)
+            if len(bad_iters) > 0:
+                num_bad_pexecs += 1
+            num_bad_iters += len(bad_iters)
+    return total_pexecs, total_iters, num_bad_pexecs, num_bad_iters
+
+
+def _collect_busy_ratios(jsn, busy_thresh):
+    ratios = []
+    for bench in jsn["wallclock_times"]:
+        bounds = 0, 2  # irrelevant for this mode really.
+        for pexec_idx in xrange(len(jsn["wallclock_times"][bench])):
+            aperfs = jsn["aperf_counts"][bench][pexec_idx]
+            mperfs = jsn["mperf_counts"][bench][pexec_idx]
+            wc_times = jsn["wallclock_times"][bench][pexec_idx]
+            res = check_amperf_ratios(aperfs, mperfs, wc_times, busy_thresh,
+                                      bounds)
+            for core_res in res:
+                for busy, ratio in zip(core_res.busy_iters, core_res.vals):
+                    if busy:
+                        ratios.append(ratio)
+    return ratios
+
+
+def plot_hist(jsn, output_filename):
+    ratios = jsn["ratios"]
+    n_bins = 1000
+
+    f, ax = plt.subplots(1, 1, sharey=False, figsize=(20, 10))
+
+    ax.hist(ratios, n_bins, facecolor="red", alpha=0.75)
+    ax.set_xlabel("Ratio")
+    ax.set_ylabel("Count")
+    ax.set_title("Probability Distribution of A/MPERF ratios")
+    ax.grid(True)
+
+    print("Plotting to %s" % output_filename)
+    plt.savefig(output_filename)
+
+
+def plot_dropoff(jsn, output_filename):
+    total_iters, total_pexecs = \
+        int(jsn["total_iters"]), int(jsn["total_pexecs"])
+    bad_pexecs_xs, bad_pexecs_ys = jsn["bad_pexecs"]
+    bad_iters_xs, bad_iters_ys = jsn["bad_iters"]
+
+    # Convert from good to bad (inverse)
+    good_pexecs_ys = [total_pexecs - y for y in bad_pexecs_ys]
+    good_iters_ys = [total_iters - y for y in bad_iters_ys]
+    good_pexecs_xs = bad_pexecs_xs  # These are the same, just a renaming
+    good_iters_xs = bad_iters_xs
+
+    # Convert Y-axes to percentages
+    good_pexecs_ys = [float(x) / total_pexecs * 100 for x in good_pexecs_ys]
+    good_iters_ys = [float(x) / total_iters * 100 for x in good_iters_ys]
+
+    f, (ax1, ax2) = plt.subplots(1, 2, sharey=False, figsize=(20, 10))
+
+    ax1.plot(good_pexecs_xs, good_pexecs_ys)
+    ax1.set_title("Good Process Executions")
+    ax1.set_xlabel("Tolerance")
+    ax1.set_ylabel("% pexecs")
+    ax1.set_ylim([0, 102])
+    ax1.grid(color="r", linestyle="--")
+    ax1.set_yticks([(x + 1) * 5 for x in xrange(20)])
+
+    ax2.plot(good_iters_xs, good_iters_ys)
+    ax2.set_title("Good In-Process Iterations")
+    ax2.set_xlabel("Tolerance")
+    ax2.set_ylabel("% iters")
+    ax2.set_ylim([0, 102])
+    ax2.grid(color="r", linestyle="--")
+    ax2.set_yticks([(x + 1) * 5 for x in xrange(20)])
+
+    print("Plotting to %s" % output_filename)
+    plt.savefig(output_filename)
+
+
+def load_json(filename, bzip=True):
+    if bzip:
+        fn = bz2.BZ2File
+    else:
+        fn = open
+
+    with fn(filename) as fh:
+        jsn = json.load(fh)
+    return jsn
+
+
+def usage():
+    print(__doc__)
+    sys.exit(1)
+
+if __name__ == "__main__":
+    try:
+        mode = sys.argv[1]
+        filename = sys.argv[2]
+    except IndexError:
+        usage()
+
+    if mode.startswith("plot"):
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+    dot_index = filename.index(".")
+    if mode == "compute":
+        try:
+            busy_thresh = int(sys.argv[3])
+        except IndexError:
+            usage()
+        jsn = load_json(filename)
+        output_filename = "%s-amstats-%s.json" % (filename[:dot_index],
+                                                  busy_thresh)
+        analyse_amperf(jsn, busy_thresh, output_filename)
+    elif mode == "plot-dropoff":
+        jsn = load_json(filename, bzip=False)
+        output_filename = "%s-dropoff.pdf" % filename[:dot_index]
+        plot_dropoff(jsn, output_filename)
+    elif mode == "plot-hist":
+        jsn = load_json(filename, bzip=False)
+        output_filename = "%s-hist.pdf" % filename[:dot_index]
+        plot_hist(jsn, output_filename)
+    else:
+        print("bad usage")


### PR DESCRIPTION
Let's start looking at this.

Goal: Check APERF/MPERF ratios after each process execution and restart if one of more in-process iteration has a ratio outside of a configurable bound.

Notes:

 * This duplicates a fair amount of code from the warmup_experiment repo, so I think the next step should probably be to flip the remaining uses to importing the krun versions and killing the originals.

 * We compute the outliers, and then discard them. We should consider (although in another PR) the ability to write the outliers into the results file directly, thus removing the need for the `mark_outliers_in_json` script.

 * You always receive an email if a process execution has a bad ratio.

 * After receiving and email, the system reboots without updating the reboot count, and without updating the manifest, thus re-running the process execution. 

 * There are three new config variables to control outliers and ratios.

 * Needs testing on OpenBSD. I will do that next.

 * We can kill the old amperf check script in the warmup repo too, but we are likely to need it later for the 0.9 data prior to this change. Perhaps we should add a git tag that we can get back to later?

Unit tests implemented for the routines, but system testing is awkward, so I've done that manually by adding scratch code to make ratios appear bad every so often:

```

        # XXX testing code
        import random
        xxx = random.randint(0, 39)
        if xxx == 0:
            ratio = 0.5
            norm_aval = busy_threshold * 2
        elif xxx == 1:
            ratio = 1.5
            norm_aval = busy_threshold * 2
```

Sample debug log snippet:

```
...
[2017-07-13 11:17:03: DEBUG] sync disks...                                      
[2017-07-13 11:17:03: WARNING] SIMULATED: `time.sleep(30)` (--quick)            
[2017-07-13 11:17:03: INFO] stderr: [iterations_runner.py] iteration 1/5        
[2017-07-13 11:17:04: INFO] stderr: [iterations_runner.py] iteration 2/5        
[2017-07-13 11:17:05: INFO] stderr: [iterations_runner.py] iteration 3/5        
[2017-07-13 11:17:06: INFO] stderr: [iterations_runner.py] iteration 4/5        
[2017-07-13 11:17:07: INFO] stderr: [iterations_runner.py] iteration 5/5        
[2017-07-13 11:17:08: DEBUG] Finding outliers with window size 200              
[2017-07-13 11:17:08: WARNING] APERF/MPERF ratio badness detected               
  in_proc_iter=4, core=2, type=turbo, ratio=1.5                                 
[2017-07-13 11:17:08: DEBUG] Sending email to 'vext01' subject line '[krun:bencher2] Benchmark needs to be re-run: dummy:CPython:defaul
t-python'
[2017-07-13 11:17:08: INFO] Finished 'dummy(1000)' (default-python variant) under 'CPython'
[2017-07-13 11:17:08: INFO] Rebooting to re-run previous process execution      
[2017-07-13 11:17:08: WARNING] SIMULATED: reboot (--hardware-reboots is OFF)    
[2017-07-13 11:17:08: DEBUG] Simulated reboot with args: ../krun.py --debug debug --quick example.krun --no-tickless-check
[2017-07-13 11:17:08: DEBUG] Attached log file: example_20170713_111523.log     
...
```

Sample email:

```
Subject: [krun:bencher2] Benchmark needs to be re-run:
 dummy:CPython:default-python
From: noreply@bencher2
To: vext01@bencher2.soft-dev.org
Date: Thu, 13 Jul 2017 14:04:38 +0100 (BST)

Message from krun running on bencher2:

APERF/MPERF ratio badness detected
  in_proc_iter=1, core=2, type=throttle, ratio=0.5
  in_proc_iter=1, core=3, type=throttle, ratio=0.5

The process execution will be retried until the ratios are OK.
```

Comments?