### PR TITLE
Re-add the wait for the system to come up.

### DIFF
--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -483,6 +483,12 @@ class ExecutionScheduler(object):
     def run(self):
         """Benchmark execution starts here"""
 
+        # In reboot mode, wait for the system to come up before we proceed
+        if self.platform.hardware_reboots:
+            debug("Waiting %s seconds for the system to come up." %
+                  str(STARTUP_WAIT_SECONDS))
+            self.platform.sleep(STARTUP_WAIT_SECONDS)
+
         # Important that the dmesg is collected after the above startup wait.
         # Otherwise we get spurious dmesg changes.
         self.platform.collect_starting_dmesg()


### PR DESCRIPTION
Here's the fix for Krun not waiting for the system to come up.

The original code that was removed looked like this:

```
-        if self.reboot and self.started_by_init and jobs_left > 0:
-            debug("Waiting %s seconds for the system to come up." %
-                 str(STARTUP_WAIT_SECONDS))
-            self.platform.sleep(STARTUP_WAIT_SECONDS)
-
         # Important that the dmesg is collected after the above startup wait.
         # Otherwise we get spurious dmesg changes.
         self.platform.collect_starting_dmesg()
```

This version is a little different due to quite a lot of code churn since.

I'm testing now, please don't merge yet.