### PR TITLE
Plumb in extra instrumentation mode iterations runners flags.

### DIFF
--- a/iterations_runners/iterations_runner.c
+++ b/iterations_runners/iterations_runner.c
@@ -111,29 +111,40 @@ convert_str_to_int(char *s)
     return ((int) r);
 }
 
+void
+usage() {
+    printf("usage: iterations_runner_c <benchmark> <# of iterations> "
+           "<benchmark param>\n             <debug flag> [instrumentation dir] "
+           "[key] [key pexec index]\n\n");
+    printf("Arguments in [] are for instrumentation mode only.\n");
+    exit(EXIT_FAILURE);
+}
+
 int
 main(int argc, char **argv)
 {
     char     *krun_benchmark = 0;
     int       krun_total_iters = 0, krun_param = 0, krun_iter_num = 0;
-    int       krun_debug = 0, krun_num_cores = 0, krun_core;
+    int       krun_debug = 0, krun_num_cores = 0, krun_core, krun_instrument = 0;
     void     *krun_dl_handle = 0;
     int     (*krun_bench_func)(int); /* func ptr to benchmark entry */
     double   *krun_wallclock_times = NULL;
     uint64_t **krun_cycle_counts = NULL, **krun_aperf_counts = NULL;
     uint64_t **krun_mperf_counts = NULL;
 
-    if (argc != 6) {
-        printf("usage: iterations_runner_c "
-            "<benchmark> <# of iterations> <benchmark param> <debug flag> "
-            "<instrument flag>\n");
-        exit(EXIT_FAILURE);
+    if (argc < 5) {
+        usage();
     }
 
     krun_benchmark = argv[1];
     krun_total_iters = convert_str_to_int(argv[2]);
     krun_param = convert_str_to_int(argv[3]);
     krun_debug = convert_str_to_int(argv[4]);
+    krun_instrument = argc >= 6;
+
+    if (krun_instrument && (argc != 8)) {
+        usage();
+    }
 
     krun_init();
     krun_num_cores = krun_get_num_cores();

--- a/iterations_runners/iterations_runner.java
+++ b/iterations_runners/iterations_runner.java
@@ -201,20 +201,31 @@ class IterationsRunner {
         System.out.print("]");
     }
 
+    public static void usage() {
+        System.out.println("usage: iterations_runner <benchmark> " +
+                "<# of iterations> <benchmark param>\n           " +
+                "<debug flag> [instrumentation dir] [key] [key pexec index]\n");
+        System.out.println("Arguments in [] are for instrumentation mode only.\n");
+        System.exit(1);
+    }
+
     public static void main(String args[]) throws
         ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, java.lang.reflect.InvocationTargetException {
 
-        if (args.length != 5) {
-            System.out.println("usage: iterations_runner <benchmark> " +
-                    "<# of iterations> <benchmark param> <debug flag>" +
-                    "<instrument flag>\n");
-            System.exit(1);
+        if (args.length < 4) {
+            usage();
         }
+
         String benchmark = args[0];
         int iterations = Integer.parseInt(args[1]);
         int param = Integer.parseInt(args[2]);
         boolean debug = Integer.parseInt(args[3]) > 0;
-        boolean instrument = Integer.parseInt(args[4]) > 0;
+
+        // Note: JDK instrumentation is still using the old Krun interface.
+        boolean instrument = args.length >= 5;
+        if ((instrument) && (args.length != 7)) {
+            usage();
+        }
 
         KrunJDKInstrumentation krunInst = null;
         if (instrument) {

--- a/iterations_runners/iterations_runner.js
+++ b/iterations_runners/iterations_runner.js
@@ -65,15 +65,26 @@ function emitPerCoreResults(name, num_cores, ary) {
     write("]")
 }
 
-if (this.arguments.length != 5) {
-    throw "usage: iterations_runner.js <benchmark> <# of iterations> " +
-          "<benchmark param> <debug flag> <instrument flag>";
+function usage() {
+    throw "\nusage: iterations_runner.js <benchmark> <# of iterations> " +
+          "<benchmark param>\n       <debug flag> [instrumentation dir] [key] " +
+          "[key pexec index]\n\nArguments in [] are for" +
+          "instrumentation mode only.\n";
+}
+
+if (this.arguments.length < 4) {
+    usage();
 }
 
 var BM_entry_point = this.arguments[0];
 var BM_n_iters = parseInt(this.arguments[1]);
 var BM_param = parseInt(this.arguments[2]);
 var BM_debug = parseInt(this.arguments[3]) > 0;
+var BM_instrument = this.arguments.length >= 5;
+
+if (BM_instrument && (this.arguments.length != 7)) {
+    usage();
+}
 
 load(BM_entry_point);
 

--- a/iterations_runners/iterations_runner.lua
+++ b/iterations_runners/iterations_runner.lua
@@ -57,6 +57,15 @@ function emit_per_core_measurements(name, num_cores, tbl, tbl_len)
     io.stdout:write("]")
 end
 
+function usage()
+    io.stderr:write("usage: iterations_runner.lua <benchmark> " ..
+                    "<# of iterations> <benchmark param>\n           " ..
+                    "<debug flag> [instrumentation dir] [key] " ..
+                    "[key pexec index]\n\n")
+    io.stderr:write("Arguments in [] are for instrumentation mode only.\n")
+    os.exit(1)
+end
+
 ffi.cdef[[
     void krun_init(void);
     void krun_done(void);
@@ -78,15 +87,18 @@ local krun_get_core_cycles_double = libkruntime.krun_get_core_cycles_double
 local krun_get_aperf_double = libkruntime.krun_get_aperf_double
 local krun_get_mperf_double = libkruntime.krun_get_mperf_double
 
+if #arg < 4 then
+    usage()
+end
+
 local BM_benchmark = arg[1]
 local BM_iters = tonumber(arg[2])
 local BM_param = tonumber(arg[3])
 local BM_debug = tonumber(arg[4]) > 0
+local BM_instrument = #arg >= 5
 
-if #arg ~= 5 then
-    io.stderr:write("usage: iterations_runner.lua <benchmark> <# of iterations> " ..
-                    "<benchmark param> <debug flag> <instrument flag>")
-    os.exit(1)
+if BM_instrument and #arg ~= 7 then
+    usage()
 end
 
 dofile(BM_benchmark)

--- a/iterations_runners/iterations_runner.php
+++ b/iterations_runners/iterations_runner.php
@@ -48,16 +48,27 @@
  *  krun_get_{core_cycles,aperf,mperf}_double();
  */
 
-if ($argc != 6) {
+function usage() {
     fwrite(STDERR, "usage: iterations_runner.php <benchmark> <# of iterations> " .
-           "<benchmark param> <debug flag> <instrument flag>\n");
+        "<benchmark param>\n           <debug flag> [instrumentation dir] " .
+        "[key] [key pexec index]>\n\n");
+    fwrite(STDERR, "Arguments in [] are for instrumentation mode only.\n");
     exit(1);
+}
+
+if ($argc < 5) {
+    usage();
 }
 
 $BM_benchmark = $argv[1];
 $BM_iters = $argv[2];
 $BM_param = (int) $argv[3];
 $BM_debug = ((int) $argv[4]) > 0;
+$BM_instrument = $argc >= 6;
+
+if ($BM_instrument && ($argc != 8)) {
+    usage();
+}
 
 if (!file_exists($BM_benchmark)) {
     throw new RuntimeException("Can't find $BM_benchmark");

--- a/iterations_runners/iterations_runner.py
+++ b/iterations_runners/iterations_runner.py
@@ -37,12 +37,13 @@
 
 """
 Iterations runner for Python VMs.
-Derived from iterations_runner.php.
 
 Executes a benchmark many times within a single process.
 
-In Kalibera terms, this script represents one executions level run.
-"""
+usage: iterations_runner.py <benchmark> <# of iterations> <benchmark param>
+           <debug flag> [instrumentation dir] [key] [key pexec index]
+
+Arguments in [] are for instrumentation mode only."""
 
 import cffi, sys, imp, os
 
@@ -70,20 +71,25 @@ krun_get_core_cycles = libkruntime.krun_get_core_cycles
 krun_get_aperf = libkruntime.krun_get_aperf
 krun_get_mperf = libkruntime.krun_get_mperf
 
+def usage():
+    print(__doc__)
+    sys.exit(1)
+
 # main
 if __name__ == "__main__":
-    if len(sys.argv) != 6:
-        sys.stderr.write("usage: iterations_runner.py <benchmark> "
-                         "<# of iterations> <benchmark param> <debug flag> "
-                         "<instrument flag>\n")
-        sys.exit(1)
+    num_args = len(sys.argv)
+    if num_args < 5:
+        usage()
 
-    benchmark, iters, param, debug, instrument = sys.argv[1:]
-    iters, param, debug, instrument = \
-        int(iters), int(param), int(debug) == 1, int(instrument) == 1
+    benchmark, iters, param, debug = sys.argv[1:5]
+    iters, param, debug = int(iters), int(param), int(debug) == 1
+    instrument = num_args >= 6
+
+    if instrument and num_args != 8:
+        usage()
 
     if instrument:
-        import pypyjit # instrumentation not supported on CPython yet anyway
+        import pypyjit  # instrumentation not supported on CPython yet.
 
     assert benchmark.endswith(".py")
     bench_mod_name = os.path.basename(benchmark[:-3])

--- a/iterations_runners/iterations_runner.rb
+++ b/iterations_runners/iterations_runner.rb
@@ -55,19 +55,29 @@ else
     end
 end
 
+def usage()
+    STDERR.puts "usage: iterations_runner.rb <benchmark> "\
+        "<# of iterations> <benchmark param>\n           "\
+        "<debug flag> [instrumentation dir] [key] [key pexec index]>\n"
+    STDERR.puts "Arguments in [] are supplied for instrumentation mode only.\n"
+    Kernel.exit(1)
+end
+
 # main
 if __FILE__ == $0
-    if ARGV.length != 5
-        STDERR.puts "usage: iterations_runner.rb <benchmark> "\
-                    "<# of iterations> <benchmark param> <debug flag> "\
-                    "<instrument flag>\n"
-        Kernel.exit(1)
+    if ARGV.length < 4
+        usage()
     end
 
     benchmark, iters, param, debug = ARGV
     iters = Integer(iters)
     param = Integer(param)
     debug = Integer(debug) > 0
+    instrument = ARGV.length >= 5
+
+    if instrument and ARGV.length != 7 then
+        usage()
+    end
 
     require("#{benchmark}")
 

--- a/krun.py
+++ b/krun.py
@@ -284,6 +284,14 @@ def inner_main(mailer, on_first_invocation, config, args):
     platform.no_pstate_check = args.no_pstate_check
     platform.hardware_reboots = args.hardware_reboots
 
+    # Create the instrumentation directory if required
+    if on_first_invocation:
+        # We only want make a dir if >=1 VM is in instrumentation mode.
+        for vm in config.VMS.itervalues():
+            if vm['vm_def'].instrument:
+                util.make_instr_dir(config)
+                break
+
     debug("Checking platform preliminaries")
     platform.check_preliminaries()
 

--- a/krun/tests/test_manifest_manager.py
+++ b/krun/tests/test_manifest_manager.py
@@ -144,6 +144,24 @@ O dummy:CPython:default-python
 E nbody:CPython:default-python
 """
 
+THIRD_KEY_REP_EXAMPLE_MANIFEST = """eta_avail_idx=4
+num_mails_sent=0000
+num_reboots=00000000
+keys
+E dummy:Java:default-java
+C nbody:Java:default-java
+C dummy:CPython:default-python
+S nbody:CPython:default-python
+C dummy:Java:default-java
+S nbody:Java:default-java
+C dummy:CPython:default-python
+E nbody:CPython:default-python
+C dummy:Java:default-java
+S nbody:Java:default-java
+O dummy:CPython:default-python
+E nbody:CPython:default-python
+"""
+
 def _setup(contents):
     class FakeConfig(object):
         filename = os.path.join(TEST_DIR, "manifest_tests.krun")
@@ -539,3 +557,29 @@ def test_missing_header_manifest0001():
     with pytest.raises(AssertionError):
         manifest = _setup(MISSING_HEADER_EXAMPLE_MANIFEST)
     _tear_down(os.path.join("krun", "tests", "manifest_tests.manifest"))
+
+
+def test_next_exec_key_index0001():
+    manifest = _setup(BLANK_EXAMPLE_MANIFEST)
+    assert manifest.next_exec_key_index() == 0
+    _tear_down(manifest.path)
+
+
+def test_next_exec_key_index0002():
+    manifest = _setup(SKIPS_EXAMPLE_MANIFEST)
+    assert manifest.next_exec_key_index() == 0
+    _tear_down(manifest.path)
+
+
+def test_next_exec_key_index0003():
+    manifest = _setup(ERRORS_ALL_EXAMPLE_MANIFEST)
+    with pytest.raises(FatalKrunError) as e:
+        manifest.next_exec_key_index()
+    assert "Manifest ended unexpectedly" in str(e)
+    _tear_down(manifest.path)
+
+
+def test_next_exec_key_index0004():
+    manifest = _setup(THIRD_KEY_REP_EXAMPLE_MANIFEST)
+    assert manifest.next_exec_key_index() == 2
+    _tear_down(manifest.path)

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -39,7 +39,8 @@ from krun.util import (format_raw_exec_results, log_and_mail, fatal,
                        check_and_parse_execution_results, run_shell_cmd,
                        run_shell_cmd_bench, get_git_version, ExecutionFailed,
                        get_session_info, run_shell_cmd_list, FatalKrunError,
-                       stash_envlog, dump_instr_json, RerunExecution)
+                       stash_envlog, dump_instr_json, RerunExecution,
+                       make_instr_dir)
 from krun.tests.mocks import MockMailer
 from krun.tests import TEST_DIR
 from krun.config import Config
@@ -428,8 +429,9 @@ def test_stash_envlog0001(mock_platform):
 def test_dump_instr_json0001():
     path = os.path.join(TEST_DIR, "example.krun")
     config = Config(path)
-
     instr_data = {k: ord(k) for k in "abcdef"}
+
+    make_instr_dir(config)
     dump_instr_json("bench:vm:variant", 666, config, instr_data)
 
     dump_dir = os.path.join(TEST_DIR, "example_instr_data")

--- a/krun/tests/test_vmdef.py
+++ b/krun/tests/test_vmdef.py
@@ -125,7 +125,7 @@ class TestVMDef(BaseKrunTest):
             return "[1]", "", 0  # stdout, stderr, exit_code
         monkeypatch.setattr(vm_def, "_run_exec_popen", fake_run_exec_popen)
 
-        vm_def.run_exec(ep, "test", 1, 1, 1, 1)
+        vm_def.run_exec(ep, 1, 1, 1, 1, "test:dummyvm:default", 0)
         assert sync_called == [True]
 
     def test_sync_disks0002(self, monkeypatch):


### PR DESCRIPTION
DO NOT MERGE.

This is the beginning of a fix for #366 

We pass two extra flags to the iterations runners *only if* we are in instrumentation mode. Those flags are:

 * A benchmark key: e.g. `nbody:PyPy:default-python`.
 * The "key process execution exec index". 

The plumbing on this one hurt my head. We will need to run some more tests, probably using the warmup experiment.

Before I go and update all of the other iterations runners, is this what we want?