### PR TITLE
Daemonise Krun

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,10 @@ easier.
 You should not collect results intended for publication with development switches
 turned on.
 
-We also recommend that for 'real' benchmarking you turn on the `--hardware-reboots`
-switch to restart physical hardware before each benchmark execution.
+We also recommend that for 'real' benchmarking you turn on the
+`--hardware-reboots` and `--daemonise` switches. These ensure that the system
+will reboot before each benchmark execution, and that Krun will run in the
+background, allowing you to log out before the first reboot.
 
 You will also need to ensure that Krun is restarted once the machine has
 rebooted. The `etc/` directory contains example `/etc/rc.local` files for the

--- a/etc/rc.local.linux
+++ b/etc/rc.local.linux
@@ -31,6 +31,6 @@ PYTHON=/usr/bin/python2.7
 # Don't change anything below here
 
 sudo -u ${INITIAL_USER} sh -c "cd ${EXPERIMENT_DIR}  && \
-    ${PYTHON} ${KRUN_DIR}/krun.py --hardware-reboots ${CONFIG_FILE}" &
+    ${PYTHON} ${KRUN_DIR}/krun.py --daemonise --hardware-reboots ${CONFIG_FILE}"
 
 exit 0  # must return 0 on Linux

--- a/etc/rc.local.openbsd
+++ b/etc/rc.local.openbsd
@@ -26,4 +26,4 @@ PYTHON=/usr/local/bin/python2.7
 # Don't change anything below here
 
 env PATH=${PATH}:/usr/local/bin sudo -u ${INITIAL_USER} sh -c \
-    "cd ${EXPERIMENT_DIR} && ${PYTHON} ${KRUN_DIR}/krun.py --hardware-reboots ${CONFIG_FILE}" &
+    "cd ${EXPERIMENT_DIR} && ${PYTHON} ${KRUN_DIR}/krun.py --hardware-reboots --daemonise ${CONFIG_FILE}"

--- a/krun.py
+++ b/krun.py
@@ -148,6 +148,8 @@ def create_arg_parser():
     parser.add_argument("--hardware-reboots", action="store_true", default=False,
                         help=("Reboot physical hardware before each benchmark "
                               "execution. Off by default."))
+    parser.add_argument("--daemonise", "-D", action="store_true",
+                        default=False, help=("Daemonise Krun"))
 
     # Developer switches
     parser.add_argument("--quick", action="store_true", default=False,
@@ -286,6 +288,11 @@ def inner_main(mailer, on_first_invocation, config, args):
              "Use bare-metal for reliable results!")
 
     platform.collect_audit()
+
+    # At this point the config file is OK, and on-disk state is consistent,
+    # so let's daemonise (if requested).
+    if args.daemonise:
+        util.daemonise()
 
     if not on_first_invocation:
         # output file must exist, due to check above

--- a/krun/util.py
+++ b/krun/util.py
@@ -528,3 +528,33 @@ def check_audit_unchanged(results, platform):
             "identical to the one on which the last results were "
             "gathered, which is not the case.")
         fatal(error_msg)
+
+
+def daemonise():
+    """Daemonise Krun"""
+
+    debug("daemonising...")
+    try:
+        pid = os.fork()
+    except OSError:
+        fatal("failed to daemonise: first fork")
+
+    if pid != 0:
+        # parent
+        os._exit(0)
+
+    os.setsid()
+    try:
+        pid = os.fork()
+    except OSError:
+        fatal("failed to daemonise: second fork")
+
+    if pid != 0:
+        # parent
+        os._exit(0)
+
+    # Redirect stdin/stdout/stderr to /dev/null
+    null = os.open("/dev/null", os.O_RDWR)
+    for fd in xrange(3):
+        # Since these fds will be in-use, dup2 will close them first
+        os.dup2(null, fd)


### PR DESCRIPTION
This change daemonises Krun. Not ready for merge, but ready for initial review.

`daemonise()` is very loosely based on the example here:
http://code.activestate.com/recipes/278731/

There's a lot of code in the above example I think we probably don't need, but I'd be interested to hear your thoughts.

If I start Krun (not in a tmux),  close the terminal, log back in, then Krun is still running :) I waited a while and looked at the log file. Krun seems to have completed OK.

Needs to be tested more thoroughly, and with reboots (will test on my Linux machine at home when I am back)

TODO:
 * Does is work with reboots.
 * Does the daemon stop the system rebooting if krun is on a mount point (as suggested in a comment in the linked recipe)
 * Update docs

Fixes #336 