### PR TITLE
Log which benchmark failed at the point the error is reported.

### DIFF
--- a/krun/scheduler.py
+++ b/krun/scheduler.py
@@ -383,7 +383,7 @@ class ExecutionJob(object):
             try:
                 self.sched.platform.check_throttle_counts(self.sched.manifest)
                 measurements = util.check_and_parse_execution_results(
-                    stdout, stderr, rc, self.sched.config, instrument=vm_def.instrument)
+                    stdout, stderr, rc, self.sched.config, self.key, instrument=vm_def.instrument)
                 flag = "C"
             except util.RerunExecution as e:
                 subject = ("Benchmark needs to be re-run: %s (exec_idx=%s)" %

--- a/krun/tests/test_util.py
+++ b/krun/tests/test_util.py
@@ -84,7 +84,7 @@ def test_check_and_parse_execution_results0001():
         "mperf_counts": [[5], [5], [5], [5]],
     })
     stderr = "[iterations_runner.py] iteration 1/1"
-    js = check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG)
+    js = check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG, "a:b:c")
     assert js == json.loads(stdout)
 
 
@@ -98,8 +98,8 @@ def test_check_and_parse_execution_results0002():
     stderr = "[iterations_runner.py] iteration 1/1"
     # Non-zero return code.
     with pytest.raises(ExecutionFailed) as excinfo:
-        check_and_parse_execution_results(stdout, stderr, 1, DUMMY_CONFIG)
-    expected = """Benchmark returned non-zero or emitted invalid JSON.
+        check_and_parse_execution_results(stdout, stderr, 1, DUMMY_CONFIG, "a:b:c")
+    expected = """Benchmark 'a:b:c' returned non-zero or emitted invalid JSON.
 return code: 1
 stdout:
 --------------------------------------------------
@@ -119,8 +119,8 @@ def test_check_and_parse_execution_results0003():
     stdout = "[0.000403["
     # Corrupt JSON in STDOUT.
     with pytest.raises(ExecutionFailed) as excinfo:
-        check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG)
-    expected = """Benchmark returned non-zero or emitted invalid JSON.\nException string: Expecting , delimiter: line 1 column 10 (char 9)
+        check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG, "a:b:c")
+    expected = """Benchmark 'a:b:c' returned non-zero or emitted invalid JSON.\nException string: Expecting , delimiter: line 1 column 10 (char 9)
 return code: 0
 stdout:
 --------------------------------------------------
@@ -145,7 +145,7 @@ def test_check_and_parse_execution_results0004(caplog):
     stderr = "[iterations_runner.py] iteration 1/1"
 
     with pytest.raises(RerunExecution) as e:
-        check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG)
+        check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG, "a:b:c")
 
     assert e.value.args[0] == \
         "APERF/MPERF ratio badness detected\n" \
@@ -163,7 +163,7 @@ def test_check_and_parse_execution_results0005(caplog):
     stderr = "[iterations_runner.py] iteration 1/1"
 
     with pytest.raises(RerunExecution) as e:
-        check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG)
+        check_and_parse_execution_results(stdout, stderr, 0, DUMMY_CONFIG, "a:b:c")
     assert e.value.args[0] == \
         "APERF/MPERF ratio badness detected\n" \
         "  in_proc_iter=1, core=0, type=throttle, ratio=0.75\n\n" \

--- a/krun/util.py
+++ b/krun/util.py
@@ -231,7 +231,7 @@ def read_popen_output_carefully(process, platform, print_stderr=True, timeout=No
     return stdout, stderr, process.returncode, False
 
 
-def check_and_parse_execution_results(stdout, stderr, rc, config,
+def check_and_parse_execution_results(stdout, stderr, rc, config, key,
                                       sanity_check=False, instrument=False):
     json_exn = None
 
@@ -248,7 +248,7 @@ def check_and_parse_execution_results(stdout, stderr, rc, config,
     if json_exn or rc != 0:
         # Something went wrong
         rule = 50 * "-"
-        err_s = ("Benchmark returned non-zero or emitted invalid JSON.\n")
+        err_s = ("Benchmark '%s' returned non-zero or emitted invalid JSON.\n" % key)
         if json_exn:
             err_s += "Exception string: %s\n" % str(e)
         err_s += "return code: %d\n" % rc
@@ -337,7 +337,7 @@ def spawn_sanity_check(platform, entry_point, vm_def,
 
     try:
         _ = check_and_parse_execution_results(stdout, stderr, rc,
-                                              platform.config,
+                                              platform.config, key,
                                               sanity_check=True)
     except ExecutionFailed as e:
         fatal("%s sanity check failed: %s" % (check_name, e.message))


### PR DESCRIPTION
This makes scanning the logs much, much easier for me.