### PR TITLE
Ensure post-exec commands are run (once) when a rerun is requested.

### DIFF
--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -526,6 +526,10 @@ class ExecutionScheduler(object):
 
             # Bail early if the process execution needs to be re-run.
             if flag == "O":
+                util.run_shell_cmd_list(
+                    self.config.POST_EXECUTION_CMDS,
+                    extra_env=self._make_post_cmd_env(results)
+                )
                 info("Rebooting to re-run previous process execution")
                 util.reboot(self.manifest, self.platform, update_count=False)
 

--- a/krun/util.py
+++ b/krun/util.py
@@ -486,7 +486,14 @@ def _do_reboot(platform):
         os.execv(args[0], args)  # replace myself
         assert False  # unreachable
     else:
-        subprocess.call(platform.get_reboot_cmd())
+        rc = subprocess.call(platform.get_reboot_cmd())
+        if rc != 0:
+            fatal("Failed to reboot with: %s" % platform.get_reboot_cmd())
+        else:
+            debug("hard exit")
+            # Use _exit() to stop without raising SystemExit, otherwise more
+            # Python code may run.
+            os._exit(0)
 
 
 def reboot(manifest, platform, update_count=True):


### PR DESCRIPTION
As the title says, and also fix some racy code I found whilst in there.

Opted to duplicate the call to run the post-exec commands, rather than try to thread it through to the `finally` block. It just looked too error prone.

Tested on bencher2, but will test again tomorrow. Please don't merge just yet.

Looks OK?