### PR TITLE
Refurbish test suite

### DIFF
--- a/krun/tests/test_config.py
+++ b/krun/tests/test_config.py
@@ -62,8 +62,7 @@ def test_check_config_consistency_fails():
     with pytest.raises(Exception) as excinfo:
         config.check_config_consistency(config_string + "\n# different config!",
                                         "fakefilename")
-    print excinfo.value.message
-    assert "+# different config!" in excinfo.value.message
+    assert "+# different config!" in excinfo.value.args[0]
 
 @pytest.mark.skipif(JAVA is None, reason="No Java found")
 def test_config_init():
@@ -165,7 +164,7 @@ def test_skip0007():
     with pytest.raises(ValueError) as e:
         config.should_skip("wobble")
 
-    assert e.value.message == "bad benchmark key: wobble"
+    assert e.value.args[0] == "bad benchmark key: wobble"
 
 def test_skip0008():
     config = Config()

--- a/krun/tests/test_env.py
+++ b/krun/tests/test_env.py
@@ -11,7 +11,7 @@ def test_env_change_set(monkeypatch, caplog):
     assert env.val == 1685
     with pytest.raises(FatalKrunError):
         env.apply({"bach": 1695})
-    assert "Environment bach is already defined" in caplog.text()
+    assert "Environment bach is already defined" in caplog.text
 
 
 def test_env_change_set_apply():

--- a/krun/tests/test_genericplatform.py
+++ b/krun/tests/test_genericplatform.py
@@ -37,7 +37,7 @@ class TestGenericPlatform(BaseKrunTest):
 
         expect = ("Temperature timeout: Temperature reading 'x' not "
                   "within interval: (27 <= 999 <= 33)")
-        assert expect in caplog.text()
+        assert expect in caplog.text
 
     def test_temperature_thresholds0003(self, mock_platform, monkeypatch, caplog):
         temps = {"x": 30.0}
@@ -54,7 +54,7 @@ class TestGenericPlatform(BaseKrunTest):
 
         expect = ("Temperature timeout: Temperature reading 'x' not "
                   "within interval: (27 <= -999 <= 33)")
-        assert expect in caplog.text()
+        assert expect in caplog.text
 
     def test_temperature_thresholds0004(self, mock_platform, monkeypatch, caplog):
         temps = {"x": 30.0}
@@ -109,7 +109,7 @@ class TestGenericPlatform(BaseKrunTest):
             platform.take_temperature_readings()
 
         expect = "Failed to read sensor"
-        assert expect in caplog.text()
+        assert expect in caplog.text
 
 
     def test_inconsistent_sensors0002(self, platform, caplog):
@@ -119,7 +119,7 @@ class TestGenericPlatform(BaseKrunTest):
             platform.starting_temperatures = {"a": 1000, "b": 2000}
 
         expect = "Inconsistent sensors. ['a', 'b'] vs ['different', 'sensors']"
-        assert expect in caplog.text()
+        assert expect in caplog.text
 
     def test_inconsistent_sensors0003(self, platform, caplog):
         platform.temp_sensors = ["a"]
@@ -128,7 +128,7 @@ class TestGenericPlatform(BaseKrunTest):
             platform.starting_temperatures = {"a": 1000, "b": 2000}
 
         expect = "Inconsistent sensors. ['a', 'b'] vs ['a']"
-        assert expect in caplog.text()
+        assert expect in caplog.text
 
     def test_dmesg_filter0001(self, mock_platform, caplog, mock_manifest):
         last_dmesg = ["line1", "line2"]
@@ -139,8 +139,8 @@ class TestGenericPlatform(BaseKrunTest):
             [], last_dmesg, new_dmesg, mock_manifest)
 
         # and the log will indicate this also
-        assert "New dmesg lines" in caplog.text()
-        assert "\nline3" in caplog.text()
+        assert "New dmesg lines" in caplog.text
+        assert "\nline3" in caplog.text
 
     def test_dmesg_filter0002(self, mock_platform, caplog, mock_manifest):
         last_dmesg = ["line1", "line2"]
@@ -169,9 +169,9 @@ class TestGenericPlatform(BaseKrunTest):
         # line5 is a problem
         assert mock_platform._check_dmesg_for_changes(
             [], last_dmesg, new_dmesg, mock_manifest)
-        assert "\nline5\n" in caplog.text()
+        assert "\nline5\n" in caplog.text
         for num in xrange(1, 5):
-            assert not ("\nline%s\n" % num) in caplog.text()
+            assert not ("\nline%s\n" % num) in caplog.text
 
     def test_dmesg_filter0005(self, mock_platform, caplog, mock_manifest):
         # simulate 2 lines falling off the top of the dmesg buffer, *and* a

--- a/krun/tests/test_linuxplatform.py
+++ b/krun/tests/test_linuxplatform.py
@@ -1,10 +1,11 @@
 import pytest
+import logging
 import krun.platform
 from distutils.spawn import find_executable
 from krun.platform import LinuxPlatform
 from krun.tests import BaseKrunTest, subst_env_arg
 from krun.util import FatalKrunError, run_shell_cmd
-from krun.vm_defs import  PythonVMDef
+from krun.vm_defs import PythonVMDef
 from krun.tests.mocks import mock_manifest
 import sys
 from StringIO import StringIO
@@ -132,7 +133,7 @@ class TestLinuxPlatform(BaseKrunTest):
             krun.platform.LinuxPlatform._check_tickless_kernel(platform)
 
         assert "CONFIG_NO_HZ_FULL_ALL overridden on kernel command line" \
-            in caplog.text()
+            in caplog.text
 
     def test_bench_cmdline_adjust0001(self, platform):
         expect = ['env', 'LD_LIBRARY_PATH=']
@@ -282,6 +283,8 @@ class TestLinuxPlatform(BaseKrunTest):
         monkeypatch.setattr(krun.platform.LinuxPlatform,
                             "_collect_temperature_sensor_globs",
                             fake_collect_temperature_sensor_globs)
+
+        caplog.set_level(logging.DEBUG)
         platform = krun.platform.detect_platform(None, None)
         assert platform.temp_sensor_map == {
             'coretemp:5:temp4_input': '/sys/class/hwmon/hwmon0/temp4_input',
@@ -291,7 +294,7 @@ class TestLinuxPlatform(BaseKrunTest):
             '__krun_unknown_chip_name:1:temp1_input':
                 '/sys/class/hwmon/hwmon1/temp1_input',
             'coretemp:5:temp5_input': '/sys/class/hwmon/hwmon0/temp5_input'}
-        assert "Un-named temperature sensor chip found" in caplog.text()
+        assert "Un-named temperature sensor chip found" in caplog.text
 
     def test_find_temperature_sensors0003(self, monkeypatch, caplog):
         """Test two un-named chips with the same number of sensors"""
@@ -312,6 +315,8 @@ class TestLinuxPlatform(BaseKrunTest):
         monkeypatch.setattr(krun.platform.LinuxPlatform,
                             "_collect_temperature_sensor_globs",
                             fake_collect_temperature_sensor_globs)
+
+        caplog.set_level(logging.DEBUG)
         platform = krun.platform.detect_platform(None, None)
         # The duplicate chips should be ignored
         assert platform.temp_sensor_map == {
@@ -321,7 +326,7 @@ class TestLinuxPlatform(BaseKrunTest):
             'coretemp:5:temp2_input': '/sys/class/hwmon/hwmon0/temp2_input',
             'coretemp:5:temp1_input': '/sys/class/hwmon/hwmon0/temp1_input'
         }
-        log = caplog.text()
+        log = caplog.text
         assert "Un-named temperature sensor chip found" in log
         assert ("Found duplicate chips named '%s' with 1 temperature sensor(s)"
                 % LinuxPlatform.UNKNOWN_SENSOR_CHIP_NAME) in log
@@ -347,6 +352,8 @@ class TestLinuxPlatform(BaseKrunTest):
         monkeypatch.setattr(krun.platform.LinuxPlatform,
                             "_collect_temperature_sensor_globs",
                             fake_collect_temperature_sensor_globs)
+
+        caplog.set_level(logging.DEBUG)
         platform = krun.platform.detect_platform(None, None)
         # The duplicate chips should be ignored
         assert platform.temp_sensor_map == {
@@ -356,7 +363,7 @@ class TestLinuxPlatform(BaseKrunTest):
             'coretemp:5:temp2_input': '/sys/class/hwmon/hwmon0/temp2_input',
             'coretemp:5:temp1_input': '/sys/class/hwmon/hwmon0/temp1_input'
         }
-        log = caplog.text()
+        log = caplog.text
         assert "Un-named temperature sensor chip found" in log
         assert ("Found duplicate chips named '%s' with 1 temperature sensor(s)"
                 % LinuxPlatform.UNKNOWN_SENSOR_CHIP_NAME) in log
@@ -380,6 +387,8 @@ class TestLinuxPlatform(BaseKrunTest):
         monkeypatch.setattr(krun.platform.LinuxPlatform,
                             "_collect_temperature_sensor_globs",
                             fake_collect_temperature_sensor_globs)
+
+        caplog.set_level(logging.DEBUG)
         platform = krun.platform.detect_platform(None, None)
         assert platform.temp_sensor_map == {
             # First un-named chip
@@ -391,7 +400,7 @@ class TestLinuxPlatform(BaseKrunTest):
             '%s:2:temp2_input' % LinuxPlatform.UNKNOWN_SENSOR_CHIP_NAME:
                 '/sys/class/hwmon/hwmon1/temp2_input',
         }
-        log = caplog.text()
+        log = caplog.text
         assert "Un-named temperature sensor chip found" in log
 
     def test_isolcpus0001(self, platform, monkeypatch, caplog):
@@ -406,7 +415,7 @@ class TestLinuxPlatform(BaseKrunTest):
             platform._check_isolcpus()
 
         find = "isolcpus should not be in the kernel command line"
-        assert find in caplog.text()
+        assert find in caplog.text
 
     def test_is_virtual0001(self, platform):
         """check that virtualisation check doesn't crash"""
@@ -439,6 +448,8 @@ class TestLinuxPlatform(BaseKrunTest):
             platform.get_dmesg_whitelist(), old_lines, new_lines, mock_manifest)
 
     def test_aslr0001(self, platform, caplog):
+        caplog.set_level(logging.DEBUG)
+
         # get current ASLR value
         with open(LinuxPlatform.ASLR_FILE, "r") as fh:
             old_val = fh.read().strip()
@@ -453,7 +464,7 @@ class TestLinuxPlatform(BaseKrunTest):
         with open(LinuxPlatform.ASLR_FILE, "r") as fh:
             new_val = fh.read().strip()
         assert new_val == '2'
-        assert "Adjust ASLR" in caplog.text()
+        assert "Adjust ASLR" in caplog.text
 
         # Restore old value
         cmd = "%s sh -c 'echo %s > %s'" % \

--- a/krun/tests/test_openbsdplatform.py
+++ b/krun/tests/test_openbsdplatform.py
@@ -68,7 +68,7 @@ class TestOpenBSDPlatform(BaseKrunTest):
         with pytest.raises(FatalKrunError):
             platform.take_temperature_readings()
 
-        assert "Odd non-degC value" in caplog.text()
+        assert "Odd non-degC value" in caplog.text
 
     def test_read_broken_temperatures0002(self, monkeypatch, platform, caplog):
         platform.temp_sensors = ["hw.sensors.some_temp0"]
@@ -83,7 +83,7 @@ class TestOpenBSDPlatform(BaseKrunTest):
         with pytest.raises(FatalKrunError):
             platform.take_temperature_readings()
 
-        assert "Non-numeric value" in caplog.text()
+        assert "Non-numeric value" in caplog.text
 
     def test_read_broken_temperatures0003(self, monkeypatch, platform, caplog):
         platform.temp_sensors = ["hw.sensors.some_temp0"]
@@ -98,19 +98,19 @@ class TestOpenBSDPlatform(BaseKrunTest):
         with pytest.raises(FatalKrunError):
             platform.take_temperature_readings()
 
-        assert "Odd non-degC value" in caplog.text()
+        assert "Odd non-degC value" in caplog.text
 
     def test_apm_state0001(self, platform, caplog):
         run_shell_cmd("apm -C")  # cool mode; forces krun to change this.
 
         platform._check_apm_state()
 
-        if "hw.setperf is not available" in caplog.text():
+        if "hw.setperf is not available" in caplog.text:
             pytest.skip()
 
-        assert "performance mode is not manual" in caplog.text()
+        assert "performance mode is not manual" in caplog.text
         # Hard to check hw.setperf, as it may well be temproarily 100
-        assert "adjusting performance mode" in caplog.text()
+        assert "adjusting performance mode" in caplog.text
 
         out, err, rc = run_shell_cmd("test `sysctl hw.setperf` == 'hw.setperf=100'")
         assert out == err == ""
@@ -129,7 +129,7 @@ class TestOpenBSDPlatform(BaseKrunTest):
 
         with pytest.raises(FatalKrunError):
             platform._check_apm_state()
-        assert "Expected 3 lines of output from apm(8)" in caplog.text()
+        assert "Expected 3 lines of output from apm(8)" in caplog.text
 
     def test_save_power0001(self, platform):
         run_shell_cmd("apm -H")

--- a/krun/tests/test_results.py
+++ b/krun/tests/test_results.py
@@ -112,7 +112,7 @@ class TestResults(BaseKrunTest):
             fake_results.integrity_check()
 
         expect = "inconsistent etas length: bench:vm:variant: 1 vs 2"
-        assert expect in caplog.text()
+        assert expect in caplog.text
 
     def test_integrity_check_results0003(self, fake_results, caplog):
         # remove a per-core measurement
@@ -121,7 +121,7 @@ class TestResults(BaseKrunTest):
             fake_results.integrity_check()
 
         expect = "inconsistent cycles length: bench:vm:variant: 1 vs 2"
-        assert expect in caplog.text()
+        assert expect in caplog.text
 
     def test_integrity_check_results0004(self, fake_results, caplog):
         # remove a core from a per-core measurement
@@ -130,7 +130,7 @@ class TestResults(BaseKrunTest):
             fake_results.integrity_check()
 
         expect = "wrong #cores in core_cycle_counts: bench:vm:variant[0]: 2 vs 1"
-        assert expect in caplog.text()
+        assert expect in caplog.text
 
     def test_integrity_check_results0005(self, fake_results, caplog):
         # remove an in-proc iteration from a per-core measurement
@@ -139,4 +139,4 @@ class TestResults(BaseKrunTest):
             fake_results.integrity_check()
 
         expect = "inconsistent #iters in core_cycle_counts: bench:vm:variant[0][0]. 1 vs 2"
-        assert expect in caplog.text()
+        assert expect in caplog.text

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -28,13 +28,12 @@ DUMMY_CONFIG.OUTLIER_WINDOW_SIZE = 10
 
 
 def test_fatal(capsys, caplog):
-    caplog.setLevel(logging.ERROR)
     msg = "example text"
     with pytest.raises(FatalKrunError):
         fatal(msg)
     out, err = capsys.readouterr()
     assert out == ""
-    assert msg in caplog.text()
+    assert msg in caplog.text
 
 
 def test_log_and_mail(mock_manifest, mock_mailer):
@@ -135,7 +134,7 @@ stderr:
 [iterations_runner.py] iteration 1/1
 --------------------------------------------------
 """ % stdout
-    assert excinfo.value.message == expected
+    assert excinfo.value.args[0] == expected
 
 
 def test_check_and_parse_execution_results0003():
@@ -156,7 +155,7 @@ stderr:
 [iterations_runner.py] iteration 1/1
 --------------------------------------------------
 """
-    assert excinfo.value.message == expected
+    assert excinfo.value.args[0] == expected
 
 
 def test_check_and_parse_execution_results0004(caplog):
@@ -171,7 +170,7 @@ def test_check_and_parse_execution_results0004(caplog):
     with pytest.raises(RerunExecution) as e:
         check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG)
 
-    assert e.value.message == \
+    assert e.value.args[0] == \
         "APERF/MPERF ratio badness detected\n" \
         "  in_proc_iter=0, core=0, type=turbo, ratio=1.5\n" \
         "  in_proc_iter=0, core=1, type=throttle, ratio=0.666666666667\n\n" \
@@ -188,7 +187,7 @@ def test_check_and_parse_execution_results0005(caplog):
 
     with pytest.raises(RerunExecution) as e:
         check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG)
-    assert e.value.message == \
+    assert e.value.args[0] == \
         "APERF/MPERF ratio badness detected\n" \
         "  in_proc_iter=1, core=0, type=throttle, ratio=0.75\n\n" \
         "The process execution will be retried until the ratios are OK."
@@ -328,7 +327,7 @@ def test_run_shell_cmd_list0002(caplog):
     assert got == "1\n"
 
     expect = "Command failed: '/flibblebop"
-    assert expect in caplog.text()
+    assert expect in caplog.text
 
 
 def test_run_shell_cmd_list0003():
@@ -359,7 +358,7 @@ def test_run_shell_cmd_list0004(caplog):
         run_shell_cmd_list(cmds, extra_env={"HOME": "test123"})
 
     expect = "Environment HOME is already defined"
-    assert expect in caplog.text()
+    assert expect in caplog.text
 
 
 def test_get_git_version0001():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-cffi==1.5.0
-coverage==4.0.3
-py==1.4.31
-pycparser==2.14
-pytest==2.8.5
-pytest-capturelog==0.7
+cffi==1.12.2
+py==1.7.0
+pycparser==2.19
+pytest==3.10.1
 pytest-cov==2.2.0


### PR DESCRIPTION
This makes the Krun test suite work on newer versions of things found in Debian 10.

I don't think we've updated the deps since Debian 7 days!

I'll squash this all into one at the end.