### PR TITLE
Make sure the libkruntime is always kept in the Lua iterations_runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
     - sudo apt-get install oracle-java8-installer
     - sudo apt-get install virt-what
     - sudo apt-get install pypy
+    - sudo apt-get install luajit
 
 install:
     - pip install -r requirements.txt

--- a/examples/benchmarks/fannkuch_redux/lua/bench.lua
+++ b/examples/benchmarks/fannkuch_redux/lua/bench.lua
@@ -1,0 +1,64 @@
+-- The Computer Language Benchmarks Game
+-- http://shootout.alioth.debian.org/
+-- contributed by Mike Pall
+
+local EXPECT_CKSUM = 1616
+local MAX_N = 8
+
+function run_iter(n)
+  for i=1,n do
+    inner_iter()
+  end
+end
+
+function inner_iter()
+  n = MAX_N
+  local p, q, s, sign, maxflips, sum = {}, {}, {}, 1, 0, 0
+  for i=1,n do p[i] = i; q[i] = i; s[i] = i end
+  repeat
+    -- Copy and flip.
+    local q1 = p[1]				-- Cache 1st element.
+    if q1 ~= 1 then
+      for i=2,n do q[i] = p[i] end		-- Work on a copy.
+      local flips = 1
+      repeat
+	local qq = q[q1]
+	if qq == 1 then				-- ... until 1st element is 1.
+	  sum = sum + sign*flips
+	  if flips > maxflips then maxflips = flips end -- New maximum?
+	  break
+	end
+	q[q1] = q1
+	if q1 >= 4 then
+	  local i, j = 2, q1 - 1
+	  repeat q[i], q[j] = q[j], q[i]; i = i + 1; j = j - 1; until i >= j
+	end
+	q1 = qq; flips = flips + 1
+      until false
+    end
+    -- Permute.
+    if sign == 1 then
+      p[2], p[1] = p[1], p[2]; sign = -1	-- Rotate 1<-2.
+    else
+      p[2], p[3] = p[3], p[2]; sign = 1		-- Rotate 1<-2 and 1<-2<-3.
+      for i=3,n do
+	local sx = s[i]
+	if sx ~= 1 then s[i] = sx-1; break end
+	if i == n then
+          if sum ~= EXPECT_CKSUM then
+            io.write("bad checksum: " .. sum .. " vs " .. EXPECT_CKSUM)
+            os.exit(1)
+          end
+          return sum, maxflips
+        end	-- Out of permutations.
+	s[i] = i
+	-- Rotate 1<-...<-i+1.
+	local t = p[1]; for j=1,i do p[j] = p[j+1] end; p[i+1] = t
+      end
+    end
+  until false
+end
+
+--local n = tonumber(arg and arg[1]) or 1
+--local sum, flips = fannkuch(n)
+--io.write(sum, "\nPfannkuchen(", n, ") = ", flips, "\n")

--- a/examples/benchmarks/nbody/lua/bench.lua
+++ b/examples/benchmarks/nbody/lua/bench.lua
@@ -1,0 +1,143 @@
+-- The Computer Language Benchmarks Game
+-- http://shootout.alioth.debian.org/
+-- contributed by Mike Pall
+-- modified by Geoff Leyland
+-- modified by Mario Pernici
+
+sun = {}
+jupiter = {}
+saturn = {}
+uranus = {}
+neptune = {}
+
+local EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625
+local N_ADVANCES = 100000
+local EPSILON = 0.0000000000001
+
+local sqrt = math.sqrt
+
+local PI = 3.141592653589793
+local SOLAR_MASS = 4 * PI * PI
+local DAYS_PER_YEAR = 365.24
+
+function setup_state()
+  -- defines global variables, that get mutated.
+  sun.x = 0.0
+  sun.y = 0.0
+  sun.z = 0.0
+  sun.vx = 0.0
+  sun.vy = 0.0
+  sun.vz = 0.0
+  sun.mass = SOLAR_MASS
+  jupiter.x = 4.84143144246472090e+00
+  jupiter.y = -1.16032004402742839e+00
+  jupiter.z = -1.03622044471123109e-01
+  jupiter.vx = 1.66007664274403694e-03 * DAYS_PER_YEAR
+  jupiter.vy = 7.69901118419740425e-03 * DAYS_PER_YEAR
+  jupiter.vz = -6.90460016972063023e-05 * DAYS_PER_YEAR
+  jupiter.mass = 9.54791938424326609e-04 * SOLAR_MASS
+  saturn.x = 8.34336671824457987e+00
+  saturn.y = 4.12479856412430479e+00
+  saturn.z = -4.03523417114321381e-01
+  saturn.vx = -2.76742510726862411e-03 * DAYS_PER_YEAR
+  saturn.vy = 4.99852801234917238e-03 * DAYS_PER_YEAR
+  saturn.vz = 2.30417297573763929e-05 * DAYS_PER_YEAR
+  saturn.mass = 2.85885980666130812e-04 * SOLAR_MASS
+  uranus.x = 1.28943695621391310e+01
+  uranus.y = -1.51111514016986312e+01
+  uranus.z = -2.23307578892655734e-01
+  uranus.vx = 2.96460137564761618e-03 * DAYS_PER_YEAR
+  uranus.vy = 2.37847173959480950e-03 * DAYS_PER_YEAR
+  uranus.vz = -2.96589568540237556e-05 * DAYS_PER_YEAR
+  uranus.mass = 4.36624404335156298e-05 * SOLAR_MASS
+  neptune.x = 1.53796971148509165e+01
+  neptune.y = -2.59193146099879641e+01
+  neptune.z = 1.79258772950371181e-01
+  neptune.vx = 2.68067772490389322e-03 * DAYS_PER_YEAR
+  neptune.vy = 1.62824170038242295e-03 * DAYS_PER_YEAR
+  neptune.vz = -9.51592254519715870e-05 * DAYS_PER_YEAR
+  neptune.mass = 5.15138902046611451e-05 * SOLAR_MASS
+
+  bodies = {sun,jupiter,saturn,uranus,neptune}
+end
+
+local function advance(bodies, nbody, dt)
+  for i=1,nbody do
+    local bi = bodies[i]
+    local bix, biy, biz, bimass = bi.x, bi.y, bi.z, bi.mass
+    local bivx, bivy, bivz = bi.vx, bi.vy, bi.vz
+    for j=i+1,nbody do
+      local bj = bodies[j]
+      local dx, dy, dz = bix-bj.x, biy-bj.y, biz-bj.z
+      local dist2 = dx*dx + dy*dy + dz*dz
+      local mag = sqrt(dist2)
+      mag = dt / (mag * dist2)
+      local bm = bj.mass*mag
+      bivx = bivx - (dx * bm)
+      bivy = bivy - (dy * bm)
+      bivz = bivz - (dz * bm)
+      bm = bimass*mag
+      bj.vx = bj.vx + (dx * bm)
+      bj.vy = bj.vy + (dy * bm)
+      bj.vz = bj.vz + (dz * bm)
+    end
+    bi.vx = bivx
+    bi.vy = bivy
+    bi.vz = bivz
+    bi.x = bix + dt * bivx
+    bi.y = biy + dt * bivy
+    bi.z = biz + dt * bivz
+  end
+end
+
+local function energy(bodies, nbody)
+  local e = 0
+  for i=1,nbody do
+    local bi = bodies[i]
+    local vx, vy, vz, bim = bi.vx, bi.vy, bi.vz, bi.mass
+    e = e + (0.5 * bim * (vx*vx + vy*vy + vz*vz))
+    for j=i+1,nbody do
+      local bj = bodies[j]
+      local dx, dy, dz = bi.x-bj.x, bi.y-bj.y, bi.z-bj.z
+      local distance = sqrt(dx*dx + dy*dy + dz*dz)
+      e = e - ((bim * bj.mass) / distance)
+    end
+  end
+  return e
+end
+
+local function offsetMomentum(b, nbody)
+  local px, py, pz = 0, 0, 0
+  for i=1,nbody do
+    local bi = b[i]
+    local bim = bi.mass
+    px = px + (bi.vx * bim)
+    py = py + (bi.vy * bim)
+    pz = pz + (bi.vz * bim)
+  end
+  b[1].vx = -px / SOLAR_MASS
+  b[1].vy = -py / SOLAR_MASS
+  b[1].vz = -pz / SOLAR_MASS
+end
+
+local function inner_iter(N)
+  local checksum = 0
+  setup_state()
+  local nbody = #bodies
+
+  offsetMomentum(bodies, nbody)
+  checksum = checksum + energy(bodies, nbody)
+  for i=1,N do advance(bodies, nbody, 0.01) end
+  checksum = checksum + energy(bodies, nbody)
+
+  if math.abs(checksum - EXPECT_CHECKSUM) >= EPSILON then
+    print("bad checksum: " .. checksum .. " vs " .. EXPECT_CHECKSUM)
+    os.exit(1)
+  end
+end
+
+function run_iter(n)
+  for i=1, n do
+    inner_iter(N_ADVANCES)
+  end
+end

--- a/examples/example.krun
+++ b/examples/example.krun
@@ -1,5 +1,5 @@
 import os
-from krun.vm_defs import (PyPyVMDef, NativeCodeVMDef)
+from krun.vm_defs import (PyPyVMDef, LuaVMDef, NativeCodeVMDef)
 from krun import EntryPoint
 from krun.util import fatal
 from distutils.spawn import find_executable
@@ -8,6 +8,10 @@ from distutils.spawn import find_executable
 PYPY_BIN = find_executable("pypy")
 if PYPY_BIN is None:
     fatal("pypy binary not found in path")
+
+LUAJIT_BIN  = find_executable("luajit")
+if LUAJIT_BIN is None:
+    fatal("luajit binary not found in path")
 
 # Who to mail
 MAIL_TO = []
@@ -25,6 +29,7 @@ STACK_LIMIT = 8192  # KiB
 VARIANTS = {
     "default-c": EntryPoint("bench.so", subdir="c"),
     "default-python": EntryPoint("bench.py", subdir="python"),
+    "default-lua": EntryPoint("bench.lua", subdir="lua"),
 }
 
 ITERATIONS_ALL_VMS = 5  # Small number for testing.
@@ -39,7 +44,12 @@ VMS = {
         'vm_def': PyPyVMDef(PYPY_BIN),
         'variants': ['default-python'],
         'n_iterations': ITERATIONS_ALL_VMS,
-    }
+    },
+    'LuaJIT': {
+        'vm_def': LuaVMDef(LUAJIT_BIN),
+        'variants': ['default-lua'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
 }
 
 
@@ -52,6 +62,7 @@ BENCHMARKS = {
 SKIP = [
     #"*:C:*",
     #"*:PyPy:*",
+    #"*:LuaJIT:*",
 ]
 
 N_EXECUTIONS = 2  # Number of fresh processes.

--- a/iterations_runners/iterations_runner.lua
+++ b/iterations_runners/iterations_runner.lua
@@ -79,7 +79,6 @@ ffi.cdef[[
 local libkruntime = ffi.load("kruntime")
 
 local krun_init = libkruntime.krun_init
-local krun_done = libkruntime.krun_done
 local krun_measure = libkruntime.krun_measure
 local krun_get_num_cores = libkruntime.krun_get_num_cores
 local krun_get_wallclock = libkruntime.krun_get_wallclock
@@ -164,7 +163,11 @@ for BM_i = 1, BM_iters, 1 do
     end
 end
 
-krun_done()
+-- In LuaJIT, FFI functions are cdata values that are unable to reference any other object owned by
+-- the garbage collector. Calling an FFI function which has been cached on the stack (as we've done above) 
+-- might fail because the parent FFI clib object may have been GC'd . By explicitly accessing krun_done via libkruntime
+-- here we guarantee libkruntime to live until this point.
+libkruntime.krun_done()
 
 io.stdout:write("{")
 


### PR DESCRIPTION
 I changed the call to krun_done in the Lua to use a direct reference to libkruntime to make sure it is always kept alive until the end of the benchmark. I also changed the call to krun_init the same way for consistency and since it is only called once.