### PR TITLE
Show the last 50 lines of stderr if a crash occurs in instrumentation mode.

### DIFF
--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -370,7 +370,7 @@ class ExecutionJob(object):
         if not dry_run:
             try:
                 measurements = util.check_and_parse_execution_results(
-                    stdout, stderr, rc, self.sched.config)
+                    stdout, stderr, rc, self.sched.config, instrument=vm_def.instrument)
                 flag = "C"
             except util.RerunExecution as e:
                 subject = ("Benchmark needs to be re-run: %s (exec_idx=%s)" %


### PR DESCRIPTION
This is the least instrustive method of fixing #361. It's not perfect, but the other ways touch a lot more code.

What do you think?

Fixes #361 