### PR TITLE
Unprotect dmesg deb9

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ than one leads to undefined behaviour).
  * Set process priorities.
  * Create cgroup shields (Linux only, off by default)
  * Detect virtualised hosts.
+ * Unrestrict the dmesg buffer (Linux Kernel 4.8+)
 
 Please make sure you understand the implications of this.
 


### PR DESCRIPTION
As of Linux 4.8, the dmesg buffer is only available to root unless a procfs file contains 1.

This makes Krun set the file to 1 if it exists.

Tested (up until the crash you will get due to #327 not yet being merged) on bencher8 (before this change Krun would crash much earlier).

OK?