### PR TITLE
Fix crash

### DIFF
--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -524,6 +524,11 @@ class ExecutionScheduler(object):
             measurements, instr_data, flag = job.run(self.mailer, self.dry_run)
             exec_end_time = time.time()
 
+            # Only now is it OK to load the results file into memory.
+            Results.ok_to_instantiate = True
+            results = Results(self.config, self.platform,
+                              results_file=self.config.results_filename())
+
             # Bail early if the process execution needs to be re-run.
             if flag == "O":
                 util.run_shell_cmd_list(
@@ -534,9 +539,6 @@ class ExecutionScheduler(object):
                 util.reboot(self.manifest, self.platform, update_count=False)
 
             # Store new result.
-            Results.ok_to_instantiate = True
-            results = Results(self.config, self.platform,
-                                   results_file=self.config.results_filename())
             results.append_exec_measurements(job.key, measurements)
 
             # Store instrumentation data in a separate file

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -537,6 +537,8 @@ class ExecutionScheduler(object):
                 )
                 info("Rebooting to re-run previous process execution")
                 util.reboot(self.manifest, self.platform, update_count=False)
+                # reboot() does not return
+                raise RuntimeError("reached unreachable code!")
 
             # Store new result.
             results.append_exec_measurements(job.key, measurements)


### PR DESCRIPTION
This fixes the crash we saw yesterday:

```
Message from krun running on bencher5:

Fatal Krun error: 'NoneType' object has no attribute 'eta_estimates'
  File "krun/krun.py", line 231, in main
    inner_main(mailer, on_first_invocation, config, args)
  File "krun/krun.py", line 357, in inner_main
    sched.run()
  File "/home/kruninit/warmup_experiment/krun/krun/scheduler.py", line 531, in run
    extra_env=self._make_post_cmd_env(results)
  File "/home/kruninit/warmup_experiment/krun/krun/scheduler.py", line 473, in _make_post_cmd_env
    eta_val = self.get_overall_time_estimate_formatter(results).finish_str
  File "/home/kruninit/warmup_experiment/krun/krun/scheduler.py", line 462, in get_overall_time_estimate_formatter
    self.get_estimated_overall_duration(results))
  File "/home/kruninit/warmup_experiment/krun/krun/scheduler.py", line 447, in get_estimated_overall_duration
    per_exec = self.get_estimated_exec_duration(key, results)
  File "/home/kruninit/warmup_experiment/krun/krun/scheduler.py", line 438, in get_estimated_exec_duration
    previous_exec_times = results.eta_estimates.get(key)
```

I'm not sure why my testing didn't find this when I was implementing the re-run logic, but anyway, I've re-tested carefully and I think this is good.

The first commit is the fix, the message explains what went wrong before.

The second commit is just some defensive programming.

OK?