### PR TITLE
Check over-commit is totally off when running on Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ than one leads to undefined behaviour).
  * Detect virtualised hosts.
  * Unrestrict the dmesg buffer (Linux Kernel 4.8+)
  * Turn off "turbo boost" (Linux only)
+ * Turn off memory over-commit (Linux only).
 
 Please make sure you understand the implications of this.
 


### PR DESCRIPTION
Query the over-commit policy and set it to 2 if it is not already 2.

Tested on Debian 9 under VMM.

OK?

Fixes #385 