### PR TITLE
Check throttle flags in Linux sysfs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python: 2.7
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install linux-libc-dev libc6-dev
-    - sudo apt-get install oracle-java8-installer
+    - sudo apt-get install default-jdk
     - sudo apt-get install virt-what
     - sudo apt-get install pypy
     - sudo apt-get install luajit
@@ -17,7 +17,6 @@ install:
 
 script:
     - sudo update-java-alternatives -l || true  # returns 1 on success!
-    - sudo update-java-alternatives -s `sudo update-java-alternatives -l | grep 8-oracle | awk '{print $1}'`
     - uname -a
     - make --version
     - ldd --version

--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -404,6 +404,9 @@ class ExecutionJob(object):
         stack_limit_kb = self.sched.config.STACK_LIMIT
         in_proc_iters = self.vm_info["n_iterations"]
 
+        if not dry_run:
+            self.sched.platform.collect_starting_throttle_counts()
+
         stdout, stderr, rc, envlog_filename = \
             vm_def.run_exec(entry_point, in_proc_iters, self.parameter,
                             heap_limit_kb, stack_limit_kb, self.key,
@@ -411,6 +414,7 @@ class ExecutionJob(object):
 
         if not dry_run:
             try:
+                self.sched.platform.check_throttle_counts(self.sched.manifest)
                 measurements = util.check_and_parse_execution_results(
                     stdout, stderr, rc, self.sched.config, instrument=vm_def.instrument)
                 flag = "C"

--- a/krun/tests/mocks.py
+++ b/krun/tests/mocks.py
@@ -146,6 +146,9 @@ class MockPlatform(BasePlatform):
     def get_num_temperature_sensors(self):
         return 1
 
+    def _read_throttle_counts(self):
+        return {}
+
 
 @pytest.fixture
 def mock_platform():


### PR DESCRIPTION
This change makes Krun check the throttle flags we've been discussing.

I've based my change on the way we check dmesg changes. i.e. if something looks wrong, we mail out and log a warning, and continue. We do not retry the process execution, nor do we mark the process execution an error.

Does that sound right? Arguably, we could retry the execution, as we do with A/MPERF problems. Not sure.

Here's an example log snippet showing what you'd get in case the counters increment:
```
[2019-06-11 16:18:09: WARNING] Throttle counts changed!

- /sys/devices/system/cpu/cpu7/thermal_throttle/package_throttle_count = 0
+ /sys/devices/system/cpu/cpu7/thermal_throttle/package_throttle_count = 4
```

You'd get a similar email also.