### PR TITLE
Pick up and use the macros from krun_linux_kernel 4.9.88 branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ If you are unable to do this, you can set `NO_MSRS=1` in your Unix environment
 when building Krun (see later), but be aware that this degrades the quality of
 the resulting benchmarking numbers.
 
+Krun works on any version of the kernel if NO_MSRS=1 is set. If a suitable
+version of the Krun custom kernel (>= 4.9.88) is used, the MSRs are also
+available.
 
 ## Step 3: Fetch and build Krun
 


### PR DESCRIPTION
Changes in light of the new `<krun-syscall.h>` header recently merged into the Krun Linux kernel.

Looks good?