### PR TITLE
Fix turbo check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ PASS_DOWN_ARGS =	ENABLE_JAVA=${ENABLE_JAVA} JAVAC=${JAVAC} \
 			CC=${CC} CFLAGS=${CFLAGS} CPPFLAGS=${CPPFLAGS} \
 			LDFLAGS=${LDFLAGS} NO_MSRS=${NO_MSRS}
 
-.PHONY: libkrun vm-sanity-checks clean all
+.PHONY: utils libkrun vm-sanity-checks clean all
 
-all: iterations-runners libkrun vm-sanity-checks platform-sanity-checks
+all: utils iterations-runners libkrun vm-sanity-checks platform-sanity-checks
 
 iterations-runners: libkrun
 	cd iterations_runners && ${MAKE} ${PASS_DOWN_ARGS}
@@ -22,8 +22,12 @@ vm-sanity-checks:
 platform-sanity-checks:
 	cd platform_sanity_checks && ${MAKE} ${PASS_DOWN_ARGS}
 
+utils:
+	cd utils && ${MAKE}
+
 clean:
 	cd iterations_runners && ${MAKE} clean
 	cd libkrun && ${MAKE} clean
 	cd vm_sanity_checks && ${MAKE} clean
 	cd platform_sanity_checks && ${MAKE} clean
+	cd utils && ${MAKE} clean

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ You need to have the following installed:
   * virt-what (Linux only. `virt-what` package in Debian)
   * Our custom Linux kernel (see below).
   * Linux kernel headers (Linux only. linux-headers-3... in Debian)
+  * taskset (Linux only)
+  * msr-tools (Linux only)
 
 If you want to benchmark Java, you will also need:
   * A Java SDK 7 (`openjdk-7-jdk` package in Debian)
@@ -406,6 +408,7 @@ than one leads to undefined behaviour).
  * Create cgroup shields (Linux only, off by default)
  * Detect virtualised hosts.
  * Unrestrict the dmesg buffer (Linux Kernel 4.8+)
+ * Turn off "turbo boost" (Linux only)
 
 Please make sure you understand the implications of this.
 

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,0 +1,1 @@
+query_turbo

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,0 +1,6 @@
+CFLAGS += -Wall -Wextra
+
+all: query_turbo
+
+clean:
+	rm -f query_turbo

--- a/utils/query_turbo.c
+++ b/utils/query_turbo.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017 King's College London
+ * created by the Software Development Team <http://soft-dev.org/>
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to
+ * any person obtaining a copy of this software, associated documentation
+ * and/or data (collectively the "Software"), free of charge and under any and
+ * all copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the
+ * Software is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition: The above copyright
+ * notice and either this complete permission notice or at a minimum a
+ * reference to the UPL must be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/*
+ * Small utility to determine if turbo boost is enabled on the *current* core.
+ *
+ * Use taskset to choose which core.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+
+/* Thermal/power management CPUID leaf */
+#define CPUID_THERM_POWER   0x6
+
+/* Fields of CPUID_THERM_POWER */
+#define CPUID_THERM_POWER_TURBO 1 << 1
+
+
+int
+main(void)
+{
+    uint32_t    eax;
+    int         enabled;
+
+    asm volatile(
+        "mov %1, %%eax\n\t"
+        "cpuid\n\t"
+        : "=a" (eax)                // out
+        : "i"(CPUID_THERM_POWER)    // in
+        :"ebx", "ecx", "edx");      // clobber
+
+    enabled = (eax & CPUID_THERM_POWER_TURBO) != 0;
+    printf("%d\n", enabled);
+
+    return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
This is the most defensive way I can muster to forcefully disable turbo mode on Linux.

Fixes #338.

My test machine boots with all cores reporting that they support turbo mode:
```
edd@chugchug:~/research/krun$ for i in 0 1 2 3; do taskset -c $i ./utils/query_turbo; done
1
1
1
1
```

The above utility uses the `CPUID`. The reason it's a separate program is so I can use `taskset` to run asm code on a specific core in user-space (annoying, I know).

If at boot the core says it supports turbo mode, then it is safe to query the disable bit in `IA32_MISC_ENABLE`:
```
edd@chugchug:~/research/krun$ sudo rdmsr --all 0x1a0
850089
850089
850089
850089
```

Those are hex, so that means the turbo mode kill switch is off, as bit (1 << 38) is off:

Here's a krun debug log snippet of what happens:
```
[2017-09-18 16:51:41: DEBUG] Checking 'turbo boost' is disabled                                                     
[2017-09-18 16:51:41: DEBUG] execute shell cmd: /usr/bin/sudo -u root modprobe msr
[2017-09-18 16:51:41: DEBUG] execute shell cmd: taskset -c 0 /home/edd/research/krun/krun/../utils/query_turbo
[2017-09-18 16:51:42: DEBUG] CPU supports turbo boost and it is enabled. Disabling...            
[2017-09-18 16:51:42: DEBUG] execute shell cmd: /usr/bin/sudo -u root rdmsr --all 0x1a0
[2017-09-18 16:51:42: DEBUG] execute shell cmd: /usr/bin/sudo -u root wrmsr -p 0 0x1a0 0x4000850089
[2017-09-18 16:51:42: DEBUG] execute shell cmd: taskset -c 1 /home/edd/research/krun/krun/../utils/query_turbo
[2017-09-18 16:51:42: DEBUG] CPU 1 doesn't support turbo boost, or it is already disabled             
[2017-09-18 16:51:42: DEBUG] execute shell cmd: taskset -c 2 /home/edd/research/krun/krun/../utils/query_turbo
[2017-09-18 16:51:42: DEBUG] CPU 2 doesn't support turbo boost, or it is already disabled                              
[2017-09-18 16:51:42: DEBUG] execute shell cmd: taskset -c 3 /home/edd/research/krun/krun/../utils/query_turbo
[2017-09-18 16:51:42: DEBUG] CPU 3 doesn't support turbo boost, or it is already disabled
[2017-09-18 16:51:42: DEBUG] execute shell cmd: /usr/bin/sudo -u root rdmsr --all 0x1a0                                                         
[2017-09-18 16:51:42: DEBUG] execute shell cmd: taskset -c 0 /home/edd/research/krun/krun/../utils/query_turbo                                  
[2017-09-18 16:51:42: DEBUG] execute shell cmd: taskset -c 1 /home/edd/research/krun/krun/../utils/query_turbo
[2017-09-18 16:51:42: DEBUG] execute shell cmd: taskset -c 2 /home/edd/research/krun/krun/../utils/query_turbo                                 
[2017-09-18 16:51:42: DEBUG] execute shell cmd: taskset -c 3 /home/edd/research/krun/krun/../utils/query_turbo
```

You can see that the turbo settings are shared across all cores on this particular machine, but we can't bank on that. I also did a final sanity pass to check that setting a later core does not affect an earlier core.

Looks good? Comments?