### PR TITLE
Move masking

### DIFF
--- a/libkrun/test/test_libkruntime.py
+++ b/libkrun/test/test_libkruntime.py
@@ -75,12 +75,18 @@ def parse_keyvals(out, doubles=False):
 
 class TestLibKrunTime(object):
     @pytest.mark.skipif(not MSR_SUPPORT, reason="No MSRs")
-    def test_cycles_u64(self):
+    def test_cycles_u64_0001(self):
         rv, out, _ = invoke_c_prog("cycles_u64")
         assert rv == 0
         dct = parse_keyvals(out)
 
         assert 0 <= dct["cycles_u64_delta"] <= NOT_MANY_CYCLES
+
+    @pytest.mark.skipif(MSR_SUPPORT, reason="Without MSRs only")
+    def test_cycles_u64_0002(self):
+        rv, _, err = invoke_c_prog("cycles_u64")
+        assert rv != 0
+        assert "libkruntime was built without MSR support" in err
 
     @pytest.mark.skipif(not MSR_SUPPORT, reason="No MSRs")
     def test_cycles_double(self):
@@ -126,24 +132,46 @@ class TestLibKrunTime(object):
         assert dct["aperf"] <= dct["mperf"]
 
     @pytest.mark.skipif(not MSR_SUPPORT, reason="No MSRs")
-    def test_aperf(self):
+    def test_aperf0001(self):
+        """Check krun_get_aperf when libkruntime has MSR support"""
+
         rv, out, _ = invoke_c_prog("aperf")
         assert rv == 0
         dct = parse_keyvals(out)
         assert dct["aperf_start"] < dct["aperf_stop"]
 
+    @pytest.mark.skipif(MSR_SUPPORT, reason="Without MSRs only")
+    def test_aperf0002(self):
+        """Check krun_get_aperf when libkruntime does not have MSR support"""
+
+        rv, _, err = invoke_c_prog("aperf")
+        assert rv != 0
+        assert "libkruntime was built without MSR support" in err
+
     @pytest.mark.skipif(not MSR_SUPPORT, reason="No MSRs")
-    def test_mperf(self):
+    def test_mperf0001(self):
+        """Check krun_get_mperf when libkruntime does not have MSR support"""
+
         rv, out, _ = invoke_c_prog("mperf")
         assert rv == 0
         dct = parse_keyvals(out)
         assert dct["mperf_start"] < dct["mperf_stop"]
 
+    @pytest.mark.skipif(MSR_SUPPORT, reason="Without MSRs only")
+    def test_mperf0002(self):
+        """Check krun_get_aperf when libkruntime does not have MSR support"""
+
+        rv, _, err = invoke_c_prog("mperf")
+        assert rv != 0
+        assert "libkruntime was built without MSR support" in err
+
+    @pytest.mark.skipif(not MSR_SUPPORT, reason="No MSRs")
     def test_core_bounds_check(self):
         rv, _, err = invoke_c_prog("core_bounds_check")
         assert rv != 0
         assert "core out of range" in err
 
+    @pytest.mark.skipif(not MSR_SUPPORT, reason="No MSRs")
     def test_mdata_index_bounds_check(self):
         rv, _, err = invoke_c_prog("mdata_index_bounds_check")
         assert rv != 0

--- a/libkrun/test/test_prog.c
+++ b/libkrun/test/test_prog.c
@@ -215,7 +215,7 @@ test_cycles_u64_double_ratio(void)
 void
 test_clock_gettime_monotonic()
 {
-    double t1, t2, delta;
+    double t1, t2;
 
     krun_measure(0);
     sleep(1);
@@ -223,7 +223,6 @@ test_clock_gettime_monotonic()
 
     t1 = krun_get_wallclock(0);
     t2 = krun_get_wallclock(1);
-    delta = t2 - t1;
 
     printf("monotonic_start= %f\n", t1);
     printf("monotonic_stop = %f\n", t2);


### PR DESCRIPTION
This moves the core cycle counter masking out of the critical section, instead doing the masking later when extracting the value from libkrun.

While we are here, make calling `krun_get_{aperf,mperf,core_cycles}()` abort when libkrun is built without MSR support (I also considered always returning a 0 core cycle count, but opted for the more explicit of the two).

(One C warning also fixed).

Needs testing on a machine with the Krun linux kernel, but can be reviewed nonetheless.

Fixes #325