### PR TITLE
Remove old rmsr submodule now that we use syscalls.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "rmsr"]
-	path = rmsr
-	url = https://github.com/softdevteam/rmsr.git
-

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PASS_DOWN_ARGS =	ENABLE_JAVA=${ENABLE_JAVA} JAVAC=${JAVAC} \
 
 .PHONY: libkrun vm-sanity-checks clean all
 
-all: iterations-runners libkrun vm-sanity-checks platform-sanity-checks rmsr/rmsr.ko
+all: iterations-runners libkrun vm-sanity-checks platform-sanity-checks
 
 iterations-runners: libkrun
 	cd iterations_runners && ${MAKE} ${PASS_DOWN_ARGS}
@@ -22,19 +22,8 @@ vm-sanity-checks:
 platform-sanity-checks:
 	cd platform_sanity_checks && ${MAKE} ${PASS_DOWN_ARGS}
 
-rmsr/rmsr.ko:
-ifeq ($(shell uname -s),Linux)
-ifneq ("${TRAVIS}","true")
-	cd rmsr && ${MAKE}
-endif
-endif
-
-
 clean:
 	cd iterations_runners && ${MAKE} clean
 	cd libkrun && ${MAKE} clean
 	cd vm_sanity_checks && ${MAKE} clean
 	cd platform_sanity_checks && ${MAKE} clean
-ifeq ($(shell uname -s),Linux)
-	cd rmsr && ${MAKE} clean
-endif


### PR DESCRIPTION
Remove old rmsr submodule now that we use syscalls.

Followed this SO answer: https://stackoverflow.com/questions/1260748/how-do-i-remove-a-submodule/36593218#36593218