### PR TITLE
Implement timeouts for process executions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You need to have the following programs installed:
   * GNU make, a C compiler and libc (`build-essential` package in Debian)
   * cpufrequtils (Linux only. `cpufrequtils` package in Debian)
   * cffi (`python-cffi` package in Debian)
+  * subprocess32 Python module.
   * cset (for pinning on Linux only. `cpuset` package in Debian)
   * virt-what (Linux only. `virt-what` package in Debian)
   * Our custom Linux kernel (see below).
@@ -464,6 +465,10 @@ The structure of the JSON results is as follows:
                                 # (structure same as 'core_cycle_counts')
     'mperf_counts': {...}       # Per-core MPERF deltas
                                 # (structure same as 'core_cycle_counts')
+    'pexec_flags': {...}        # A flag for each process execution:
+                                # 'C' completed OK.
+                                # 'E' benchmark crashed.
+                                # 'T' benchmark timed out.
     'eta_estimates': {u"bmark:VM:variant": [t_0, t_1, ...], ...} # A dict mapping
                   # benchmark keys to rough process execution times. Used internally:
                   # users can ignore this.

--- a/examples/example.krun
+++ b/examples/example.krun
@@ -13,6 +13,8 @@ LUAJIT_BIN  = find_executable("luajit")
 if LUAJIT_BIN is None:
     fatal("luajit binary not found in path")
 
+EXECUTION_TIMEOUT = 60  # time allowance for each process execution in seconds.
+
 # Who to mail
 MAIL_TO = []
 

--- a/krun/config.py
+++ b/krun/config.py
@@ -32,6 +32,7 @@ class Config(object):
         self.AMPERF_RATIO_BOUNDS = None
         self.PRE_EXECUTION_CMDS = []
         self.POST_EXECUTION_CMDS = []
+        self.EXECUTION_TIMEOUT = None
 
         # config defaults (callbacks)
         self.custom_dmesg_whitelist = None
@@ -139,4 +140,5 @@ class Config(object):
                 (self.SKIP == other.SKIP) and
                 (self.N_EXECUTIONS == other.N_EXECUTIONS) and
                 (self.PRE_EXECUTION_CMDS == other.PRE_EXECUTION_CMDS) and
-                (self.POST_EXECUTION_CMDS == other.POST_EXECUTION_CMDS))
+                (self.POST_EXECUTION_CMDS == other.POST_EXECUTION_CMDS) and
+                (self.EXECUTION_TIMEOUT == other.EXECUTION_TIMEOUT))

--- a/krun/mail.py
+++ b/krun/mail.py
@@ -2,7 +2,7 @@ from email.mime.text import MIMEText
 import socket
 import textwrap
 import logging
-from subprocess import Popen, PIPE
+import subprocess32
 
 
 FROM_USER = "noreply"
@@ -79,7 +79,8 @@ class Mailer(object):
         logging.debug("Sending email to '%s' subject line '%s'" %
                       (msg['To'], msg['Subject']))
 
-        pipe = Popen([SENDMAIL, "-t", "-oi"], stdin=PIPE)
+        pipe = subprocess32.Popen([SENDMAIL, "-t", "-oi"],
+            stdin=subprocess32.PIPE)
         pipe.communicate(msg.as_string())
 
         rc = pipe.returncode

--- a/krun/platform.py
+++ b/krun/platform.py
@@ -5,7 +5,7 @@ import os
 import difflib
 import sys
 import glob
-import subprocess
+import subprocess32
 import re
 import pwd
 import cffi
@@ -491,7 +491,7 @@ class UnixLikePlatform(BasePlatform):
         """Force pending I/O to physical disks"""
 
         debug("sync disks...")
-        rc = subprocess.call("/bin/sync")
+        rc = subprocess32.call("/bin/sync")
         if rc != 0:
             fatal("sync failed")
 

--- a/krun/tests/test_results.py
+++ b/krun/tests/test_results.py
@@ -28,6 +28,7 @@ def fake_results(mock_platform, no_results_instantiation_check):
                             [[[4., 4.], [4., 4.,]], [[4., 4.], [4., 4.]]]}
     results.mperf_counts = {"bench:vm:variant":
                             [[[5., 5.], [5., 5.,]], [[5., 5.], [5., 5.]]]}
+    results.pexec_flags = {"bench:vm:variant": ["C", "T"]}
     return results
 
 
@@ -91,6 +92,7 @@ class TestResults(BaseKrunTest):
         results0.core_cycle_counts = {u"dummy:Java:default-java": [[[2], [3], [4], [5]]]}
         results0.aperf_counts = {u"dummy:Java:default-java": [[[3], [4], [5], [6]]]}
         results0.mperf_counts = {u"dummy:Java:default-java": [[[4], [5], [6], [7]]]}
+        results0.pexec_flags = {u"dummy:Java:default-java": [[["C"], ["C"], ["C"], ["C"]]]}
         results0.reboots = 5
         results0.error_flag = False
         results0.write_to_file()

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -1,6 +1,6 @@
 from krun.util import (format_raw_exec_results, log_and_mail, fatal,
                        check_and_parse_execution_results, run_shell_cmd,
-                       run_shell_cmd_bench, get_git_version, ExecutionFailed,
+                       get_git_version, ExecutionFailed,
                        get_session_info, run_shell_cmd_list, FatalKrunError,
                        stash_envlog, dump_instr_json, RerunExecution,
                        make_instr_dir, read_popen_output_carefully)
@@ -75,29 +75,6 @@ def test_run_shell_cmd_fatal():
     assert cmd in err
     assert out == ""
 
-def test_run_shell_cmd_bench():
-    platform = detect_platform(None, None)
-    msg = "example text\n"
-    out, err, rc, _ = run_shell_cmd_bench("echo " + msg, platform)
-    assert out == msg
-    assert err == ""
-    assert rc == 0
-
-    msg2 = "another example\n"
-    out, err, rc, _ = run_shell_cmd_bench(
-        "(>&2 echo %s)  && (echo %s)" % (msg2, msg),
-        platform)
-    assert out == msg
-    assert err == msg2
-    assert rc == 0
-
-def test_run_shell_cmd_bench_fatal():
-    cmd = "nonsensecommand"
-    platform = detect_platform(None, None)
-    out, err, rc, _ = run_shell_cmd_bench(cmd, platform, False)
-    assert rc != 0
-    assert cmd in err
-    assert out == ""
 
 def test_check_and_parse_execution_results0001():
     stdout = json.dumps({

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -3,18 +3,20 @@ from krun.util import (format_raw_exec_results, log_and_mail, fatal,
                        run_shell_cmd_bench, get_git_version, ExecutionFailed,
                        get_session_info, run_shell_cmd_list, FatalKrunError,
                        stash_envlog, dump_instr_json, RerunExecution,
-                       make_instr_dir)
+                       make_instr_dir, read_popen_output_carefully)
 from krun.tests.mocks import MockMailer
 from krun.tests import TEST_DIR
 from krun.config import Config
 from krun.scheduler import ManifestManager
 from krun.tests.mocks import mock_platform, mock_manifest, mock_mailer
+from krun.platform import detect_platform
 from bz2 import BZ2File
 
 import json
 import logging
 import pytest
 import os
+import subprocess32
 from tempfile import NamedTemporaryFile
 
 
@@ -74,16 +76,15 @@ def test_run_shell_cmd_fatal():
     assert out == ""
 
 def test_run_shell_cmd_bench():
-    from krun.platform import detect_platform
     platform = detect_platform(None, None)
     msg = "example text\n"
-    out, err, rc = run_shell_cmd_bench("echo " + msg, platform)
+    out, err, rc, _ = run_shell_cmd_bench("echo " + msg, platform)
     assert out == msg
     assert err == ""
     assert rc == 0
 
     msg2 = "another example\n"
-    out, err, rc = run_shell_cmd_bench(
+    out, err, rc, _ = run_shell_cmd_bench(
         "(>&2 echo %s)  && (echo %s)" % (msg2, msg),
         platform)
     assert out == msg
@@ -91,10 +92,9 @@ def test_run_shell_cmd_bench():
     assert rc == 0
 
 def test_run_shell_cmd_bench_fatal():
-    from krun.platform import detect_platform
     cmd = "nonsensecommand"
     platform = detect_platform(None, None)
-    out, err, rc = run_shell_cmd_bench(cmd, platform, False)
+    out, err, rc, _ = run_shell_cmd_bench(cmd, platform, False)
     assert rc != 0
     assert cmd in err
     assert out == ""
@@ -405,3 +405,10 @@ def test_dump_instr_json0001():
     os.rmdir(dump_dir)
 
     assert js == instr_data
+
+
+def test_read_popen_output_carefully_0001():
+    platform = detect_platform(None, None)
+    process = subprocess32.Popen(["/bin/sleep", "5"], stdout=subprocess32.PIPE)
+    _, _, _, timed_out = read_popen_output_carefully(process, platform, timeout=1)
+    assert timed_out

--- a/krun/tests/test_vmdef.py
+++ b/krun/tests/test_vmdef.py
@@ -85,7 +85,7 @@ class TestVMDef(BaseKrunTest):
         monkeypatch.setattr(platform, "sync_disks", fake_sync_disks)
 
         def fake_run_exec_popen(args, stderr_file=None):
-            return "[1]", "", 0  # stdout, stderr, exit_code
+            return "[1]", "", 0, False  # stdout, stderr, exit_code, timed_out
         monkeypatch.setattr(vm_def, "_run_exec_popen", fake_run_exec_popen)
 
         vm_def.run_exec(ep, 1, 1, 1, 1, "test:dummyvm:default", 0)
@@ -113,7 +113,7 @@ class TestVMDef(BaseKrunTest):
         monkeypatch.setattr(platform, "sync_disks", fake_sync_disks)
 
         def fake_run_exec_popen(args, stderr_file=None):
-            return stdout, "", 0  # stdout, stderr, exit_code
+            return stdout, "", 0, False  # stdout, stderr, exit_code, timed_out
 
         monkeypatch.setattr(vm_def, "_run_exec_popen", fake_run_exec_popen)
 
@@ -130,11 +130,12 @@ class TestVMDef(BaseKrunTest):
 
         args = [sys.executable, "-c",
                 "import sys; sys.stdout.write('STDOUT'); sys.stderr.write('STDERR')"]
-        out, err, rv = vm_def._run_exec_popen(args)
+        out, err, rv, timed_out = vm_def._run_exec_popen(args)
 
         assert err == "STDERR"
         assert out == "STDOUT"
         assert rv == 0
+        assert timed_out == False
 
     def test_run_exec_popen0002(self, monkeypatch):
         """Check that writing stderr to a file works. Used for instrumentation"""
@@ -149,11 +150,12 @@ class TestVMDef(BaseKrunTest):
 
         with NamedTemporaryFile(delete=False, prefix="kruntest") as fh:
             filename = fh.name
-            out, err, rv = vm_def._run_exec_popen(args, fh)
+            out, err, rv, timed_out = vm_def._run_exec_popen(args, fh)
 
         assert err == ""  # not here due to redirection
         assert out == "STDOUT"  # behaviour should be unchanged
         assert rv == 0
+        assert timed_out == False
 
         # stderr should be in this file
         with open(filename) as fh:

--- a/krun/util.py
+++ b/krun/util.py
@@ -109,19 +109,6 @@ def run_shell_cmd(cmd, failure_fatal=True, extra_env=None):
         fatal(msg)
     return stdout.strip(), stderr.strip(), rc
 
-def run_shell_cmd_bench(cmd, platform, failure_fatal=True, extra_env=None):
-    """ The same as run_shell_cmd, but reads the output of the command more
-    carefully, by setting the pipes to unbuffered and using select.
-    Requires a platform."""
-    process = _run_shell_cmd_start_process(cmd, extra_env)
-    res = read_popen_output_carefully(process, platform, print_stderr=False)
-    stdout, stderr, rc, _ = res
-    if failure_fatal and rc != 0:
-        msg = "Command failed: '%s'\n" % cmd
-        msg += "stdout:\n%s\n" % stdout
-        msg += "stderr:\n%s\n" % stderr
-        fatal(msg)
-    return res
 
 def run_shell_cmd_list(cmds, failure_fatal=True, extra_env=None):
     """Run a list of shell commands, stopping on first failure."""

--- a/libkrun/test/test_libkruntime.py
+++ b/libkrun/test/test_libkruntime.py
@@ -1,4 +1,4 @@
-from subprocess import Popen, PIPE
+import subprocess32
 import os
 import sys
 import pytest
@@ -19,8 +19,8 @@ MSR_SUPPORT = PLATFORM.num_per_core_measurements > 0
 def invoke_c_prog(mode):
     assert os.path.exists(TEST_PROG_PATH)
 
-    p = Popen(TEST_PROG_PATH + " " + mode,
-              stderr=PIPE, stdout=PIPE, shell=True)
+    p = subprocess32.Popen(TEST_PROG_PATH + " " + mode,
+        stderr=subprocess32.PIPE, stdout=subprocess32.PIPE, shell=True)
     out, err = p.communicate()
     return p.returncode, out.strip(), err.strip()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ py==1.7.0
 pycparser==2.19
 pytest==3.10.1
 pytest-cov==2.2.0
+subprocess32==3.5.4


### PR DESCRIPTION
This is required because sometimes you need to benchmark VMs and/or
benchmark suites which freeze up. We've seen this numerous times with
Java VMs and benchmarks. Without having a timeout to kill frozen process
executions, you can't make progress and have to restart the experiment
(possibly skipping that benchmark).

Further, by restarting the experiment you are biasing your experiment:
giving benchmarks that have the worst performance (that's what a
non-terminating benchmark is) another chance to redeem themselves.

Timed-out process executions now show as a 'T' flag in the manifest file.
Flags for finished process executions are carried through to the results
file in a new `pexec_flags` field. This field can be one of {C, E, T}
(completed, errored, timed-out).