### PR TITLE
Add an ExternalScriptVMDef and an example.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 
 language: python
+python: 2.7
 
 before_install:
     - sudo apt-get update -qq

--- a/README.md
+++ b/README.md
@@ -272,23 +272,36 @@ Each benchmark should expose a function (or method) called `run_iter` which is
 the entry point to the benchmark. To preserve source code history, it can
 be easiest to put this function in a new file, which then imports the benchmark.
 
-New VMs require some support in Krun. The following VMs are currently supported
-out of the box:
+With regards to VM/compiler support, there are two ways Krun can invoke a
+benchmark:
 
-  * OpenJDK (i.e. Hotspot)
-  * GraalVM
-  * cPython
-  * Lua
-  * PHP
-  * Ruby
-  * TruffleRuby
-  * Javascript V8
+  * Via a dedicated "VM definition" (e.g. `JavaVMDef`).
+  * Via an external benchmark suite (`ExternalSuiteVMDef`).
 
-To add a new VM definition, add a new class to `krun/vm_defs.py` and a
-new iteration runner to the `iterations_runners` directory.
+The former option is best, as it supports Krun's core-cycle counting and
+APERF/MPERF ratio features. The following compilers/VMs are currently supported
+for this mode:
+
+  * Native code languages (`NativeCodeVMDef`).
+  * OpenJDK. (i.e. Hotspot) (`JavaVMDef`).
+  * GraalVM (`GraalVMDef`).
+  * cPython (`PythonVMDef`).
+  * Lua (`LuaVMDef`).
+  * PHP (`PHPVMDef`).
+  * Ruby (`RubyVMDef`).
+  * TruffleRuby (`TruffleRubyVMDef`).
+  * Javascript V8 (`V8VMDef`).
+
+If your VM isn't listed, you can either add it to Krun, or use the external
+suite definition (see below). To add a new VM definition, add a new class to
+`krun/vm_defs.py` and a new iteration runner to the `iterations_runners`
+directory.
+
+The latter option -- `ExternalSuiteVMDef` -- is useful if you want to quickly
+wrap an existing benchmark suite. For an example see `examples/ext.krun` and
+`examples/ext_script.py`.
 
 To add a new platform definition, add a new class to `krun/platform.py`.
-
 
 ## Testing your configurations
 

--- a/examples/ext.krun
+++ b/examples/ext.krun
@@ -1,0 +1,58 @@
+import os
+from krun.vm_defs import ExternalSuiteVMDef
+
+# Who to mail
+MAIL_TO = []
+
+# Maximum number of error emails to send per-run
+#MAX_MAILS = 2
+
+DIR = os.getcwd()
+
+HEAP_LIMIT = 2097152  # KiB
+STACK_LIMIT = 8192  # KiB
+
+# Variant name -> EntryPoint
+VARIANTS = {
+    # Normally you'd have an EntryPoint on the right-hand side, but there's no
+    # such notion for the ExternalSuiteVMDef. Just pass None.
+    "default-ext": None,
+}
+
+ITERATIONS_ALL_VMS = 5  # Small number for testing.
+
+VMS = {
+    'Ext': {
+        'vm_def': ExternalSuiteVMDef(os.path.join(DIR, "ext_script.py")),
+        'variants': ['default-ext'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+}
+
+BENCHMARKS = {
+    'fannkuch_redux': 100,
+    'nbody': 15,
+}
+
+# list of "bench:vm:variant"
+SKIP = []
+
+N_EXECUTIONS = 2  # Number of fresh processes.
+
+# No. of seconds to wait before taking the initial temperature reading.
+# You should set this high enough for the system to cool down a bit.
+# The default (if omitted) is 60 seconds.
+TEMP_READ_PAUSE = 1
+
+# Commands to run before and after each process execution
+#
+# Environment available for these commands:
+#   KRUN_RESULTS_FILE: path to results file.
+#   KRUN_LOG_FILE: path to log file.
+#   KRUN_ETA_DATUM: time the ETA was computed
+#   KRUN_ETA_VALUE: estimated time of completion
+#PRE_EXECUTION_CMDS = ["sudo service cron stop"]
+#POST_EXECUTION_CMDS = ["sudo service cron start"]
+
+# CPU pinning (off by default)
+#ENABLE_PINNING = False

--- a/examples/ext_script.py
+++ b/examples/ext_script.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python2.7
+# A dummy external script, demonstrating how the ExternalSuiteVMDef works.
+#
+# This script is called once for each process execution.
+
+import sys
+import json
+
+_, benchmark, iters, param, instr = sys.argv
+iters = int(iters)
+
+# <INSERT INVOCATION OF PROCESS EXECUTION HERE>
+
+# Then emit your results to stdout in the following format:
+js = {
+    "wallclock_times": list(range(iters)),  # dummy results.
+    # ExternalSuiteVMDef doesn't support the following fields.
+    "core_cycle_counts": [],
+    "aperf_counts": [],
+    "mperf_counts": [],
+}
+
+sys.stdout.write("%s\n" % json.dumps(js))

--- a/krun/vm_defs.py
+++ b/krun/vm_defs.py
@@ -321,6 +321,29 @@ class BaseVMDef(object):
             return self.parse_instr_stderr_file(fh)
 
 
+class ExternalSuiteVMDef(BaseVMDef):
+    """Not really a "VM definition". This runs an arbitrary script which is
+    expected to run one process execution and write the results to stdout. This
+    is useful if you want to wrap an external benchmark suite, but note that
+    you won't get any of the advanced Krun goodies like A/MPERF ratio checks or
+    core-cycle counts."""
+
+    def __init__(self, script_path, env=None):
+        BaseVMDef.__init__(self, None, env=env, instrument=False)
+        self.script_path = script_path
+
+    def run_exec(self, _entry_point, iterations, param, heap_lim_k,
+                 stack_lim_k, key, key_pexec_idx, force_dir=None, sync_disks=True):
+        benchmark = key.split(":")[0]
+        args = [self.script_path, benchmark, str(iterations), str(param)]
+        return self._run_exec(args, heap_lim_k, stack_lim_k, key,
+                              key_pexec_idx, sync_disks=sync_disks)
+
+    def check_benchmark_files(self, _benchmark, _entry_point):
+        if not os.path.exists(self.script_path):
+            fatal("External script non-existent: %s" % self.script_path)
+
+
 class NativeCodeVMDef(BaseVMDef):
     """Not really a "VM definition" at all. Runs native code."""
 


### PR DESCRIPTION
Here's a first stab at a VM def for an external suite.

We can only wrap suites which we can control at the process execution level, as we need to reboot between process executions. Looking at your renaissance work, I think that's OK.

For now, the example just runs a dummy script and produces dummy results.

Is this about what you expected, before I try to actually run the renaissance benchmarks.