### PR TITLE
Kill some rmsr left overs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,6 @@ Sudo is used to:
  * Set process priorities.
  * Create cgroup shields (Linux only, off by default)
  * Detect virtualised hosts.
- * Change Linux capabilities(7) for MSR device node access.
- * Change MSR device node filesystem permissions.
 
 Please make sure you understand the implications of this.
 


### PR DESCRIPTION
Killing the submodule revealed some leftover code that I missed! My bad.

I've grepped the repo and this is the last of rmsr now.

Looks like `set_msr_dev_permissions()` was not used. We didn't need it, as we put the krun user in the root group anyway.

Tested bencher7.

OK?