### PR TITLE
Allow the user to customise the dmesg whitelist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ examples/*.manifest
 **/*.so
 iterations_runners/iterations_runner_c
 platform_sanity_checks/check_openbsd_malloc_options
+.cache

--- a/README.md
+++ b/README.md
@@ -425,6 +425,38 @@ PRE_EXECUTION_CMDS = [
 Similarly, you can use `POST_EXECUTION_CMDS` to turn daemons back on after each
 process execution.
 
+## Custom Dmesg Whitelists
+
+For each platform, Krun has a default built-in dmesg whitelist. The whitelist
+is a collection of regex patterns which are used to decide if a line in the
+dmesg buffer is a cause for concern. If a new line appears in the dmesg during
+benchmarking, and the line is not matched by at least one whitelist pattern,
+then Krun will flag the process execution as ``errored'' and email the user.
+
+From time to time you may find that you need to customise the whitelist. This
+is achieved by adding a callback named `custom_dmesg_whitelist` into your
+config file. The callback is passed the default list of patterns for your
+platform and must return a new list of patterns. In the implementation of your
+callback you have the choice to base your custom whitelist on the defaults or
+to define your own patterns from scratch.
+
+For example, to add a pattern, you would add a callback like:
+
+```python
+def custom_dmesg_whitelist(defaults):
+    return defaults + ["^.*your+regex.*pattern$"]
+```
+
+Krun uses Python's `re` module to compile regex patterns. Consult the Python
+docs for more information on the regex syntax.
+
+Bear in mind that Linux dmesg lines start with a time code which custom dmesg
+lines will need to match.
+
+If you have added custom patterns which you think would be useful for other
+users of Krun, please raise an issue (or pull request) to have the patterns
+added to the defaults.
+
 ## Unit Tests
 
 Krun has a pytest suite which can be run by executing `py.test` in the

--- a/krun/config.py
+++ b/krun/config.py
@@ -52,7 +52,7 @@ class Config(object):
     """
 
     def __init__(self, config_file=None):
-        # config defaults go here
+        # config defaults (variables)
         self.MAIL_TO = list()
         self.MAX_MAILS = 5
         self.VMS = dict()
@@ -67,9 +67,11 @@ class Config(object):
         self.ENABLE_PINNING = False
         self.AMPERF_BUSY_THRESHOLD = None
         self.AMPERF_RATIO_BOUNDS = None
-
         self.PRE_EXECUTION_CMDS = []
         self.POST_EXECUTION_CMDS = []
+
+        # config defaults (callbacks)
+        self.custom_dmesg_whitelist = None
 
         if config_file is not None:
             self.read_from_file(config_file)

--- a/krun/tests/custom_dmesg_whitelist0001.krun
+++ b/krun/tests/custom_dmesg_whitelist0001.krun
@@ -1,0 +1,27 @@
+import os
+from krun.vm_defs import PythonVMDef
+from krun import EntryPoint
+
+VARIANTS = {
+    "default-python": EntryPoint("bench.py", subdir="python"),
+}
+
+N_EXECUTIONS = 2
+
+VMS = {
+    'CPython': {
+        'vm_def': PythonVMDef('/usr/bin/python2'),
+        'variants': ['default-python'],
+        'n_iterations': 10,
+    }
+}
+
+BENCHMARKS = {
+    'nbody': 1000,
+}
+
+def custom_dmesg_whitelist(default_whitelist):
+    return default_whitelist + ["^custom1*", "^.custom2$"]
+
+HEAP_LIMIT = 2097152
+STACK_LIMIT = 8192

--- a/krun/tests/custom_dmesg_whitelist0002.krun
+++ b/krun/tests/custom_dmesg_whitelist0002.krun
@@ -1,0 +1,27 @@
+import os
+from krun.vm_defs import PythonVMDef
+from krun import EntryPoint
+
+VARIANTS = {
+    "default-python": EntryPoint("bench.py", subdir="python"),
+}
+
+N_EXECUTIONS = 2
+
+VMS = {
+    'CPython': {
+        'vm_def': PythonVMDef('/usr/bin/python2'),
+        'variants': ['default-python'],
+        'n_iterations': 10,
+    }
+}
+
+BENCHMARKS = {
+    'nbody': 1000,
+}
+
+def custom_dmesg_whitelist(default_whitelist):
+    return ["^.no+", "^defaults", "^here+"]
+
+HEAP_LIMIT = 2097152
+STACK_LIMIT = 8192

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -71,6 +71,9 @@ class MockPlatform(BasePlatform):
         self.no_user_change = True
         self.temp_sensors = []
 
+    def default_dmesg_whitelist(self):
+        return []
+
     def pin_process_args(self):
         return []
 

--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -43,6 +43,8 @@ from krun.util import FatalKrunError
 import os
 import pytest
 import time
+import sys
+import krun.platform
 from distutils.spawn import find_executable
 
 
@@ -323,3 +325,34 @@ def test_space_in_variant_name0001():
     with pytest.raises(FatalKrunError) as e:
         config = Config(path)
     assert "Variant names must not contain spaces" in str(e)
+
+
+def test_custom_dmesg_whitelist0001(monkeypatch):
+    """Test a config file that appends two patterns to the default whitelist"""
+
+    path = os.path.join(TEST_DIR, "custom_dmesg_whitelist0001.krun")
+    config = Config(path)
+    platform = krun.platform.detect_platform(None, config)
+    patterns = [p.pattern for p in platform.get_dmesg_whitelist()]
+    assert patterns == platform.default_dmesg_whitelist() + \
+        ["^custom1*", "^.custom2$"]
+
+
+def test_custom_dmesg_whitelist0002(monkeypatch):
+    """Test a config file that replaces entirely the dmesg whitelist"""
+
+    path = os.path.join(TEST_DIR, "custom_dmesg_whitelist0002.krun")
+    config = Config(path)
+    platform = krun.platform.detect_platform(None, config)
+    patterns = [p.pattern for p in platform.get_dmesg_whitelist()]
+    assert patterns == ["^.no+", "^defaults", "^here+"]
+
+
+def test_custom_dmesg_whitelist0003(monkeypatch):
+    """Test a config file that uses no custom whitelist"""
+
+    path = os.path.join(TEST_DIR, "example.krun")
+    config = Config(path)
+    platform = krun.platform.detect_platform(None, config)
+    patterns = [p.pattern for p in platform.get_dmesg_whitelist()]
+    assert patterns == platform.default_dmesg_whitelist()

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -463,7 +463,7 @@ class TestLinuxPlatform(BaseKrunTest):
             "[   75.007583] tg3 0000:04:00.0 eth0: EEE is disabled",
         ]
         assert not platform._check_dmesg_for_changes(
-            platform.get_allowed_dmesg_patterns(), old_lines, new_lines, mock_manifest)
+            platform.get_dmesg_whitelist(), old_lines, new_lines, mock_manifest)
 
     def test_aslr0001(self, platform, caplog):
         # get current ASLR value


### PR DESCRIPTION
This changes allows the user to customise the dmesg whitelist.

In the end I *did* opt for the callback.

Queries:
 * Should the `CUSTOM_DMESG_WHITELIST` config func be lowercase or remain all caps?
 * I'm thinking of renaming `get_allowed_dmesg_lines()` to `get_dmesg_whitelist()`. Thoughts?

Comments? OK?

Fixes #213 

I have no idea what that cache file is. Going to kill it.