### PR TITLE
Tickless fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Krun works on any version of the kernel if NO_MSRS=1 is set. If a suitable
 version of the Krun custom kernel (>= 4.9.88) is used, the MSRs are also
 available.
 
+### Tickless Kernel
+
+Unless `--no-tickless-check` is passed to Krun, all cores but the boot core
+are  expected to be in full adaptive ticks mode (tickless mode).
+
+On older kernels which still have the `CONFIG_NO_HZ_FULL_ALL` config option,
+build the kernel with this set to "y".
+
+On newer kernels, where `CONFIG_NO_HZ_FULL_ALL` is absent, you will have to add
+a `nohz_full=1-N` kernel command line option (where N is the number of cores
+your system has, minus one).
+
+If your system has only one core then tickless mode is not checked, as the boot
+core (i.e. your only core) cannot be placed into adaptive ticks mode.
+
 ## Step 3: Fetch and build Krun
 
 First fetch Krun:

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -1,5 +1,6 @@
 import pytest
 import krun.platform
+from distutils.spawn import find_executable
 from krun.platform import LinuxPlatform
 from krun.tests import BaseKrunTest, subst_env_arg
 from krun.util import FatalKrunError, run_shell_cmd
@@ -7,6 +8,8 @@ from krun.vm_defs import  PythonVMDef
 from krun.tests.mocks import mock_manifest
 import sys
 from StringIO import StringIO
+
+DASH = find_executable("dash")
 
 
 def mk_dummy_kernel_config_fn(options_dct):
@@ -182,7 +185,7 @@ class TestLinuxPlatform(BaseKrunTest):
         wrapper_filename = "abcdefg.dash"
         got = vm_def._wrapper_args(wrapper_filename)
         expect = ['/usr/bin/sudo', '-u', 'root', '/usr/bin/nice', '-n', '-20',
-                  '/usr/bin/sudo', '-u', 'krun', '/bin/dash', wrapper_filename]
+                  '/usr/bin/sudo', '-u', 'krun', DASH, wrapper_filename]
         assert got == expect
 
     def test_wrapper_args0002(self, platform):
@@ -193,7 +196,7 @@ class TestLinuxPlatform(BaseKrunTest):
         wrapper_filename = "abcdefg.dash"
         got = vm_def._wrapper_args(wrapper_filename)
         expect = ['/usr/bin/sudo', '-u', 'root', '/usr/bin/nice', '-n', '-20',
-                  '/usr/bin/sudo', '-u', 'krun', '/bin/dash', wrapper_filename]
+                  '/usr/bin/sudo', '-u', 'krun', DASH, wrapper_filename]
         assert got == expect
 
     def test_take_temperature_readings0001(self, platform):


### PR DESCRIPTION
The first commit message should help to explain the need for this change.

The second commit is just test housekeeping. Also note that the test suite explodes badly using newer py.test versions. I had to install the old versions listed in `requirements.txt`.