### PR TITLE
Use typed arrays in Javascript runner.

### DIFF
--- a/iterations_runners/iterations_runner.js
+++ b/iterations_runners/iterations_runner.js
@@ -91,22 +91,23 @@ load(BM_entry_point);
 krun_init();
 var BM_num_cores = krun_get_num_cores();
 
-// Pre-allocate and fill arrays
-var BM_wallclock_times = new Array(BM_n_iters);
-BM_wallclock_times.fill(0);
+// Pre-allocate and fill arrays.
+// We use typed arrays to encourage type stability.
+var BM_wallclock_times = new Float64Array(BM_n_iters);
+BM_wallclock_times.fill(NaN);
 
 var BM_cycle_counts = new Array(BM_num_cores);
 var BM_aperf_counts = new Array(BM_num_cores);
 var BM_mperf_counts = new Array(BM_num_cores);
 
 for (BM_core = 0; BM_core < BM_num_cores; BM_core++) {
-    BM_cycle_counts[BM_core] = new Array(BM_n_iters);
-    BM_aperf_counts[BM_core] = new Array(BM_n_iters);
-    BM_mperf_counts[BM_core] = new Array(BM_n_iters);
+    BM_cycle_counts[BM_core] = new Float64Array(BM_n_iters);
+    BM_aperf_counts[BM_core] = new Float64Array(BM_n_iters);
+    BM_mperf_counts[BM_core] = new Float64Array(BM_n_iters);
 
-    BM_cycle_counts[BM_core].fill(0);
-    BM_aperf_counts[BM_core].fill(0);
-    BM_mperf_counts[BM_core].fill(0);
+    BM_cycle_counts[BM_core].fill(NaN);
+    BM_aperf_counts[BM_core].fill(NaN);
+    BM_mperf_counts[BM_core].fill(NaN);
 }
 
 // Main loop


### PR DESCRIPTION
Ah ha! We can actually used typed arrays in JavaScript since there is a `Float64Array`. I've checked that both V8 and spidermonkey (only the former of which is part of the main experiment) support this, and they do.

Tested using the warmup experiment running only V8 (we don't have an iterations running for spidermonkey).

Info about `Float64Array` here:
https://blog.codingbox.io/exploring-javascript-typed-arrays-c8fd4f8bd24f

OK?

Fixes #382 