### PR TITLE
Tolerate one un-named sensor chip on Linux.

### DIFF
--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -140,6 +140,9 @@ class MockPlatform(BasePlatform):
     def make_fresh_krun_user(self):
         pass
 
+    def get_num_temperature_sensors(self):
+        return 1
+
 
 @pytest.fixture
 def mock_platform():

--- a/krun/tests/test_scheduler.py
+++ b/krun/tests/test_scheduler.py
@@ -51,7 +51,7 @@ from krun.tests import TEST_DIR
 from krun.tests.test_results import no_results_instantiation_check
 
 
-class TestReboot(Exception):
+class _TestReboot(Exception):
     pass
 
 def type_check_results(results):
@@ -74,7 +74,7 @@ def make_reboot_raise(monkeypatch):
     def dummy_do_reboot(self):
         from logging import info
         info("SIMULATED: reboot via exception")
-        raise TestReboot()
+        raise _TestReboot()
     monkeypatch.setattr(util, '_do_reboot', dummy_do_reboot)
 
 
@@ -116,7 +116,7 @@ def run_with_captured_reboots(config, platform, monkeypatch):
         sched = ExecutionScheduler(config, platform.mailer, platform, dry_run=True)
         try:
             sched.run()
-        except TestReboot:
+        except _TestReboot:
             reboots += 1
         else:
             # normal exit() from run -- schedule finished
@@ -250,7 +250,7 @@ class TestScheduler(BaseKrunTest):
         assert sched.manifest.num_mails_sent == 1
         try:
             sched.run()
-        except TestReboot:
+        except _TestReboot:
             pass
         else:
             assert False
@@ -291,7 +291,7 @@ class TestScheduler(BaseKrunTest):
                                    dry_run=True)
         try:
             sched.run()
-        except TestReboot:
+        except _TestReboot:
             pass
         else:
             assert False
@@ -329,7 +329,7 @@ class TestScheduler(BaseKrunTest):
                                    dry_run=True)
         try:
             sched.run()
-        except TestReboot:
+        except _TestReboot:
             pass
         else:
             assert False


### PR DESCRIPTION
This change allows Krun to tolerate at most one un-named sensor chip.

I've commented liberally, as the logic is a bit fiddly.

Tested on a machine with no un-named chips, and on Travis, which has no sensors at all. I don't have a machine with un-named sensors to test on.

Any comments?

@snim2 @fsfod  can you try this branch and report back?