### PR TITLE
Make clear CPU shield command non fatal

### DIFF
--- a/krun/platform.py
+++ b/krun/platform.py
@@ -946,7 +946,7 @@ class LinuxPlatform(UnixLikePlatform):
     def clear_cpu_pinning(self):
         debug("Clearing cpuset")
         args = self.change_user_args() + [LinuxPlatform.CSET_CMD, "shield", "-r"]
-        out, _, _ = run_shell_cmd(" ".join(args))
+        out, _, _ = run_shell_cmd(" ".join(args), failure_fatal=False)
         debug(out)
 
     # separate for testing


### PR DESCRIPTION
Make the command run from clear_cpu_pinning is considered non-fatal since its always used at startup to make sure there are no existing cpu shields set. The command was returning a non zero result when there is no cpu shield is set.